### PR TITLE
Support reference streaming

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -10,7 +10,7 @@ import ChildProcess = cp.ChildProcess;
 import {
 	workspace as Workspace, window as Window, languages as Languages, commands as Commands,
 	TextDocumentChangeEvent, TextDocument, Disposable, OutputChannel,
-	FileSystemWatcher, DiagnosticCollection, Uri,
+	FileSystemWatcher, DiagnosticCollection, Uri, ProgressCallback,
 	CancellationToken, Position as VPosition, Location as VLocation, Range as VRange,
 	CompletionItem as VCompletionItem, CompletionList as VCompletionList, SignatureHelp as VSignatureHelp, Definition as VDefinition, DocumentHighlight as VDocumentHighlight,
 	SymbolInformation as VSymbolInformation, CodeActionContext as VCodeActionContext, Command as VCommand, CodeLens as VCodeLens,
@@ -21,14 +21,14 @@ import {
 
 import {
 	Message, MessageType as RPCMessageType, Logger, createMessageConnection, ErrorCodes, ResponseError,
-	RequestType, RequestType0, RequestHandler, RequestHandler0, GenericRequestHandler,
+	RequestType, RequestTypeWithStreamingResponse, RequestType0, RequestHandler, RequestHandler0, GenericRequestHandler,
 	NotificationType, NotificationType0,
 	NotificationHandler, NotificationHandler0, GenericNotificationHandler,
 	MessageReader, IPCMessageReader, MessageWriter, IPCMessageWriter, Trace, Tracer, Event, Emitter
 } from 'vscode-jsonrpc';
 
 import {
-	WorkspaceEdit
+	WorkspaceEdit, Location
 } from 'vscode-languageserver-types';
 
 
@@ -74,7 +74,7 @@ import * as UUID from './utils/uuid';
 
 export {
 	ResponseError, InitializeError, ErrorCodes,
-	RequestType, RequestType0, RequestHandler, RequestHandler0, GenericRequestHandler,
+	RequestTypeWithStreamingResponse, RequestType, RequestType0, RequestHandler, RequestHandler0, GenericRequestHandler,
 	NotificationType, NotificationType0, NotificationHandler, NotificationHandler0, GenericNotificationHandler
 }
 export { Converter as Code2ProtocolConverter } from './codeConverter';
@@ -94,6 +94,8 @@ interface IConnection {
 	sendRequest<R>(method: string, token?: CancellationToken): Thenable<R>;
 	sendRequest<R>(method: string, param: any, token?: CancellationToken): Thenable<R>;
 	sendRequest<R>(type: string | RPCMessageType, ...params: any[]): Thenable<R>;
+
+	sendRequestWithStreamingResponse<P, PC, R>(type: RequestTypeWithStreamingResponse<P, PC, R, any, any>, params: P, token?: CancellationToken, progress?: ProgressCallback<PC>): Thenable<R>;
 
 	onRequest<R, E, RO>(type: RequestType0<R, E, RO>, handler: RequestHandler0<R, E>): void;
 	onRequest<P, R, E, RO>(type: RequestType<P, R, E, RO>, handler: RequestHandler<P, R, E>): void;
@@ -167,6 +169,7 @@ function createConnection(input: any, output: any, errorHandler: ConnectionError
 		listen: (): void => connection.listen(),
 
 		sendRequest: <R>(type: string | RPCMessageType, ...params: any[]): Thenable<R> => connection.sendRequest(is.string(type) ? type : type.method, ...params),
+		sendRequestWithStreamingResponse: <P, PC, R>(type: RequestTypeWithStreamingResponse<P, PC, R, any, any>, params: P, token?: CancellationToken, progress?: ProgressCallback<PC>): Thenable<R> => connection.sendRequestWithStreamingResponse(type, params, token, progress),
 		onRequest: <R, E>(type: string | RPCMessageType, handler: GenericRequestHandler<R, E>): void => connection.onRequest(is.string(type) ? type : type.method, handler),
 
 		sendNotification: (type: string | RPCMessageType, params?: any): void => connection.sendNotification(is.string(type) ? type : type.method, params),
@@ -955,6 +958,19 @@ export class LanguageClient {
 			return this._resolvedConnection!.sendRequest<R>(type, ...params);
 		} catch (error) {
 			this.error(`Sending request ${is.string(type) ? type : type.method} failed.`, error);
+			throw error;
+		}
+	}
+
+	public sendRequestWithStreamingResponse<P, PC, R>(type: RequestTypeWithStreamingResponse<P, PC, R, any, any>, params: P, token?: CancellationToken, progress?: ProgressCallback<PC>): Thenable<R> {
+		if (!this.isConnectionActive()) {
+			throw new Error('Language client is not ready yet');
+		}
+		this.forceDocumentSync();
+		try {
+			return this._resolvedConnection!.sendRequestWithStreamingResponse(type, params, token, progress);
+		} catch (error) {
+			this.error(`Sending request ${type.method} failed.`, error);
 			throw error;
 		}
 	}
@@ -1989,8 +2005,30 @@ export class LanguageClient {
 
 	private createReferencesProvider(options: TextDocumentRegistrationOptions): Disposable {
 		return Languages.registerReferenceProvider(options.documentSelector!, {
-			provideReferences: (document: TextDocument, position: VPosition, options: { includeDeclaration: boolean; }, token: CancellationToken): Thenable<VLocation[]> => {
-				return this.sendRequest(ReferencesRequest.type, this._c2p.asReferenceParams(document, position, options), token).then(
+			provideReferences: (document: TextDocument, position: VPosition, options: { includeDeclaration: boolean; }, token: CancellationToken, progress: ProgressCallback<VLocation[]>): Thenable<VLocation[]> => {
+				const knownReferences = new Set<string>();
+				const patch2Locations = (locations: Location[]) => {
+					// Right now references contains the entire partial result up until this point.
+					// Since the data gets serialized over IPC to the main thread,
+					// only forward the new results as a performance optimization.
+					const references = this._p2c.asReferences(locations);
+					const newReferences: VLocation[] = [];
+					references.forEach((reference) => {
+						const id = [
+							reference.uri.toString(),
+							reference.range.start.line,
+							reference.range.start.character,
+							reference.range.end.line,
+							reference.range.end.character
+						].join(":")
+						if (!knownReferences.has(id)) {
+							newReferences.push(reference);
+						}
+						knownReferences.add(id);
+					});
+					progress(newReferences);
+				};
+				return this.sendRequestWithStreamingResponse(ReferencesRequest.type, this._c2p.asReferenceParams(document, position, options), token, patch2Locations).then(
 					this._p2c.asReferences,
 					(error) => {
 						this.logFailedRequest(ReferencesRequest.type, error);

--- a/client/src/protocol.ts
+++ b/client/src/protocol.ts
@@ -4,7 +4,7 @@
  * ------------------------------------------------------------------------------------------ */
 'use strict';
 
-import { RequestType, RequestType0, NotificationType, NotificationType0 } from 'vscode-jsonrpc';
+import { RequestType, RequestType0, RequestTypeWithStreamingResponse, NotificationType, NotificationType0 } from 'vscode-jsonrpc';
 
 import {
 	TextDocumentContentChangeEvent, Position, Range, Location, Diagnostic, Command,
@@ -1169,7 +1169,7 @@ export interface ReferenceParams extends TextDocumentPositionParams {
  * [Location[]](#Location) or a Thenable that resolves to such.
  */
 export namespace ReferencesRequest {
-	export const type = new RequestType<ReferenceParams, Location[], void, TextDocumentRegistrationOptions>('textDocument/references');
+	export const type = new RequestTypeWithStreamingResponse<ReferenceParams, Location[], Location[], void, TextDocumentRegistrationOptions>('textDocument/references');
 }
 
 //---- Document Highlight ----------------------------------

--- a/jsonrpc/package.json
+++ b/jsonrpc/package.json
@@ -16,6 +16,9 @@
 	},
 	"main": "./lib/main.js",
 	"typings": "./lib/main.d.ts",
+	"dependencies": {
+		"fast-json-patch": "^1.1.5"
+	},
 	"devDependencies": {
 		"mocha": "^3.1.0",
 		"typescript": "^2.1.5",

--- a/jsonrpc/src/messages.ts
+++ b/jsonrpc/src/messages.ts
@@ -173,6 +173,13 @@ export class RequestType<P, R, E, RO> extends AbstractMessageType {
 	}
 }
 
+export class RequestTypeWithStreamingResponse<Params, ProgressCallback, Result, Error, RegistrationOptions> extends AbstractMessageType {
+	private _?: [Params, ProgressCallback, Result, Error, RegistrationOptions, _EM];
+	constructor(method: string) {
+		super(method, 1);
+		this._ = undefined;
+	}
+}
 
 export class RequestType1<P1, R, E, RO> extends AbstractMessageType {
 	private _?: [P1, R, E, RO, _EM];


### PR DESCRIPTION
This PR implements the necessary changes in vscode-languageclient and vscode-jsonrpc to support streaming the response for "Find all references" requests as described in https://github.com/Microsoft/vscode/issues/20010 (please read this issue for complete context).

This PR depends on (and should not be merged before):
- [ ] LSP protocol proposal https://github.com/Microsoft/language-server-protocol/pull/182
- [ ] vscode.d.ts proposal https://github.com/Microsoft/vscode/pull/20346 (required before CI can pass)

**Implementation details**

The vscode-jsonrpc layer applies JSON patches and forwards the cumulative partial result so higher layers don't need to care about the JSON patch format.

Methods in vscode-languageclient may choose to forward this as-is or perform performance optimizations to only send new data since the data gets serialized over RPC. For streaming references I implemented this performance optimization.

Todos:
- [ ] Use capabilities as defined in spec
- [ ] Update implementation to expect null final result
- [ ] Forward JSON patch all the way to UI?
- [ ] Don't forward incomplete locations