### PR TITLE
Fix Client.stop promise

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -932,17 +932,19 @@ export class LanguageClient {
 		this.state = ClientState.Stopping;
 		this.cleanUp();
 		// unkook listeners
-		return this.resolveConnection().then(connection => {
-			connection.shutdown().then(() => {
-				connection.exit();
-				connection.dispose();
-				this.state = ClientState.Stopped;
-				this._connection = null;
-				let toCheck = this._childProcess;
-				this._childProcess = null;
-				// Remove all markers
-				this.checkProcessDied(toCheck);
-			})
+		let connection;
+		return this.resolveConnection().then(_connection => {
+			connection = _connection;
+			return connection.shutdown();
+		}).then(() => {
+			connection.exit();
+			connection.dispose();
+			this.state = ClientState.Stopped;
+			this._connection = null;
+			let toCheck = this._childProcess;
+			this._childProcess = null;
+			// Remove all markers
+			this.checkProcessDied(toCheck);
 		});
 	}
 


### PR DESCRIPTION
The promise should wait for `connection.shutdown()`, not just
`resolveConnection()`. Also flatten the promise to match the type
signature of the method.
