### PR TITLE
Add `undefined` to TextDocuments#get(uri: string)

### DIFF
--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -207,7 +207,7 @@ export class TextDocuments {
 	 * @param uri The text document's URI to retrieve.
 	 * @return the text document or `undefined`.
 	 */
-	public get(uri: string): TextDocument {
+	public get(uri: string): TextDocument | undefined {
 		return this._documents[uri];
 	}
 


### PR DESCRIPTION
As the [documentation of `TextDocuments#get(uri: string)` funtion](https://github.com/Microsoft/vscode-languageserver-node/blob/master/server/src/main.ts#L203-L212) states:
> Returns the document for the given URI. Returns undefined if the document is not mananged by this instance.

The return type does not reflect that it can return `undefined`. This commit adds that.

This might be a breaking change for existing code bases (which use `strictNullChecks`), so feel free to reject this PR.