### PR TITLE
Correct some grammar and typos

### DIFF
--- a/protocol/src/protocol.implementation.proposed.md
+++ b/protocol/src/protocol.implementation.proposed.md
@@ -23,7 +23,7 @@ The client sets the following capability if it supports goto implementation.
 
 _Server Capabilities_:
 
-The server answer with the following cpatbility of it supports goto implementation
+The server answers with the following capability if it supports goto implementation.
 
 ```ts
 	/**


### PR DESCRIPTION
The new `protocol.implementation.proposed.md` file has a few minor English mistakes that needs to be fixed up.