### PR TITLE
Change TextDocument's getText to take an optional range

### DIFF
--- a/types/src/main.ts
+++ b/types/src/main.ts
@@ -1460,11 +1460,14 @@ export interface TextDocument {
 	readonly version: number;
 
 	/**
-	 * Get the text of this document.
+	 * Get the text of this document. A substring can be retrieved by
+	 * providing a range.
 	 *
-	 * @return The text of this document.
+	 * @param range The interested range within the document to return.
+	 * @return The text of this document or a substring of the text if a
+	 *         range is provided.
 	 */
-	getText(): string;
+	getText(range?: Range): string;
 
 	/**
 	 * Converts a zero-based offset to a position.
@@ -1607,7 +1610,12 @@ class FullTextDocument implements TextDocument {
 		return this._version;
 	}
 
-	public getText(): string {
+	public getText(range?: Range): string {
+		if (range) {
+			let start = this.offsetAt(range.start);
+			let end = this.offsetAt(range.end);
+			return this._content.substring(start, end);
+		}
 		return this._content;
 	}
 

--- a/types/src/test/textdocument.test.ts
+++ b/types/src/test/textdocument.test.ts
@@ -5,7 +5,7 @@
 'use strict';
 
 import assert = require('assert');
-import { TextDocument, Position } from '../main';
+import { TextDocument, Range, Position } from '../main';
 
 suite('Text Document Lines Model Validator', () => {
 	function newDocument(str: string) {
@@ -62,6 +62,17 @@ suite('Text Document Lines Model Validator', () => {
 		assert.equal(newDocument(str).lineCount, 3);
 	})
 
+	test('getText(Range)', () => {
+		var str = "12345\n12345\n12345";
+		var lm = newDocument(str);
+		assert.equal(lm.getText(), str);
+		assert.equal(lm.getText(Range.create(-1, 0, 0, 5)), "12345");
+		assert.equal(lm.getText(Range.create(0, 0, 0, 5)), "12345");
+		assert.equal(lm.getText(Range.create(0, 4, 1, 1)), "5\n1");
+		assert.equal(lm.getText(Range.create(0, 4, 2, 1)), "5\n12345\n1");
+		assert.equal(lm.getText(Range.create(0, 4, 3, 1)), "5\n12345\n12345");
+		assert.equal(lm.getText(Range.create(0, 0, 3, 5)), str);
+	});
 
 	test('Invalid inputs', () => {
 		var str = "Hello World";


### PR DESCRIPTION
I've changed `TextDocument` so that its `getText()` function is now a `getText(range?: Range)`. This fixes #255 and allows a client to extract a substring from the document instead of the entire range. If any positions are detected to be outside the bounds of the document (an offset less than zero or an offset greater than the length of the document), they will be adjusted to accordingly to fit within the bounds of the document.