### PR TITLE
Do not assume that a client has workspace capabilities

### DIFF
--- a/server/src/workspaceFolders.proposed.ts
+++ b/server/src/workspaceFolders.proposed.ts
@@ -21,7 +21,7 @@ export const WorkspaceFoldersFeature: WorkspaceFeature<WorkspaceFolders> = (Base
 		private _unregistration: Thenable<Disposable>;
 		public initialize(capabilities: ClientCapabilities): void {
 			let workspaceCapabilities = (capabilities as Proposed.WorkspaceFoldersClientCapabilities).workspace;
-			if (workspaceCapabilities.workspaceFolders) {
+			if (workspaceCapabilities && workspaceCapabilities.workspaceFolders) {
 				this._onDidChangeWorkspaceFolders = new Emitter<Proposed.WorkspaceFoldersChangeEvent>();
 				this.connection.onNotification(Proposed.DidChangeWorkspaceFoldersNotification.type, (params) => {
 					this._onDidChangeWorkspaceFolders.fire(params.event);


### PR DESCRIPTION
Fix #257 by checking that the client actually has workspace capabilities defined before trying to read it.

https://github.com/Microsoft/vscode-languageserver-node/blob/9059f83cd8fb25b4a0fe5429540c562aa899dc6e/server/src/workspaceFolders.proposed.ts#L23-L24
