### PR TITLE
sendRequest fail if not listening

### DIFF
--- a/jsonrpc/src/main.ts
+++ b/jsonrpc/src/main.ts
@@ -447,6 +447,12 @@ function createMessageConnection<T extends MessageConnection>(messageReader: Mes
 		}
 	}
 
+	function throwIfNotListening() {
+		if (!isListening()) {
+			throw new Error('Call listen() first.');
+		}
+	}
+
 	let connection: MessageConnection = {
 		sendNotification: <P>(type: NotificationType<P>, params): void  => {
 			throwIfClosedOrDisposed();
@@ -468,6 +474,7 @@ function createMessageConnection<T extends MessageConnection>(messageReader: Mes
 		},
 		sendRequest: <P, R, E>(type: RequestType<P, R, E>, params: P, token?:CancellationToken) => {
 			throwIfClosedOrDisposed();
+			throwIfNotListening();
 
 			let id = sequenceNumber++;
 			let result = new Promise<R | ResponseError<E>>((resolve, reject) => {

--- a/jsonrpc/src/main.ts
+++ b/jsonrpc/src/main.ts
@@ -457,15 +457,15 @@ function createMessageConnection<T extends MessageConnection>(messageReader: Mes
 		sendNotification: <P>(type: NotificationType<P>, params): void  => {
 			throwIfClosedOrDisposed();
 
-			let notificatioMessage : NotificationMessage = {
+			let notificationMessage : NotificationMessage = {
 				jsonrpc: version,
 				method: type.method,
 				params: params
 			}
 			if (trace != Trace.Off && tracer) {
-				traceSendNotification(notificatioMessage);
+				traceSendNotification(notificationMessage);
 			}
-			messageWriter.write(notificatioMessage);
+			messageWriter.write(notificationMessage);
 		},
 		onNotification: <P>(type: NotificationType<P>, handler: NotificationHandler<P>) => {
 			throwIfClosedOrDisposed();


### PR DESCRIPTION
Rejects calls to `sendRequest` when `listen()` hasn't been called already. This immediately identifies a common mistake for a new _client_ that doesn't realize that `listen()` is important to call, even though no incoming RPC calls are expected.
