### PR TITLE
Fix documentLink/resolve by introducing a data field

### DIFF
--- a/client/src/codeConverter.ts
+++ b/client/src/codeConverter.ts
@@ -9,6 +9,7 @@ import * as proto from 'vscode-languageserver-protocol';
 import * as Is from './utils/is';
 import ProtocolCompletionItem from './protocolCompletionItem';
 import ProtocolCodeLens from './protocolCodeLens';
+import ProtocolDocumentLink from './protocolDocumentLink';
 import { MarkdownString } from 'vscode';
 
 export interface Converter {
@@ -409,6 +410,10 @@ export function createConverter(uriConverter?: URIConverter): Converter {
 	function asDocumentLink(item: code.DocumentLink): proto.DocumentLink {
 		let result = proto.DocumentLink.create(asRange(item.range));
 		if (item.target) { result.target = asUri(item.target); }
+		let protocolItem = item instanceof ProtocolDocumentLink ? item as ProtocolDocumentLink : undefined;
+		if (protocolItem && protocolItem.data) {
+			result.data = protocolItem.data;
+		}
 		return result;
 	}
 

--- a/client/src/protocolConverter.ts
+++ b/client/src/protocolConverter.ts
@@ -9,6 +9,7 @@ import * as ls from 'vscode-languageserver-protocol';
 import * as Is from './utils/is';
 import ProtocolCompletionItem from './protocolCompletionItem';
 import ProtocolCodeLens from './protocolCodeLens';
+import ProtocolDocumentLink from './protocolDocumentLink';
 
 export interface Converter {
 
@@ -539,7 +540,9 @@ export function createConverter(uriConverter?: URIConverter): Converter {
 		let range = asRange(item.range);
 		let target = item.target ? asUri(item.target) : undefined;
 		// target must be optional in DocumentLink
-		return new code.DocumentLink(range, target);
+		let link = new ProtocolDocumentLink(range, target);
+		if (item.data !== void 0 && item.data !== null) { link.data = item.data; }
+		return link;
 	}
 
 	function asDocumentLinks(items: ls.DocumentLink[]): code.DocumentLink[];

--- a/client/src/protocolDocumentLink.ts
+++ b/client/src/protocolDocumentLink.ts
@@ -1,0 +1,16 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+'use strict';
+
+import * as code from 'vscode';
+
+export default class ProtocolDocumentLink extends code.DocumentLink {
+
+	public data: any;
+
+	constructor(range: code.Range, target?: code.Uri | undefined) {
+		super(range, target);
+	}
+}

--- a/types/src/main.ts
+++ b/types/src/main.ts
@@ -1461,6 +1461,12 @@ export class DocumentLink {
 	 * The uri this link points to.
 	 */
 	target?: string;
+
+	/**
+	 * A data entry field that is preserved on a document link between a
+	 * DocumentLinkRequest and a DocumentLinkResolveRequest.
+	 */
+	data?: any
 }
 
 /**
@@ -1471,8 +1477,8 @@ export namespace DocumentLink {
 	/**
 	 * Creates a new DocumentLink literal.
 	 */
-	export function create(range: Range, target?: string): DocumentLink {
-		return { range, target };
+	export function create(range: Range, target?: string, data?: any): DocumentLink {
+		return { range, target, data };
 	}
 
 	/**


### PR DESCRIPTION
The current definition of a `DocumentLink` makes resolving a link with `documentLink/resolve` essentially impossible. With only a `range` field available, it is not possible for the server to deduce what the originating content is as it does not have any information as to which text document the link is for.

To correct this, a new `data` field has been introduced to `DocumentLink` that servers can fill in with some whatever it needs when initially fulfilling the `textDocument/documentLink` request. This way, a subsequent `documentLink/resolve` request will have the necessary contextual information available to resolve the link and return back a URI to use in the `target` field.