### PR TITLE
Print child process stderr to output channel

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -980,6 +980,9 @@ export class LanguageClient {
 				return Promise.reject<IConnection>(`Launching server using command ${command.command} failed.`);
 			}
 			this._childProcess = process;
+			if (process.stderr) {
+				process.stderr.on('data', data => this.outputChannel.append(data.toString()));
+			}
 			return Promise.resolve(createConnection(process.stdout, process.stdin, errorHandler, closeHandler));
 		}
 		return Promise.reject<IConnection>(new Error(`Unsupported server configuartion ` + JSON.stringify(server, null, 4)));


### PR DESCRIPTION
Prior to this change, child process stderr was discarded, which makes
it hard to debug language server processes. (You can make them log to
a separate file or use the window/logMessage method, but in general
it's hard to guarantee that all output, including crash stack traces,
goes through a user-defined stream in a program.)

This change appends child process stderr output to the output channel.
Clients can suppress this behavior by setting the server's
Executable.stdio 3rd element to be "ignore" (per the Node.js spec).

Fixes #82