### PR TITLE
MessageBuffer.append: length of string in bytes

### DIFF
--- a/jsonrpc/src/messageReader.ts
+++ b/jsonrpc/src/messageReader.ts
@@ -31,8 +31,9 @@ class MessageBuffer {
 		var toAppend: Buffer = <Buffer>chunk;
 		if (typeof (chunk) == 'string') {
 			var str = <string>chunk;
-			toAppend = new Buffer(str.length);
-			toAppend.write(str, 0, str.length, this.encoding);
+			var bufferLen = Buffer.byteLength(str, this.encoding);
+			toAppend = new Buffer(bufferLen);
+			toAppend.write(str, 0, bufferLen, this.encoding);
 		}
 		if (this.buffer.length - this.index >= toAppend.length) {
 			toAppend.copy(this.buffer, this.index, 0, toAppend.length);


### PR DESCRIPTION
messageBuffer.append creates a buffer based on the length of the string to be written to it. `str.length` does not return the correct length of the string in bytes when the string contains multi-byte unicode characters. Buffer.byteLength does return the proper length, so switched to this method.