### PR TITLE
Fix rename ResponseError not being passed onto VSCode

### DIFF
--- a/client/src/client.ts
+++ b/client/src/client.ts
@@ -2317,7 +2317,7 @@ export abstract class BaseLanguageClient {
 				this._p2c.asWorkspaceEdit,
 				(error: ResponseError<void>) => {
 					this.logFailedRequest(RenameRequest.type, error);
-					Promise.resolve(new Error(error.message));
+					throw error.message;
 				}
 			);
 		};


### PR DESCRIPTION
I was trying to return a `ResponseError` from the rename method in the Haxe language server to display an error in the UI (like the TypeScript language server does in some siutations, [example](http://i.imgur.com/M5ioIWz.png)).

However, no matter what error code I used, the end result was always the same, VSCode displays `"No result."` and the language client just logs it to the output channel:

![](http://i.imgur.com/9asUGvQ.png)

This is probably not a proper solution, and there might be other methods that are affected similarly, but it _does_ fix my issue:

![](http://i.imgur.com/hVkxpBK.png)