### PR TITLE
Add return value to getEnvironment().

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -1391,6 +1391,7 @@ export class LanguageClient {
 			let result: any = Object.create(null);
 			Object.keys(process.env).forEach(key => result[key] = process.env[key]);
 			Object.keys(env).forEach(key => result[key] = env[key]);
+			return result;
 		}
 
 		function startedInDebugMode(): boolean {


### PR DESCRIPTION
This fixes a bug where `env` was not being propagated to spawned server instances.

I was debugging why my user-defined `env` object was not being passed down to my spawned language server and noticed the missing return value, resulting in `undefined` being passed down the chain. 