### PR TITLE
Detect and copy npm-shirkwrap file if present

### DIFF
--- a/server/bin/installServerIntoExtension
+++ b/server/bin/installServerIntoExtension
@@ -57,5 +57,12 @@ var dest = path.join(extensionServerDirectory, 'package.json');
 console.log('Copying package.json to extension\'s server location...');
 fs.writeFileSync(dest, fs.readFileSync(packageFile));
 
+var shrinkwrapFile = process.argv[5];
+if (fs.existsSync(shrinkwrapFile)) {
+	console.log('Copying npm-shrinkwrap.json to extension\'s server location...');
+	fs.writeFileSync(dest, fs.readFileSync(shrinkwrapFile));
+
+}
+
 console.log('Updating server npm modules into extension\'s server location...');
 cp.execSync('npm update --production --prefix ' + extensionServerDirectory);

--- a/server/bin/installServerIntoExtension
+++ b/server/bin/installServerIntoExtension
@@ -59,6 +59,7 @@ fs.writeFileSync(dest, fs.readFileSync(packageFile));
 
 var shrinkwrapFile = process.argv[5];
 if (fs.existsSync(shrinkwrapFile)) {
+	shrinkwrapFile = path.resolve(shrinkwrapFile);
 	console.log('Copying npm-shrinkwrap.json to extension\'s server location...');
 	fs.writeFileSync(dest, fs.readFileSync(shrinkwrapFile));
 

--- a/server/bin/installServerIntoExtension
+++ b/server/bin/installServerIntoExtension
@@ -59,9 +59,10 @@ fs.writeFileSync(dest, fs.readFileSync(packageFile));
 
 var shrinkwrapFile = process.argv[5];
 if (fs.existsSync(shrinkwrapFile)) {
+	const shrinkWrapDest = path.join(extensionServerDirectory, 'npm-shrinkwrap.json');
 	shrinkwrapFile = path.resolve(shrinkwrapFile);
 	console.log('Copying npm-shrinkwrap.json to extension\'s server location...');
-	fs.writeFileSync(dest, fs.readFileSync(shrinkwrapFile));
+	fs.writeFileSync(shrinkWrapDest, fs.readFileSync(shrinkwrapFile));
 
 }
 


### PR DESCRIPTION
This PR, when a shrinkwrap file is provided as `argv[5]` and this exist, will make sure that file gets copied so I can lock down my dependencies in both client and server installations and have a 100% reproducible environment in my local development experience.

This should become a best practise, worth mentioning in the documentation.