### PR TITLE
Fix a parameter typo

### DIFF
--- a/types/src/main.ts
+++ b/types/src/main.ts
@@ -319,7 +319,7 @@ export namespace TextEdit {
 	}
 	/**
 	 * Creates a insert text edit.
-	 * @param psotion The position to insert the text at.
+	 * @param position The position to insert the text at.
 	 * @param newText The text to be inserted.
 	 */
 	export function insert(position: Position, newText: string): TextEdit {


### PR DESCRIPTION
TextEdit's `insert` function has a documented parameter name that doesn't match the actual parameter's name.