### PR TITLE
Client does not declare that clientCapabilities.workspace.workspaceEdit.documentChanges is supported

### DIFF
--- a/client/src/client.ts
+++ b/client/src/client.ts
@@ -2888,6 +2888,7 @@ export abstract class BaseLanguageClient {
 	private computeClientCapabilities(): ClientCapabilities {
 		let result: ClientCapabilities = {};
 		ensure(result, 'workspace')!.applyEdit = true;
+		ensure(ensure(result, 'workspace')!, 'workspaceEdit')!.documentChanges = true;
 		for (let feature of this._features) {
 			feature.fillClientCapabilities(result);
 		}

--- a/client/src/test/servers/testInitializeResult.ts
+++ b/client/src/test/servers/testInitializeResult.ts
@@ -19,6 +19,7 @@ documents.listen(connection);
 
 connection.onInitialize((params: InitializeParams): any => {
 	assert.equal((params.capabilities.workspace as any).applyEdit, true);
+	assert.equal(params.capabilities.workspace!.workspaceEdit!.documentChanges, true);
 	let valueSet = params.capabilities.textDocument!.completion!.completionItemKind!.valueSet!;
 	assert.equal(valueSet[0], 1);
 	assert.equal(valueSet[valueSet.length - 1], CompletionItemKind.TypeParameter);


### PR DESCRIPTION
https://github.com/Microsoft/vscode-languageserver-node/blob/f4595fa4f3a52c9210792c7b412f9e2ee478cdd3/client/src/client.ts#L2945-L2955

As seen in the code above, we can see that `documentChanges` are supported and are handled by the VS Code LSP client. However, this capability is not stated in the initialization parameters that the LSP client sends to a language server. It used to be sent but it was [commented out](https://github.com/Microsoft/vscode-languageserver-node/commit/863685b0dc160345bb91d7f7bac84cc6b89d8153#diff-79d1f5abc1a9f55a0e9eae588a7fdd56) and [later removed](https://github.com/Microsoft/vscode-languageserver-node/commit/4bc789ecfca9af5f98188e42ee3302dae2b2a5aa#diff-79d1f5abc1a9f55a0e9eae588a7fdd56). This is basically the same problem as #263 just for a different capability. This pull request adds the capability back to the initialization parameters and fixes #306.