### PR TITLE
Remove reference to a non-existent range property

### DIFF
--- a/types/src/main.ts
+++ b/types/src/main.ts
@@ -768,7 +768,7 @@ export interface CompletionItem {
 	/**
 	 * An [edit](#TextEdit) which is applied to a document when selecting
 	 * this completion. When an edit is provided the value of
-	 * [insertText](#CompletionItem.insertText) and [range](#CompletionItem.range) is ignored.
+	 * [insertText](#CompletionItem.insertText).
 	 */
 	textEdit?: TextEdit;
 


### PR DESCRIPTION
The documentation for `textEdit` in `CompletionItem` refers to a `range` property but this property doesn't actually exist on `CompletionItem`.