### PR TITLE
client: Fixed issue where executeCommand result from language server was always undefined

### DIFF
--- a/client/src/client.ts
+++ b/client/src/client.ts
@@ -2162,7 +2162,7 @@ class ExecuteCommandFeature implements DynamicFeature<ExecuteCommandRegistration
 						arguments: args
 					};
 					return client.sendRequest(ExecuteCommandRequest.type, params).then(
-						undefined,
+						(result) => result,
 						(error) => {
 							client.logFailedRequest(ExecuteCommandRequest.type, error);
 						}


### PR DESCRIPTION
If the command is implemented inside the VSCode extension, it works correctly:

``` typescript
vscode.commands.registerCommand("myCommand", () =>
{
	return true;
});
```

``` typescript
vscode.commands.executeCommand("myCommand").then((result) =>
{
	console.log("myCommand result:", result);
});
```

However, if the command is implemented in the language server instead (in my case, I'm using eclipse/lsp4j with Java), the result is always `undefined`. With this change, it should use the correct result instead of `undefined`