### PR TITLE
Add middleware to intercept textDocument/publishDiagnostics

### DIFF
--- a/client/src/test/servers/testInitializeResult.ts
+++ b/client/src/test/servers/testInitializeResult.ts
@@ -33,6 +33,9 @@ connection.onInitialize((params: InitializeParams): any => {
 	return { capabilities, customResults: { "hello": "world" } };
 });
 
+connection.onInitialized(() => {
+	connection.sendDiagnostics({ uri: "uri:/test.ts", diagnostics: [] });
+});
 
 // Listen on the connection
 connection.listen();


### PR DESCRIPTION
It is currently not possible for a client to inspect the contents of the `textDocument/publishDiagnostics` notifications from the server before letting VS Code handle them. This pull request introduces a middleware function to allow clients to intercept the contents of the notification before passing them off to VS Code.