### PR TITLE
client: Fix unintended argument passing

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -1557,7 +1557,7 @@ export class LanguageClient {
 			let command: Executable = <Executable>json;
 			let options = command.options || {};
 			options.cwd = options.cwd || Workspace.rootPath;
-			let process = cp.spawn(command.command, command.args, command.options);
+			let process = cp.spawn(command.command, command.args, options);
 			if (!process || !process.pid) {
 				return Promise.reject<IConnection>(`Launching server using command ${command.command} failed.`);
 			}


### PR DESCRIPTION
This is probably working for most time since it's referencing the same object, but not for the undefined case.