### PR TITLE
Replace symlinking in Travis build with npm scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,15 +20,9 @@ before_install:
     fi
 
 install:
-  - cd protocol && mkdir node_modules && cd ..
-  - cd protocol/node_modules && ln -s ../../jsonrpc vscode-jsonrpc && cd ../..
-  - cd protocol/node_modules && ln -s ../../types vscode-languageserver-types && cd ../..
-  - cd client && mkdir node_modules && cd ..
-  - cd client/node_modules && ln -s ../../protocol vscode-languageserver-protocol && cd ../..
-  - cd server && mkdir node_modules && cd ..
-  - cd server/node_modules && ln -s ../../protocol vscode-languageserver-protocol && cd ../..
+  - npm install
+  - npm run symlink
 
 script:
-  - npm install
   - npm run compile
   - npm run test

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,6 +68,12 @@
 			"integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
 			"dev": true
 		},
+		"es6-object-assign": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.1.0.tgz",
+			"integrity": "sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw=",
+			"dev": true
+		},
 		"escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -132,6 +138,12 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
 			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+			"dev": true
+		},
+		"interpret": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
+			"integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=",
 			"dev": true
 		},
 		"json3": {
@@ -273,6 +285,30 @@
 			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
 			"dev": true
 		},
+		"path-parse": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+			"integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+			"dev": true
+		},
+		"rechoir": {
+			"version": "0.6.2",
+			"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+			"integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+			"dev": true,
+			"requires": {
+				"resolve": "1.7.1"
+			}
+		},
+		"resolve": {
+			"version": "1.7.1",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.1.tgz",
+			"integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
+			"dev": true,
+			"requires": {
+				"path-parse": "1.0.5"
+			}
+		},
 		"rimraf": {
 			"version": "2.6.2",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
@@ -280,6 +316,36 @@
 			"dev": true,
 			"requires": {
 				"glob": "7.1.1"
+			}
+		},
+		"shelljs": {
+			"version": "0.7.8",
+			"resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
+			"integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
+			"dev": true,
+			"requires": {
+				"glob": "7.1.1",
+				"interpret": "1.1.0",
+				"rechoir": "0.6.2"
+			}
+		},
+		"shx": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/shx/-/shx-0.2.2.tgz",
+			"integrity": "sha1-CjBNAgsO3xMGrYFXDoDwNG31ijk=",
+			"dev": true,
+			"requires": {
+				"es6-object-assign": "1.1.0",
+				"minimist": "1.2.0",
+				"shelljs": "0.7.8"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+					"dev": true
+				}
 			}
 		},
 		"supports-color": {

--- a/package.json
+++ b/package.json
@@ -16,11 +16,13 @@
 		"mocha": "^3.5.0",
 		"@types/node": "^6.0.88",
 		"@types/mocha": "^2.2.42",
-		"rimraf": "^2.6.2"
+		"rimraf": "^2.6.2",
+		"shx": "^0.2.2"
 	},
 	"scripts": {
 		"postinstall": "cd types && npm install && cd ../jsonrpc && npm install && cd ../protocol && npm install && cd ../server && npm install && cd ../client && npm install && cd ..",
 		"test": "cd types && npm test && cd ../jsonrpc && npm test && cd ../protocol && npm test && cd ../server && npm test && cd ../client && npm test && cd ..",
+		"symlink": "shx rm -rf protocol/node_modules/vscode-jsonrpc protocol/node_modules/vscode-languageserver-types client/node_modules/vscode-languageserver-protocol server/node_modules/vscode-languageserver-protocol && cd client/node_modules && shx ln -s ../../protocol vscode-languageserver-protocol && cd ../../server/node_modules && shx ln -s ../../protocol vscode-languageserver-protocol && cd ../../protocol/node_modules && shx ln -s ../../jsonrpc vscode-jsonrpc && shx ln -s ../../types vscode-languageserver-types",
 		"compile": "npm run compile:types && npm run compile:jsonrpc && npm run compile:protocol && npm run compile:server && npm run compile:client",
 		"compile:types": "tsc -p ./types/tsconfig.json",
 		"compile:jsonrpc": "tsc -p ./jsonrpc/tsconfig.json",


### PR DESCRIPTION
In npm 5 (which is included in Node.js 8), symbolic links in the `node_modules` folder are now replaced by what's in the npm registry. This means that symbolic links that were originally created in `.travis.yml` prior to invoking `npm install` were getting deleted and replaced by packages from the npm registry. As a result, we now need to create the symbolic links **after** `npm install` has completed.

Pushing the linking magic down to an npm script instead of only performing this as part of the CI build also allows it to be reused for local development. This has the advantage of making local development more closely match what is happening in the CI builds.