### PR TITLE
client: Pass all arguments to ExecuteCommandRequest

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -723,7 +723,7 @@ class ExecuteCommandFeature implements FeatureHandler<ExecuteCommandRegistration
 		if (data.registerOptions.commands) {
 			let disposeables: Disposable[] = [];
 			for (const command of data.registerOptions.commands) {
-				disposeables.push(Commands.registerCommand(command, (args: any[]) => {
+				disposeables.push(Commands.registerCommand(command, (...args: any[]) => {
 					let params: ExecuteCommandParams = {
 						command,
 						arguments: args


### PR DESCRIPTION
Previously, only the first argument was passed.