### PR TITLE
CompletionItem's deprecated property should be preserved across requests

### DIFF
--- a/client/src/client.ts
+++ b/client/src/client.ts
@@ -1303,7 +1303,7 @@ class CompletionItemFeature extends TextDocumentFeature<CompletionRegistrationOp
 		let completion = ensure(ensure(capabilites, 'textDocument')!, 'completion')!;
 		completion.dynamicRegistration = true;
 		completion.contextSupport = true;
-		completion.completionItem = { snippetSupport: true, commitCharactersSupport: true, documentationFormat: [MarkupKind.Markdown, MarkupKind.PlainText], deprecatedSupport: false };
+		completion.completionItem = { snippetSupport: true, commitCharactersSupport: true, documentationFormat: [MarkupKind.Markdown, MarkupKind.PlainText], deprecatedSupport: true };
 		completion.completionItemKind = { valueSet: SupportedCompletionItemKinds };
 	}
 

--- a/client/src/codeConverter.ts
+++ b/client/src/codeConverter.ts
@@ -319,8 +319,13 @@ export function createConverter(uriConverter?: URIConverter): Converter {
 		if (item.additionalTextEdits) { result.additionalTextEdits = asTextEdits(item.additionalTextEdits); }
 		if (item.commitCharacters) { result.commitCharacters = item.commitCharacters.slice(); }
 		if (item.command) { result.command = asCommand(item.command); }
-		if (protocolItem && protocolItem.data) {
-			result.data = protocolItem.data;
+		if (protocolItem) {
+			if (protocolItem.data) {
+				result.data = protocolItem.data;
+			}
+			if (protocolItem.deprecated === true || protocolItem.deprecated === false) {
+				result.deprecated = protocolItem.deprecated;
+			}
 		}
 		return result;
 	}

--- a/client/src/protocolCompletionItem.ts
+++ b/client/src/protocolCompletionItem.ts
@@ -13,6 +13,7 @@ export default class ProtocolCompletionItem extends code.CompletionItem {
 	public fromEdit: boolean;
 	public documentationFormat: string;
 	public originalItemKind: proto.CompletionItemKind;
+	public deprecated: boolean;
 
 	constructor(label: string) {
 		super(label);

--- a/client/src/protocolConverter.ts
+++ b/client/src/protocolConverter.ts
@@ -301,6 +301,7 @@ export function createConverter(uriConverter?: URIConverter): Converter {
 		if (item.additionalTextEdits) { result.additionalTextEdits = asTextEdits(item.additionalTextEdits); }
 		if (Is.stringArray(item.commitCharacters)) { result.commitCharacters = item.commitCharacters.slice(); }
 		if (item.command) { result.command = asCommand(item.command); }
+		if (item.deprecated === true || item.deprecated === false) { result.deprecated = item.deprecated };
 		if (item.data !== void 0 && item.data !== null) { result.data = item.data; }
 		return result;
 	}

--- a/client/src/test/servers/testInitializeResult.ts
+++ b/client/src/test/servers/testInitializeResult.ts
@@ -20,6 +20,7 @@ documents.listen(connection);
 connection.onInitialize((params: InitializeParams): any => {
 	assert.equal((params.capabilities.workspace as any).applyEdit, true);
 	assert.equal(params.capabilities.workspace!.workspaceEdit!.documentChanges, true);
+	assert.equal(params.capabilities.textDocument!.completion!.completionItem!.deprecatedSupport, true);
 	let valueSet = params.capabilities.textDocument!.completion!.completionItemKind!.valueSet!;
 	assert.equal(valueSet[0], 1);
 	assert.equal(valueSet[valueSet.length - 1], CompletionItemKind.TypeParameter);


### PR DESCRIPTION
Although VS Code does not currently support appending a visual indicator that a completion item is "deprecated", the `deprecated` property itself of a `CompletionItem` should still be preserved across requests. This will allow language servers to read and write to that field across a `textDocument/completion` request and a `completionItem/resolve` request.

I used `if (x.val === true || x.val === false) { y.val = x.val; }` to ensure that only `boolean` values would be converted as I didn't want to encourage an "anything goes" attitude.