### PR TITLE
Fix registration parameters for workspace/didChangeWatchedFiles

### DIFF
--- a/protocol/src/protocol.ts
+++ b/protocol/src/protocol.ts
@@ -1191,7 +1191,7 @@ export namespace WillSaveTextDocumentWaitUntilRequest {
  * the client detects changes to file watched by the lanaguage client.
  */
 export namespace DidChangeWatchedFilesNotification {
-	export const type = new NotificationType<DidChangeWatchedFilesParams, void>('workspace/didChangeWatchedFiles');
+	export const type = new NotificationType<DidChangeWatchedFilesParams, DidChangeWatchedFilesRegistrationOptions>('workspace/didChangeWatchedFiles');
 }
 
 /**


### PR DESCRIPTION
It's currently not possible to register for `workspace/didChangeWatchedFiles` notifications because it has `void` set as a parameter. We should be using `DidChangeWatchedFilesRegistrationOptions` instead so that servers can define the interested files when sending its `client/registerCapability` request to the client.