### PR TITLE
export './protocol' from client as Protocol.

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -92,6 +92,9 @@ export {
 export { Converter as Code2ProtocolConverter } from './codeConverter';
 export { Converter as Protocol2CodeConverter } from './protocolConverter';
 
+import * as Protocol from './protocol';
+export { Protocol };
+
 declare var v8debug;
 
 interface IConnection {


### PR DESCRIPTION
Would be nice if the definitions of the `Protocol` were available outside of the `Client`.
