### PR TITLE
Test #351 to ensure that CompletionItem data is preserved

### DIFF
--- a/client/src/test/converter.test.ts
+++ b/client/src/test/converter.test.ts
@@ -309,6 +309,36 @@ suite('Protocol Converter', () => {
 		strictEqual(result.data, completionItem.data);
 	});
 
+	test('Completion Item Preserve Data === 0', () => {
+		let completionItem: proto.CompletionItem = {
+			label: 'item',
+			data: 0
+		};
+
+		let result = c2p.asCompletionItem(p2c.asCompletionItem(completionItem));
+		strictEqual(result.data, completionItem.data);
+	});
+
+	test('Completion Item Preserve Data === false', () => {
+		let completionItem: proto.CompletionItem = {
+			label: 'item',
+			data: false
+		};
+
+		let result = c2p.asCompletionItem(p2c.asCompletionItem(completionItem));
+		strictEqual(result.data, completionItem.data);
+	});
+
+	test('Completion Item Preserve Data === ""', () => {
+		let completionItem: proto.CompletionItem = {
+			label: 'item',
+			data: ''
+		};
+
+		let result = c2p.asCompletionItem(p2c.asCompletionItem(completionItem));
+		strictEqual(result.data, completionItem.data);
+	});
+
 	test('Completion Item Documentation as string', () => {
 		let completionItem: proto.CompletionItem = {
 			label: 'item',


### PR DESCRIPTION
I've added tests to ensure that if a `CompletionItem` has `data === 0`, `data === false`, or `data === ""`, it will be preserved across a `textDocument/completionItem` and a `completionItem/resolve` request.