### PR TITLE
Add deprecated boolean property to CompletionItem and SymbolInformation

### DIFF
--- a/client/src/client.ts
+++ b/client/src/client.ts
@@ -1303,7 +1303,7 @@ class CompletionItemFeature extends TextDocumentFeature<CompletionRegistrationOp
 		let completion = ensure(ensure(capabilites, 'textDocument')!, 'completion')!;
 		completion.dynamicRegistration = true;
 		completion.contextSupport = true;
-		completion.completionItem = { snippetSupport: true, commitCharactersSupport: true, documentationFormat: [MarkupKind.Markdown, MarkupKind.PlainText] };
+		completion.completionItem = { snippetSupport: true, commitCharactersSupport: true, documentationFormat: [MarkupKind.Markdown, MarkupKind.PlainText], deprecatedSupport: false };
 		completion.completionItemKind = { valueSet: SupportedCompletionItemKinds };
 	}
 

--- a/protocol/src/protocol.ts
+++ b/protocol/src/protocol.ts
@@ -299,6 +299,11 @@ export interface TextDocumentClientCapabilities {
 			 * property. The order describes the preferred format of the client.
 			 */
 			documentationFormat?: MarkupKind[];
+
+			/**
+			 * Client supports the deprecated property on a completion item.
+			 */
+			deprecatedSupport?: boolean;
 		},
 
 		completionItemKind?: {

--- a/types/src/main.ts
+++ b/types/src/main.ts
@@ -875,6 +875,11 @@ export interface CompletionItem {
 	documentation?: string | MarkupContent;
 
 	/**
+	 * Indicates if this item is deprecated.
+	 */
+	deprecated?: boolean;
+
+	/**
 	 * A string that should be used when comparing this item
 	 * with other items. When `falsy` the [label](#CompletionItem.label)
 	 * is used.
@@ -1261,6 +1266,11 @@ export interface SymbolInformation {
 	 * The kind of this symbol.
 	 */
 	kind: SymbolKind;
+
+	/**
+	 * Indicates if this symbol is deprecated.
+	 */
+	deprecated?: boolean;
 
 	/**
 	 * The location of this symbol. The location's range is used by a tool


### PR DESCRIPTION
I've added a new boolean `deprecated` property both `CompletionItem` and `SymbolInformation`.

See Microsoft/language-server-protocol#139.