### PR TITLE
Typeguards

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "vscode-languageclient",
-	"version": "4.2.0",
+	"version": "4.2.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -10,10 +10,10 @@
 			"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
 			"dev": true,
 			"requires": {
-				"co": "4.6.0",
-				"fast-deep-equal": "1.0.0",
-				"fast-json-stable-stringify": "2.0.0",
-				"json-schema-traverse": "0.3.1"
+				"co": "^4.6.0",
+				"fast-deep-equal": "^1.0.0",
+				"fast-json-stable-stringify": "^2.0.0",
+				"json-schema-traverse": "^0.3.0"
 			}
 		},
 		"ansi-gray": {
@@ -49,7 +49,7 @@
 			"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
 			"dev": true,
 			"requires": {
-				"arr-flatten": "1.1.0"
+				"arr-flatten": "^1.0.1"
 			}
 		},
 		"arr-flatten": {
@@ -70,7 +70,7 @@
 			"integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
 			"dev": true,
 			"requires": {
-				"array-uniq": "1.0.3"
+				"array-uniq": "^1.0.1"
 			}
 		},
 		"array-uniq": {
@@ -122,7 +122,7 @@
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"tweetnacl": "0.14.5"
+				"tweetnacl": "^0.14.3"
 			}
 		},
 		"beeper": {
@@ -137,7 +137,7 @@
 			"integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
 			"dev": true,
 			"requires": {
-				"inherits": "2.0.3"
+				"inherits": "~2.0.0"
 			}
 		},
 		"brace-expansion": {
@@ -146,7 +146,7 @@
 			"integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
 			"dev": true,
 			"requires": {
-				"balanced-match": "1.0.0",
+				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
 			}
 		},
@@ -156,9 +156,9 @@
 			"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
 			"dev": true,
 			"requires": {
-				"expand-range": "1.8.2",
-				"preserve": "0.2.0",
-				"repeat-element": "1.1.2"
+				"expand-range": "^1.8.1",
+				"preserve": "^0.2.0",
+				"repeat-element": "^1.1.2"
 			}
 		},
 		"browser-stdout": {
@@ -179,11 +179,11 @@
 			"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 			"dev": true,
 			"requires": {
-				"ansi-styles": "2.2.1",
-				"escape-string-regexp": "1.0.5",
-				"has-ansi": "2.0.0",
-				"strip-ansi": "3.0.1",
-				"supports-color": "2.0.0"
+				"ansi-styles": "^2.2.1",
+				"escape-string-regexp": "^1.0.2",
+				"has-ansi": "^2.0.0",
+				"strip-ansi": "^3.0.0",
+				"supports-color": "^2.0.0"
 			}
 		},
 		"clone": {
@@ -210,9 +210,9 @@
 			"integrity": "sha1-pikNQT8hemEjL5XkWP84QYz7ARc=",
 			"dev": true,
 			"requires": {
-				"inherits": "2.0.3",
-				"process-nextick-args": "1.0.7",
-				"through2": "2.0.3"
+				"inherits": "^2.0.1",
+				"process-nextick-args": "^1.0.6",
+				"through2": "^2.0.1"
 			}
 		},
 		"co": {
@@ -233,7 +233,7 @@
 			"integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
 			"dev": true,
 			"requires": {
-				"delayed-stream": "1.0.0"
+				"delayed-stream": "~1.0.0"
 			}
 		},
 		"concat-map": {
@@ -260,7 +260,7 @@
 			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
 			"dev": true,
 			"requires": {
-				"assert-plus": "1.0.0"
+				"assert-plus": "^1.0.0"
 			},
 			"dependencies": {
 				"assert-plus": {
@@ -292,7 +292,7 @@
 			"integrity": "sha1-sJJ0O+hCfcYh6gBnzex+cN0Z83s=",
 			"dev": true,
 			"requires": {
-				"is-obj": "1.0.1"
+				"is-obj": "^1.0.0"
 			}
 		},
 		"delayed-stream": {
@@ -319,7 +319,7 @@
 			"integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
 			"dev": true,
 			"requires": {
-				"readable-stream": "1.1.14"
+				"readable-stream": "~1.1.9"
 			},
 			"dependencies": {
 				"isarray": {
@@ -334,10 +334,10 @@
 					"integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
 					"dev": true,
 					"requires": {
-						"core-util-is": "1.0.2",
-						"inherits": "2.0.3",
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.1",
 						"isarray": "0.0.1",
-						"string_decoder": "0.10.31"
+						"string_decoder": "~0.10.x"
 					}
 				},
 				"string_decoder": {
@@ -354,10 +354,10 @@
 			"integrity": "sha1-ThUWvmiDi8kKSZlPCzmm5ZYL780=",
 			"dev": true,
 			"requires": {
-				"end-of-stream": "1.4.0",
-				"inherits": "2.0.3",
-				"readable-stream": "2.3.3",
-				"stream-shift": "1.0.0"
+				"end-of-stream": "^1.0.0",
+				"inherits": "^2.0.1",
+				"readable-stream": "^2.0.0",
+				"stream-shift": "^1.0.0"
 			}
 		},
 		"ecc-jsbn": {
@@ -367,7 +367,7 @@
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"jsbn": "0.1.1"
+				"jsbn": "~0.1.0"
 			}
 		},
 		"end-of-stream": {
@@ -376,7 +376,7 @@
 			"integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
 			"dev": true,
 			"requires": {
-				"once": "1.4.0"
+				"once": "^1.4.0"
 			}
 		},
 		"es6-object-assign": {
@@ -397,13 +397,13 @@
 			"integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
 			"dev": true,
 			"requires": {
-				"duplexer": "0.1.1",
-				"from": "0.1.7",
-				"map-stream": "0.1.0",
+				"duplexer": "~0.1.1",
+				"from": "~0",
+				"map-stream": "~0.1.0",
 				"pause-stream": "0.0.11",
-				"split": "0.3.3",
-				"stream-combiner": "0.0.4",
-				"through": "2.3.8"
+				"split": "0.3",
+				"stream-combiner": "~0.0.4",
+				"through": "~2.3.1"
 			}
 		},
 		"expand-brackets": {
@@ -412,7 +412,7 @@
 			"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
 			"dev": true,
 			"requires": {
-				"is-posix-bracket": "0.1.1"
+				"is-posix-bracket": "^0.1.0"
 			}
 		},
 		"expand-range": {
@@ -421,7 +421,7 @@
 			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
 			"dev": true,
 			"requires": {
-				"fill-range": "2.2.3"
+				"fill-range": "^2.1.0"
 			}
 		},
 		"extend": {
@@ -436,7 +436,7 @@
 			"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 			"dev": true,
 			"requires": {
-				"is-extendable": "0.1.1"
+				"is-extendable": "^0.1.0"
 			}
 		},
 		"extglob": {
@@ -445,7 +445,7 @@
 			"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
 			"dev": true,
 			"requires": {
-				"is-extglob": "1.0.0"
+				"is-extglob": "^1.0.0"
 			},
 			"dependencies": {
 				"is-extglob": {
@@ -468,9 +468,9 @@
 			"integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
 			"dev": true,
 			"requires": {
-				"ansi-gray": "0.1.1",
-				"color-support": "1.1.3",
-				"time-stamp": "1.1.0"
+				"ansi-gray": "^0.1.1",
+				"color-support": "^1.1.3",
+				"time-stamp": "^1.0.0"
 			}
 		},
 		"fast-deep-equal": {
@@ -491,7 +491,7 @@
 			"integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
 			"dev": true,
 			"requires": {
-				"pend": "1.2.0"
+				"pend": "~1.2.0"
 			}
 		},
 		"filename-regex": {
@@ -506,11 +506,11 @@
 			"integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
 			"dev": true,
 			"requires": {
-				"is-number": "2.1.0",
-				"isobject": "2.1.0",
-				"randomatic": "1.1.7",
-				"repeat-element": "1.1.2",
-				"repeat-string": "1.6.1"
+				"is-number": "^2.1.0",
+				"isobject": "^2.0.0",
+				"randomatic": "^1.1.3",
+				"repeat-element": "^1.1.2",
+				"repeat-string": "^1.5.2"
 			}
 		},
 		"first-chunk-stream": {
@@ -531,7 +531,7 @@
 			"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
 			"dev": true,
 			"requires": {
-				"for-in": "1.0.2"
+				"for-in": "^1.0.1"
 			}
 		},
 		"forever-agent": {
@@ -558,10 +558,10 @@
 			"integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"inherits": "2.0.3",
-				"mkdirp": "0.5.1",
-				"rimraf": "2.6.2"
+				"graceful-fs": "^4.1.2",
+				"inherits": "~2.0.0",
+				"mkdirp": ">=0.5 0",
+				"rimraf": "2"
 			}
 		},
 		"getpass": {
@@ -570,7 +570,7 @@
 			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
 			"dev": true,
 			"requires": {
-				"assert-plus": "1.0.0"
+				"assert-plus": "^1.0.0"
 			},
 			"dependencies": {
 				"assert-plus": {
@@ -587,12 +587,12 @@
 			"integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
 			"dev": true,
 			"requires": {
-				"fs.realpath": "1.0.0",
-				"inflight": "1.0.6",
-				"inherits": "2.0.3",
-				"minimatch": "3.0.4",
-				"once": "1.4.0",
-				"path-is-absolute": "1.0.1"
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.0.4",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
 			}
 		},
 		"glob-base": {
@@ -601,8 +601,8 @@
 			"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
 			"dev": true,
 			"requires": {
-				"glob-parent": "2.0.0",
-				"is-glob": "2.0.1"
+				"glob-parent": "^2.0.0",
+				"is-glob": "^2.0.0"
 			},
 			"dependencies": {
 				"glob-parent": {
@@ -611,7 +611,7 @@
 					"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
 					"dev": true,
 					"requires": {
-						"is-glob": "2.0.1"
+						"is-glob": "^2.0.0"
 					}
 				},
 				"is-extglob": {
@@ -626,7 +626,7 @@
 					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
 					"dev": true,
 					"requires": {
-						"is-extglob": "1.0.0"
+						"is-extglob": "^1.0.0"
 					}
 				}
 			}
@@ -637,8 +637,8 @@
 			"integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
 			"dev": true,
 			"requires": {
-				"is-glob": "3.1.0",
-				"path-dirname": "1.0.2"
+				"is-glob": "^3.1.0",
+				"path-dirname": "^1.0.0"
 			}
 		},
 		"glob-stream": {
@@ -647,14 +647,14 @@
 			"integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
 			"dev": true,
 			"requires": {
-				"extend": "3.0.1",
-				"glob": "5.0.15",
-				"glob-parent": "3.1.0",
-				"micromatch": "2.3.11",
-				"ordered-read-streams": "0.3.0",
-				"through2": "0.6.5",
-				"to-absolute-glob": "0.1.1",
-				"unique-stream": "2.2.1"
+				"extend": "^3.0.0",
+				"glob": "^5.0.3",
+				"glob-parent": "^3.0.0",
+				"micromatch": "^2.3.7",
+				"ordered-read-streams": "^0.3.0",
+				"through2": "^0.6.0",
+				"to-absolute-glob": "^0.1.1",
+				"unique-stream": "^2.0.2"
 			},
 			"dependencies": {
 				"glob": {
@@ -663,11 +663,11 @@
 					"integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
 					"dev": true,
 					"requires": {
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "2 || 3",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
 					}
 				},
 				"isarray": {
@@ -682,10 +682,10 @@
 					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
 					"dev": true,
 					"requires": {
-						"core-util-is": "1.0.2",
-						"inherits": "2.0.3",
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.1",
 						"isarray": "0.0.1",
-						"string_decoder": "0.10.31"
+						"string_decoder": "~0.10.x"
 					}
 				},
 				"string_decoder": {
@@ -700,8 +700,8 @@
 					"integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
 					"dev": true,
 					"requires": {
-						"readable-stream": "1.0.34",
-						"xtend": "4.0.1"
+						"readable-stream": ">=1.0.33-1 <1.1.0-0",
+						"xtend": ">=4.0.0 <4.1.0-0"
 					}
 				}
 			}
@@ -712,7 +712,7 @@
 			"integrity": "sha1-f+DxmfV6yQbPUS/urY+Q7kooT8U=",
 			"dev": true,
 			"requires": {
-				"sparkles": "1.0.0"
+				"sparkles": "^1.0.0"
 			}
 		},
 		"graceful-fs": {
@@ -733,9 +733,9 @@
 			"integrity": "sha1-AMOQuSigeZslGsz2MaoJ4BzGKZw=",
 			"dev": true,
 			"requires": {
-				"deep-assign": "1.0.0",
-				"stat-mode": "0.2.2",
-				"through2": "2.0.3"
+				"deep-assign": "^1.0.0",
+				"stat-mode": "^0.2.0",
+				"through2": "^2.0.0"
 			}
 		},
 		"gulp-filter": {
@@ -744,9 +744,9 @@
 			"integrity": "sha1-XYf2YuMX5YOe92UOYg5skAj/ktA=",
 			"dev": true,
 			"requires": {
-				"gulp-util": "3.0.8",
-				"multimatch": "2.1.0",
-				"streamfilter": "1.0.7"
+				"gulp-util": "^3.0.6",
+				"multimatch": "^2.0.0",
+				"streamfilter": "^1.0.5"
 			}
 		},
 		"gulp-gunzip": {
@@ -755,8 +755,8 @@
 			"integrity": "sha1-FbdBFF6Dqcb1CIYkG1fMWHHxUak=",
 			"dev": true,
 			"requires": {
-				"through2": "0.6.5",
-				"vinyl": "0.4.6"
+				"through2": "~0.6.5",
+				"vinyl": "~0.4.6"
 			},
 			"dependencies": {
 				"clone": {
@@ -817,11 +817,11 @@
 			"integrity": "sha512-/9vtSk9eI9DEWCqzGieglPqmx0WUQ9pwPHyHFpKmfxqdgqGJC2l0vFMdYs54hLdDsMDEZFLDL2J4ikjc4hQ5HQ==",
 			"dev": true,
 			"requires": {
-				"event-stream": "3.3.4",
-				"node.extend": "1.1.6",
-				"request": "2.83.0",
-				"through2": "2.0.3",
-				"vinyl": "2.1.0"
+				"event-stream": "^3.3.4",
+				"node.extend": "^1.1.2",
+				"request": "^2.79.0",
+				"through2": "^2.0.3",
+				"vinyl": "^2.0.1"
 			},
 			"dependencies": {
 				"clone": {
@@ -848,12 +848,12 @@
 					"integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
 					"dev": true,
 					"requires": {
-						"clone": "2.1.1",
-						"clone-buffer": "1.0.0",
-						"clone-stats": "1.0.0",
-						"cloneable-readable": "1.0.0",
-						"remove-trailing-separator": "1.1.0",
-						"replace-ext": "1.0.0"
+						"clone": "^2.1.1",
+						"clone-buffer": "^1.0.0",
+						"clone-stats": "^1.0.0",
+						"cloneable-readable": "^1.0.0",
+						"remove-trailing-separator": "^1.0.1",
+						"replace-ext": "^1.0.0"
 					}
 				}
 			}
@@ -864,11 +864,11 @@
 			"integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
 			"dev": true,
 			"requires": {
-				"convert-source-map": "1.5.1",
-				"graceful-fs": "4.1.11",
-				"strip-bom": "2.0.0",
-				"through2": "2.0.3",
-				"vinyl": "1.2.0"
+				"convert-source-map": "^1.1.1",
+				"graceful-fs": "^4.1.2",
+				"strip-bom": "^2.0.0",
+				"through2": "^2.0.0",
+				"vinyl": "^1.0.0"
 			},
 			"dependencies": {
 				"vinyl": {
@@ -877,8 +877,8 @@
 					"integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
 					"dev": true,
 					"requires": {
-						"clone": "1.0.3",
-						"clone-stats": "0.0.1",
+						"clone": "^1.0.0",
+						"clone-stats": "^0.0.1",
 						"replace-ext": "0.0.1"
 					}
 				}
@@ -890,10 +890,10 @@
 			"integrity": "sha1-wWUyBzLRks5W/ZQnH/oSMjS/KuA=",
 			"dev": true,
 			"requires": {
-				"event-stream": "3.3.4",
-				"mkdirp": "0.5.1",
-				"queue": "3.1.0",
-				"vinyl-fs": "2.4.4"
+				"event-stream": "^3.3.1",
+				"mkdirp": "^0.5.1",
+				"queue": "^3.1.0",
+				"vinyl-fs": "^2.4.3"
 			}
 		},
 		"gulp-untar": {
@@ -902,11 +902,11 @@
 			"integrity": "sha1-1r3v3n6ajgVMnxYjhaB4LEvnQAA=",
 			"dev": true,
 			"requires": {
-				"event-stream": "3.3.4",
-				"gulp-util": "3.0.8",
-				"streamifier": "0.1.1",
-				"tar": "2.2.1",
-				"through2": "2.0.3"
+				"event-stream": "~3.3.4",
+				"gulp-util": "~3.0.8",
+				"streamifier": "~0.1.1",
+				"tar": "^2.2.1",
+				"through2": "~2.0.3"
 			}
 		},
 		"gulp-util": {
@@ -915,24 +915,24 @@
 			"integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
 			"dev": true,
 			"requires": {
-				"array-differ": "1.0.0",
-				"array-uniq": "1.0.3",
-				"beeper": "1.1.1",
-				"chalk": "1.1.3",
-				"dateformat": "2.2.0",
-				"fancy-log": "1.3.2",
-				"gulplog": "1.0.0",
-				"has-gulplog": "0.1.0",
-				"lodash._reescape": "3.0.0",
-				"lodash._reevaluate": "3.0.0",
-				"lodash._reinterpolate": "3.0.0",
-				"lodash.template": "3.6.2",
-				"minimist": "1.2.0",
-				"multipipe": "0.1.2",
-				"object-assign": "3.0.0",
+				"array-differ": "^1.0.0",
+				"array-uniq": "^1.0.2",
+				"beeper": "^1.0.0",
+				"chalk": "^1.0.0",
+				"dateformat": "^2.0.0",
+				"fancy-log": "^1.1.0",
+				"gulplog": "^1.0.0",
+				"has-gulplog": "^0.1.0",
+				"lodash._reescape": "^3.0.0",
+				"lodash._reevaluate": "^3.0.0",
+				"lodash._reinterpolate": "^3.0.0",
+				"lodash.template": "^3.0.0",
+				"minimist": "^1.1.0",
+				"multipipe": "^0.1.2",
+				"object-assign": "^3.0.0",
 				"replace-ext": "0.0.1",
-				"through2": "2.0.3",
-				"vinyl": "0.5.3"
+				"through2": "^2.0.0",
+				"vinyl": "^0.5.0"
 			}
 		},
 		"gulp-vinyl-zip": {
@@ -941,13 +941,13 @@
 			"integrity": "sha1-JOQGhdwFtxSZlSRQmeBZAmO+ja0=",
 			"dev": true,
 			"requires": {
-				"event-stream": "3.3.4",
-				"queue": "4.4.2",
-				"through2": "2.0.3",
-				"vinyl": "2.1.0",
-				"vinyl-fs": "2.4.4",
-				"yauzl": "2.9.1",
-				"yazl": "2.4.3"
+				"event-stream": "^3.3.1",
+				"queue": "^4.2.1",
+				"through2": "^2.0.3",
+				"vinyl": "^2.0.2",
+				"vinyl-fs": "^2.0.0",
+				"yauzl": "^2.2.1",
+				"yazl": "^2.2.1"
 			},
 			"dependencies": {
 				"clone": {
@@ -968,7 +968,7 @@
 					"integrity": "sha512-fSMRXbwhMwipcDZ08enW2vl+YDmAmhcNcr43sCJL8DIg+CFOsoRLG23ctxA+fwNk1w55SePSiS7oqQQSgQoVJQ==",
 					"dev": true,
 					"requires": {
-						"inherits": "2.0.3"
+						"inherits": "~2.0.0"
 					}
 				},
 				"replace-ext": {
@@ -983,12 +983,12 @@
 					"integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
 					"dev": true,
 					"requires": {
-						"clone": "2.1.1",
-						"clone-buffer": "1.0.0",
-						"clone-stats": "1.0.0",
-						"cloneable-readable": "1.0.0",
-						"remove-trailing-separator": "1.1.0",
-						"replace-ext": "1.0.0"
+						"clone": "^2.1.1",
+						"clone-buffer": "^1.0.0",
+						"clone-stats": "^1.0.0",
+						"cloneable-readable": "^1.0.0",
+						"remove-trailing-separator": "^1.0.1",
+						"replace-ext": "^1.0.0"
 					}
 				}
 			}
@@ -999,7 +999,7 @@
 			"integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
 			"dev": true,
 			"requires": {
-				"glogg": "1.0.0"
+				"glogg": "^1.0.0"
 			}
 		},
 		"har-schema": {
@@ -1014,7 +1014,7 @@
 			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
 			"dev": true,
 			"requires": {
-				"ansi-regex": "2.1.1"
+				"ansi-regex": "^2.0.0"
 			}
 		},
 		"has-flag": {
@@ -1029,7 +1029,7 @@
 			"integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
 			"dev": true,
 			"requires": {
-				"sparkles": "1.0.0"
+				"sparkles": "^1.0.0"
 			}
 		},
 		"he": {
@@ -1044,8 +1044,8 @@
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 			"dev": true,
 			"requires": {
-				"once": "1.4.0",
-				"wrappy": "1.0.2"
+				"once": "^1.3.0",
+				"wrappy": "1"
 			}
 		},
 		"inherits": {
@@ -1084,7 +1084,7 @@
 			"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
 			"dev": true,
 			"requires": {
-				"is-primitive": "2.0.0"
+				"is-primitive": "^2.0.0"
 			}
 		},
 		"is-extendable": {
@@ -1105,7 +1105,7 @@
 			"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
 			"dev": true,
 			"requires": {
-				"is-extglob": "2.1.1"
+				"is-extglob": "^2.1.0"
 			}
 		},
 		"is-number": {
@@ -1114,7 +1114,7 @@
 			"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
 			"dev": true,
 			"requires": {
-				"kind-of": "3.2.2"
+				"kind-of": "^3.0.2"
 			}
 		},
 		"is-obj": {
@@ -1205,7 +1205,7 @@
 			"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
 			"dev": true,
 			"requires": {
-				"jsonify": "0.0.0"
+				"jsonify": "~0.0.0"
 			}
 		},
 		"json-stringify-safe": {
@@ -1246,7 +1246,7 @@
 			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 			"dev": true,
 			"requires": {
-				"is-buffer": "1.1.6"
+				"is-buffer": "^1.1.5"
 			}
 		},
 		"lazystream": {
@@ -1255,7 +1255,7 @@
 			"integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
 			"dev": true,
 			"requires": {
-				"readable-stream": "2.3.3"
+				"readable-stream": "^2.0.5"
 			}
 		},
 		"lodash._basecopy": {
@@ -1318,7 +1318,7 @@
 			"integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
 			"dev": true,
 			"requires": {
-				"lodash._root": "3.0.1"
+				"lodash._root": "^3.0.0"
 			}
 		},
 		"lodash.isarguments": {
@@ -1345,9 +1345,9 @@
 			"integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
 			"dev": true,
 			"requires": {
-				"lodash._getnative": "3.9.1",
-				"lodash.isarguments": "3.1.0",
-				"lodash.isarray": "3.0.4"
+				"lodash._getnative": "^3.0.0",
+				"lodash.isarguments": "^3.0.0",
+				"lodash.isarray": "^3.0.0"
 			}
 		},
 		"lodash.restparam": {
@@ -1362,15 +1362,15 @@
 			"integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
 			"dev": true,
 			"requires": {
-				"lodash._basecopy": "3.0.1",
-				"lodash._basetostring": "3.0.1",
-				"lodash._basevalues": "3.0.0",
-				"lodash._isiterateecall": "3.0.9",
-				"lodash._reinterpolate": "3.0.0",
-				"lodash.escape": "3.2.0",
-				"lodash.keys": "3.1.2",
-				"lodash.restparam": "3.6.1",
-				"lodash.templatesettings": "3.1.1"
+				"lodash._basecopy": "^3.0.0",
+				"lodash._basetostring": "^3.0.0",
+				"lodash._basevalues": "^3.0.0",
+				"lodash._isiterateecall": "^3.0.0",
+				"lodash._reinterpolate": "^3.0.0",
+				"lodash.escape": "^3.0.0",
+				"lodash.keys": "^3.0.0",
+				"lodash.restparam": "^3.0.0",
+				"lodash.templatesettings": "^3.0.0"
 			}
 		},
 		"lodash.templatesettings": {
@@ -1379,8 +1379,8 @@
 			"integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
 			"dev": true,
 			"requires": {
-				"lodash._reinterpolate": "3.0.0",
-				"lodash.escape": "3.2.0"
+				"lodash._reinterpolate": "^3.0.0",
+				"lodash.escape": "^3.0.0"
 			}
 		},
 		"map-stream": {
@@ -1395,7 +1395,7 @@
 			"integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
 			"dev": true,
 			"requires": {
-				"readable-stream": "2.3.3"
+				"readable-stream": "^2.0.1"
 			}
 		},
 		"micromatch": {
@@ -1404,19 +1404,19 @@
 			"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
 			"dev": true,
 			"requires": {
-				"arr-diff": "2.0.0",
-				"array-unique": "0.2.1",
-				"braces": "1.8.5",
-				"expand-brackets": "0.1.5",
-				"extglob": "0.3.2",
-				"filename-regex": "2.0.1",
-				"is-extglob": "1.0.0",
-				"is-glob": "2.0.1",
-				"kind-of": "3.2.2",
-				"normalize-path": "2.1.1",
-				"object.omit": "2.0.1",
-				"parse-glob": "3.0.4",
-				"regex-cache": "0.4.4"
+				"arr-diff": "^2.0.0",
+				"array-unique": "^0.2.1",
+				"braces": "^1.8.2",
+				"expand-brackets": "^0.1.4",
+				"extglob": "^0.3.1",
+				"filename-regex": "^2.0.0",
+				"is-extglob": "^1.0.0",
+				"is-glob": "^2.0.1",
+				"kind-of": "^3.0.2",
+				"normalize-path": "^2.0.1",
+				"object.omit": "^2.0.0",
+				"parse-glob": "^3.0.4",
+				"regex-cache": "^0.4.2"
 			},
 			"dependencies": {
 				"is-extglob": {
@@ -1431,7 +1431,7 @@
 					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
 					"dev": true,
 					"requires": {
-						"is-extglob": "1.0.0"
+						"is-extglob": "^1.0.0"
 					}
 				}
 			}
@@ -1448,7 +1448,7 @@
 			"integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
 			"dev": true,
 			"requires": {
-				"mime-db": "1.30.0"
+				"mime-db": "~1.30.0"
 			}
 		},
 		"minimatch": {
@@ -1457,7 +1457,7 @@
 			"integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
 			"dev": true,
 			"requires": {
-				"brace-expansion": "1.1.8"
+				"brace-expansion": "^1.1.7"
 			}
 		},
 		"minimist": {
@@ -1513,7 +1513,7 @@
 					"integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
 					"dev": true,
 					"requires": {
-						"has-flag": "2.0.0"
+						"has-flag": "^2.0.0"
 					}
 				}
 			}
@@ -1530,10 +1530,10 @@
 			"integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
 			"dev": true,
 			"requires": {
-				"array-differ": "1.0.0",
-				"array-union": "1.0.2",
-				"arrify": "1.0.1",
-				"minimatch": "3.0.4"
+				"array-differ": "^1.0.0",
+				"array-union": "^1.0.1",
+				"arrify": "^1.0.0",
+				"minimatch": "^3.0.0"
 			}
 		},
 		"multipipe": {
@@ -1551,7 +1551,7 @@
 			"integrity": "sha1-p7iCyC1sk6SGOlUEvV3o7IYli5Y=",
 			"dev": true,
 			"requires": {
-				"is": "3.2.1"
+				"is": "^3.1.0"
 			}
 		},
 		"normalize-path": {
@@ -1560,7 +1560,7 @@
 			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
 			"dev": true,
 			"requires": {
-				"remove-trailing-separator": "1.1.0"
+				"remove-trailing-separator": "^1.0.1"
 			}
 		},
 		"oauth-sign": {
@@ -1581,8 +1581,8 @@
 			"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
 			"dev": true,
 			"requires": {
-				"for-own": "0.1.5",
-				"is-extendable": "0.1.1"
+				"for-own": "^0.1.4",
+				"is-extendable": "^0.1.1"
 			}
 		},
 		"once": {
@@ -1591,7 +1591,7 @@
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 			"dev": true,
 			"requires": {
-				"wrappy": "1.0.2"
+				"wrappy": "1"
 			}
 		},
 		"ordered-read-streams": {
@@ -1600,8 +1600,8 @@
 			"integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
 			"dev": true,
 			"requires": {
-				"is-stream": "1.1.0",
-				"readable-stream": "2.3.3"
+				"is-stream": "^1.0.1",
+				"readable-stream": "^2.0.1"
 			}
 		},
 		"parse-glob": {
@@ -1610,10 +1610,10 @@
 			"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
 			"dev": true,
 			"requires": {
-				"glob-base": "0.3.0",
-				"is-dotfile": "1.0.3",
-				"is-extglob": "1.0.0",
-				"is-glob": "2.0.1"
+				"glob-base": "^0.3.0",
+				"is-dotfile": "^1.0.0",
+				"is-extglob": "^1.0.0",
+				"is-glob": "^2.0.0"
 			},
 			"dependencies": {
 				"is-extglob": {
@@ -1628,7 +1628,7 @@
 					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
 					"dev": true,
 					"requires": {
-						"is-extglob": "1.0.0"
+						"is-extglob": "^1.0.0"
 					}
 				}
 			}
@@ -1657,7 +1657,7 @@
 			"integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
 			"dev": true,
 			"requires": {
-				"through": "2.3.8"
+				"through": "~2.3"
 			}
 		},
 		"pend": {
@@ -1702,7 +1702,7 @@
 			"integrity": "sha1-bEnQHwCeIlZ4h4nyv/rGuLmZBYU=",
 			"dev": true,
 			"requires": {
-				"inherits": "2.0.3"
+				"inherits": "~2.0.0"
 			}
 		},
 		"randomatic": {
@@ -1711,8 +1711,8 @@
 			"integrity": "sha1-x6vpzIuHwLqodrGf3oP9RkeX44w=",
 			"dev": true,
 			"requires": {
-				"is-number": "3.0.0",
-				"kind-of": "4.0.0"
+				"is-number": "^3.0.0",
+				"kind-of": "^4.0.0"
 			},
 			"dependencies": {
 				"is-number": {
@@ -1721,7 +1721,7 @@
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 					"dev": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -1730,7 +1730,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "1.1.6"
+								"is-buffer": "^1.1.5"
 							}
 						}
 					}
@@ -1741,7 +1741,7 @@
 					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
 					"dev": true,
 					"requires": {
-						"is-buffer": "1.1.6"
+						"is-buffer": "^1.1.5"
 					}
 				}
 			}
@@ -1752,13 +1752,13 @@
 			"integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
 			"dev": true,
 			"requires": {
-				"core-util-is": "1.0.2",
-				"inherits": "2.0.3",
-				"isarray": "1.0.0",
-				"process-nextick-args": "1.0.7",
-				"safe-buffer": "5.1.1",
-				"string_decoder": "1.0.3",
-				"util-deprecate": "1.0.2"
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.3",
+				"isarray": "~1.0.0",
+				"process-nextick-args": "~1.0.6",
+				"safe-buffer": "~5.1.1",
+				"string_decoder": "~1.0.3",
+				"util-deprecate": "~1.0.1"
 			}
 		},
 		"rechoir": {
@@ -1767,7 +1767,7 @@
 			"integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
 			"dev": true,
 			"requires": {
-				"resolve": "1.6.0"
+				"resolve": "^1.1.6"
 			}
 		},
 		"regex-cache": {
@@ -1776,7 +1776,7 @@
 			"integrity": "sha1-db3FiioUls7EihKDW8VMjVYjNt0=",
 			"dev": true,
 			"requires": {
-				"is-equal-shallow": "0.1.3"
+				"is-equal-shallow": "^0.1.3"
 			}
 		},
 		"remove-trailing-separator": {
@@ -1809,28 +1809,28 @@
 			"integrity": "sha1-ygtl2gLtYpNYh4COb1EDgQNOM1Y=",
 			"dev": true,
 			"requires": {
-				"aws-sign2": "0.7.0",
-				"aws4": "1.6.0",
-				"caseless": "0.12.0",
-				"combined-stream": "1.0.5",
-				"extend": "3.0.1",
-				"forever-agent": "0.6.1",
-				"form-data": "2.3.1",
-				"har-validator": "5.0.3",
-				"hawk": "6.0.2",
-				"http-signature": "1.2.0",
-				"is-typedarray": "1.0.0",
-				"isstream": "0.1.2",
-				"json-stringify-safe": "5.0.1",
-				"mime-types": "2.1.17",
-				"oauth-sign": "0.8.2",
-				"performance-now": "2.1.0",
-				"qs": "6.5.1",
-				"safe-buffer": "5.1.1",
-				"stringstream": "0.0.5",
-				"tough-cookie": "2.3.3",
-				"tunnel-agent": "0.6.0",
-				"uuid": "3.1.0"
+				"aws-sign2": "~0.7.0",
+				"aws4": "^1.6.0",
+				"caseless": "~0.12.0",
+				"combined-stream": "~1.0.5",
+				"extend": "~3.0.1",
+				"forever-agent": "~0.6.1",
+				"form-data": "~2.3.1",
+				"har-validator": "~5.0.3",
+				"hawk": "~6.0.2",
+				"http-signature": "~1.2.0",
+				"is-typedarray": "~1.0.0",
+				"isstream": "~0.1.2",
+				"json-stringify-safe": "~5.0.1",
+				"mime-types": "~2.1.17",
+				"oauth-sign": "~0.8.2",
+				"performance-now": "^2.1.0",
+				"qs": "~6.5.1",
+				"safe-buffer": "^5.1.1",
+				"stringstream": "~0.0.5",
+				"tough-cookie": "~2.3.3",
+				"tunnel-agent": "^0.6.0",
+				"uuid": "^3.1.0"
 			},
 			"dependencies": {
 				"assert-plus": {
@@ -1851,7 +1851,7 @@
 					"integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
 					"dev": true,
 					"requires": {
-						"hoek": "4.2.0"
+						"hoek": "4.x.x"
 					}
 				},
 				"caseless": {
@@ -1866,7 +1866,7 @@
 					"integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
 					"dev": true,
 					"requires": {
-						"boom": "5.2.0"
+						"boom": "5.x.x"
 					},
 					"dependencies": {
 						"boom": {
@@ -1875,7 +1875,7 @@
 							"integrity": "sha1-XdnabuOl8wIHdDYpDLcX0/SlTgI=",
 							"dev": true,
 							"requires": {
-								"hoek": "4.2.0"
+								"hoek": "4.x.x"
 							}
 						}
 					}
@@ -1886,9 +1886,9 @@
 					"integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
 					"dev": true,
 					"requires": {
-						"asynckit": "0.4.0",
-						"combined-stream": "1.0.5",
-						"mime-types": "2.1.17"
+						"asynckit": "^0.4.0",
+						"combined-stream": "^1.0.5",
+						"mime-types": "^2.1.12"
 					}
 				},
 				"har-validator": {
@@ -1897,8 +1897,8 @@
 					"integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
 					"dev": true,
 					"requires": {
-						"ajv": "5.5.2",
-						"har-schema": "2.0.0"
+						"ajv": "^5.1.0",
+						"har-schema": "^2.0.0"
 					}
 				},
 				"hawk": {
@@ -1907,10 +1907,10 @@
 					"integrity": "sha1-r02RTrBl+bXOTZ0RwcshJu7MMDg=",
 					"dev": true,
 					"requires": {
-						"boom": "4.3.1",
-						"cryptiles": "3.1.2",
-						"hoek": "4.2.0",
-						"sntp": "2.1.0"
+						"boom": "4.x.x",
+						"cryptiles": "3.x.x",
+						"hoek": "4.x.x",
+						"sntp": "2.x.x"
 					}
 				},
 				"hoek": {
@@ -1925,9 +1925,9 @@
 					"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
 					"dev": true,
 					"requires": {
-						"assert-plus": "1.0.0",
-						"jsprim": "1.4.1",
-						"sshpk": "1.13.1"
+						"assert-plus": "^1.0.0",
+						"jsprim": "^1.2.2",
+						"sshpk": "^1.7.0"
 					}
 				},
 				"qs": {
@@ -1942,7 +1942,7 @@
 					"integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
 					"dev": true,
 					"requires": {
-						"hoek": "4.2.0"
+						"hoek": "4.x.x"
 					}
 				},
 				"tunnel-agent": {
@@ -1951,7 +1951,7 @@
 					"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
 					"dev": true,
 					"requires": {
-						"safe-buffer": "5.1.1"
+						"safe-buffer": "^5.0.1"
 					}
 				}
 			}
@@ -1968,7 +1968,7 @@
 			"integrity": "sha512-mw7JQNu5ExIkcw4LPih0owX/TZXjD/ZUF/ZQ/pDnkw3ZKhDcZZw5klmBlj6gVMwjQ3Pz5Jgu7F3d0jcDVuEWdw==",
 			"dev": true,
 			"requires": {
-				"path-parse": "1.0.5"
+				"path-parse": "^1.0.5"
 			}
 		},
 		"rimraf": {
@@ -1977,7 +1977,7 @@
 			"integrity": "sha1-LtgVDSShbqhlHm1u8PR8QVjOejY=",
 			"dev": true,
 			"requires": {
-				"glob": "7.1.2"
+				"glob": "^7.0.5"
 			}
 		},
 		"safe-buffer": {
@@ -1998,9 +1998,9 @@
 			"integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
 			"dev": true,
 			"requires": {
-				"glob": "7.1.2",
-				"interpret": "1.1.0",
-				"rechoir": "0.6.2"
+				"glob": "^7.0.0",
+				"interpret": "^1.0.0",
+				"rechoir": "^0.6.2"
 			}
 		},
 		"shx": {
@@ -2009,9 +2009,9 @@
 			"integrity": "sha1-CjBNAgsO3xMGrYFXDoDwNG31ijk=",
 			"dev": true,
 			"requires": {
-				"es6-object-assign": "1.1.0",
-				"minimist": "1.2.0",
-				"shelljs": "0.7.8"
+				"es6-object-assign": "^1.0.3",
+				"minimist": "^1.2.0",
+				"shelljs": "^0.7.3"
 			}
 		},
 		"source-map": {
@@ -2026,7 +2026,7 @@
 			"integrity": "sha512-vUoN3I7fHQe0R/SJLKRdKYuEdRGogsviXFkHHo17AWaTGv17VLnxw+CFXvqy+y4ORZ3doWLQcxRYfwKrsd/H7Q==",
 			"dev": true,
 			"requires": {
-				"source-map": "0.6.1"
+				"source-map": "^0.6.0"
 			}
 		},
 		"sparkles": {
@@ -2041,7 +2041,7 @@
 			"integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
 			"dev": true,
 			"requires": {
-				"through": "2.3.8"
+				"through": "2"
 			}
 		},
 		"sshpk": {
@@ -2050,14 +2050,14 @@
 			"integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
 			"dev": true,
 			"requires": {
-				"asn1": "0.2.3",
-				"assert-plus": "1.0.0",
-				"bcrypt-pbkdf": "1.0.1",
-				"dashdash": "1.14.1",
-				"ecc-jsbn": "0.1.1",
-				"getpass": "0.1.7",
-				"jsbn": "0.1.1",
-				"tweetnacl": "0.14.5"
+				"asn1": "~0.2.3",
+				"assert-plus": "^1.0.0",
+				"bcrypt-pbkdf": "^1.0.0",
+				"dashdash": "^1.12.0",
+				"ecc-jsbn": "~0.1.1",
+				"getpass": "^0.1.1",
+				"jsbn": "~0.1.0",
+				"tweetnacl": "~0.14.0"
 			},
 			"dependencies": {
 				"assert-plus": {
@@ -2080,7 +2080,7 @@
 			"integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
 			"dev": true,
 			"requires": {
-				"duplexer": "0.1.1"
+				"duplexer": "~0.1.1"
 			}
 		},
 		"stream-shift": {
@@ -2095,7 +2095,7 @@
 			"integrity": "sha512-Gk6KZM+yNA1JpW0KzlZIhjo3EaBJDkYfXtYSbOwNIQ7Zd6006E6+sCFlW1NDvFG/vnXhKmw6TJJgiEQg/8lXfQ==",
 			"dev": true,
 			"requires": {
-				"readable-stream": "2.3.3"
+				"readable-stream": "^2.0.2"
 			}
 		},
 		"streamifier": {
@@ -2110,7 +2110,7 @@
 			"integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
 			"dev": true,
 			"requires": {
-				"safe-buffer": "5.1.1"
+				"safe-buffer": "~5.1.0"
 			}
 		},
 		"stringstream": {
@@ -2125,7 +2125,7 @@
 			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 			"dev": true,
 			"requires": {
-				"ansi-regex": "2.1.1"
+				"ansi-regex": "^2.0.0"
 			}
 		},
 		"strip-bom": {
@@ -2134,7 +2134,7 @@
 			"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
 			"dev": true,
 			"requires": {
-				"is-utf8": "0.2.1"
+				"is-utf8": "^0.2.0"
 			}
 		},
 		"strip-bom-stream": {
@@ -2143,8 +2143,8 @@
 			"integrity": "sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4=",
 			"dev": true,
 			"requires": {
-				"first-chunk-stream": "1.0.0",
-				"strip-bom": "2.0.0"
+				"first-chunk-stream": "^1.0.0",
+				"strip-bom": "^2.0.0"
 			}
 		},
 		"supports-color": {
@@ -2159,9 +2159,9 @@
 			"integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
 			"dev": true,
 			"requires": {
-				"block-stream": "0.0.9",
-				"fstream": "1.0.11",
-				"inherits": "2.0.3"
+				"block-stream": "*",
+				"fstream": "^1.0.2",
+				"inherits": "2"
 			}
 		},
 		"through": {
@@ -2176,8 +2176,8 @@
 			"integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
 			"dev": true,
 			"requires": {
-				"readable-stream": "2.3.3",
-				"xtend": "4.0.1"
+				"readable-stream": "^2.1.5",
+				"xtend": "~4.0.1"
 			}
 		},
 		"through2-filter": {
@@ -2186,8 +2186,8 @@
 			"integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
 			"dev": true,
 			"requires": {
-				"through2": "2.0.3",
-				"xtend": "4.0.1"
+				"through2": "~2.0.0",
+				"xtend": "~4.0.0"
 			}
 		},
 		"time-stamp": {
@@ -2202,7 +2202,7 @@
 			"integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
 			"dev": true,
 			"requires": {
-				"extend-shallow": "2.0.1"
+				"extend-shallow": "^2.0.1"
 			}
 		},
 		"tough-cookie": {
@@ -2211,7 +2211,7 @@
 			"integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
 			"dev": true,
 			"requires": {
-				"punycode": "1.4.1"
+				"punycode": "^1.4.1"
 			}
 		},
 		"tweetnacl": {
@@ -2227,8 +2227,8 @@
 			"integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
 			"dev": true,
 			"requires": {
-				"json-stable-stringify": "1.0.1",
-				"through2-filter": "2.0.0"
+				"json-stable-stringify": "^1.0.0",
+				"through2-filter": "^2.0.0"
 			}
 		},
 		"url-parse": {
@@ -2237,8 +2237,8 @@
 			"integrity": "sha512-DT1XbYAfmQP65M/mE6OALxmXzZ/z1+e5zk2TcSKe/KiYbNGZxgtttzC0mR/sjopbpOXcbniq7eIKmocJnUWlEw==",
 			"dev": true,
 			"requires": {
-				"querystringify": "1.0.0",
-				"requires-port": "1.0.0"
+				"querystringify": "~1.0.0",
+				"requires-port": "~1.0.0"
 			}
 		},
 		"util-deprecate": {
@@ -2265,9 +2265,9 @@
 			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
 			"dev": true,
 			"requires": {
-				"assert-plus": "1.0.0",
+				"assert-plus": "^1.0.0",
 				"core-util-is": "1.0.2",
-				"extsprintf": "1.3.0"
+				"extsprintf": "^1.2.0"
 			},
 			"dependencies": {
 				"assert-plus": {
@@ -2284,8 +2284,8 @@
 			"integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
 			"dev": true,
 			"requires": {
-				"clone": "1.0.3",
-				"clone-stats": "0.0.1",
+				"clone": "^1.0.0",
+				"clone-stats": "^0.0.1",
 				"replace-ext": "0.0.1"
 			}
 		},
@@ -2295,23 +2295,23 @@
 			"integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
 			"dev": true,
 			"requires": {
-				"duplexify": "3.5.1",
-				"glob-stream": "5.3.5",
-				"graceful-fs": "4.1.11",
+				"duplexify": "^3.2.0",
+				"glob-stream": "^5.3.2",
+				"graceful-fs": "^4.0.0",
 				"gulp-sourcemaps": "1.6.0",
-				"is-valid-glob": "0.3.0",
-				"lazystream": "1.0.0",
-				"lodash.isequal": "4.5.0",
-				"merge-stream": "1.0.1",
-				"mkdirp": "0.5.1",
-				"object-assign": "4.1.1",
-				"readable-stream": "2.3.3",
-				"strip-bom": "2.0.0",
-				"strip-bom-stream": "1.0.0",
-				"through2": "2.0.3",
-				"through2-filter": "2.0.0",
-				"vali-date": "1.0.0",
-				"vinyl": "1.2.0"
+				"is-valid-glob": "^0.3.0",
+				"lazystream": "^1.0.0",
+				"lodash.isequal": "^4.0.0",
+				"merge-stream": "^1.0.0",
+				"mkdirp": "^0.5.0",
+				"object-assign": "^4.0.0",
+				"readable-stream": "^2.0.4",
+				"strip-bom": "^2.0.0",
+				"strip-bom-stream": "^1.0.0",
+				"through2": "^2.0.0",
+				"through2-filter": "^2.0.0",
+				"vali-date": "^1.0.0",
+				"vinyl": "^1.0.0"
 			},
 			"dependencies": {
 				"object-assign": {
@@ -2326,8 +2326,8 @@
 					"integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
 					"dev": true,
 					"requires": {
-						"clone": "1.0.3",
-						"clone-stats": "0.0.1",
+						"clone": "^1.0.0",
+						"clone-stats": "^0.0.1",
 						"replace-ext": "0.0.1"
 					}
 				}
@@ -2339,8 +2339,8 @@
 			"integrity": "sha1-RMvlEIIFJ53rDFZTwJSiiHk4sas=",
 			"dev": true,
 			"requires": {
-				"through2": "0.6.5",
-				"vinyl": "0.4.6"
+				"through2": "^0.6.1",
+				"vinyl": "^0.4.3"
 			},
 			"dependencies": {
 				"clone": {
@@ -2361,10 +2361,10 @@
 					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
 					"dev": true,
 					"requires": {
-						"core-util-is": "1.0.2",
-						"inherits": "2.0.3",
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.1",
 						"isarray": "0.0.1",
-						"string_decoder": "0.10.31"
+						"string_decoder": "~0.10.x"
 					}
 				},
 				"string_decoder": {
@@ -2379,8 +2379,8 @@
 					"integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
 					"dev": true,
 					"requires": {
-						"readable-stream": "1.0.34",
-						"xtend": "4.0.1"
+						"readable-stream": ">=1.0.33-1 <1.1.0-0",
+						"xtend": ">=4.0.0 <4.1.0-0"
 					}
 				},
 				"vinyl": {
@@ -2389,8 +2389,8 @@
 					"integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
 					"dev": true,
 					"requires": {
-						"clone": "0.2.0",
-						"clone-stats": "0.0.1"
+						"clone": "^0.2.0",
+						"clone-stats": "^0.0.1"
 					}
 				}
 			}
@@ -2401,42 +2401,40 @@
 			"integrity": "sha512-yNMyrgEua2qyW7+trNNYhA6PeldRrBcwtLtlazkdtzcmkHMKECM/08bPF8HF2ZFuwHgD+8FQsdqd/DvJYQYjJg==",
 			"dev": true,
 			"requires": {
-				"glob": "7.1.2",
-				"gulp-chmod": "2.0.0",
-				"gulp-filter": "5.0.1",
+				"glob": "^7.1.2",
+				"gulp-chmod": "^2.0.0",
+				"gulp-filter": "^5.0.1",
 				"gulp-gunzip": "1.0.0",
-				"gulp-remote-src-vscode": "0.5.0",
-				"gulp-symdest": "1.1.0",
-				"gulp-untar": "0.0.6",
-				"gulp-vinyl-zip": "2.1.0",
-				"mocha": "4.0.1",
-				"request": "2.83.0",
-				"semver": "5.4.1",
-				"source-map-support": "0.5.0",
-				"url-parse": "1.2.0",
-				"vinyl-source-stream": "1.1.0"
+				"gulp-remote-src-vscode": "^0.5.0",
+				"gulp-symdest": "^1.1.0",
+				"gulp-untar": "^0.0.6",
+				"gulp-vinyl-zip": "^2.1.0",
+				"mocha": "^4.0.1",
+				"request": "^2.83.0",
+				"semver": "^5.4.1",
+				"source-map-support": "^0.5.0",
+				"url-parse": "^1.1.9",
+				"vinyl-source-stream": "^1.1.0"
 			}
 		},
+		"vscode-jsonrpc": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-3.6.2.tgz",
+			"integrity": "sha512-T24Jb5V48e4VgYliUXMnZ379ItbrXgOimweKaJshD84z+8q7ZOZjJan0MeDe+Ugb+uqERDVV8SBmemaGMSMugA=="
+		},
 		"vscode-languageserver-protocol": {
-			"version": "3.8.0",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.8.0.tgz",
-			"integrity": "sha512-gqNrpD27rTZ9b401ppoz9jb6vmZU06v6sHipHjq5PBYitET7XNHpxXlT92+jqE2LRp8ezuwEyhNcVoRb3B6eIA==",
+			"version": "3.8.1",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.8.1.tgz",
+			"integrity": "sha512-KdeetvQ2JavRiuE9afNrV5+xJZocj7NGPQwH4kpSFw5cp+0wijv87qgXfSEvmwPUaknhMBoSuSrSIG/LRrzWJQ==",
 			"requires": {
-				"vscode-jsonrpc": "3.6.2",
-				"vscode-languageserver-types": "3.8.0"
-			},
-			"dependencies": {
-				"vscode-jsonrpc": {
-					"version": "3.6.2",
-					"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-3.6.2.tgz",
-					"integrity": "sha512-T24Jb5V48e4VgYliUXMnZ379ItbrXgOimweKaJshD84z+8q7ZOZjJan0MeDe+Ugb+uqERDVV8SBmemaGMSMugA=="
-				},
-				"vscode-languageserver-types": {
-					"version": "3.8.0",
-					"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.8.0.tgz",
-					"integrity": "sha512-ssiFoZtQqsnmEdvVTdYnSOKbSF8LvlwVzEDUcNL0py2SLiOdcIarLbet5EIwDgXu4WrpOqjHW1O3leiYFcgWLA=="
-				}
+				"vscode-jsonrpc": "^3.6.2",
+				"vscode-languageserver-types": "^3.8.1"
 			}
+		},
+		"vscode-languageserver-types": {
+			"version": "3.8.1",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.8.1.tgz",
+			"integrity": "sha512-O8IBrxSBp2AJALIZBwT2Gd6gX67MMtwCwnfzT9T3QynE+dqikoj7x3kOb3fdIjd9hIoAB2yc38XcJJDw8H1cpw=="
 		},
 		"wrappy": {
 			"version": "1.0.2",
@@ -2456,8 +2454,8 @@
 			"integrity": "sha1-qBmB6nCleUYTOIPwKcWCGok1mn8=",
 			"dev": true,
 			"requires": {
-				"buffer-crc32": "0.2.13",
-				"fd-slicer": "1.0.1"
+				"buffer-crc32": "~0.2.3",
+				"fd-slicer": "~1.0.1"
 			}
 		},
 		"yazl": {
@@ -2466,7 +2464,7 @@
 			"integrity": "sha1-7CblzIfVYBud+EMtvdPNLlFzoHE=",
 			"dev": true,
 			"requires": {
-				"buffer-crc32": "0.2.13"
+				"buffer-crc32": "~0.2.3"
 			}
 		}
 	}

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
 			"integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
 			"dev": true,
 			"requires": {
-				"balanced-match": "1.0.0",
+				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
 			}
 		},
@@ -44,7 +44,7 @@
 			"integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
 			"dev": true,
 			"requires": {
-				"graceful-readlink": "1.0.1"
+				"graceful-readlink": ">= 1.0.0"
 			}
 		},
 		"concat-map": {
@@ -92,12 +92,12 @@
 			"integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
 			"dev": true,
 			"requires": {
-				"fs.realpath": "1.0.0",
-				"inflight": "1.0.6",
-				"inherits": "2.0.3",
-				"minimatch": "3.0.4",
-				"once": "1.4.0",
-				"path-is-absolute": "1.0.1"
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.0.2",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
 			}
 		},
 		"graceful-readlink": {
@@ -130,8 +130,8 @@
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 			"dev": true,
 			"requires": {
-				"once": "1.4.0",
-				"wrappy": "1.0.2"
+				"once": "^1.3.0",
+				"wrappy": "1"
 			}
 		},
 		"inherits": {
@@ -158,8 +158,8 @@
 			"integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
 			"dev": true,
 			"requires": {
-				"lodash._basecopy": "3.0.1",
-				"lodash.keys": "3.1.2"
+				"lodash._basecopy": "^3.0.0",
+				"lodash.keys": "^3.0.0"
 			}
 		},
 		"lodash._basecopy": {
@@ -192,9 +192,9 @@
 			"integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
 			"dev": true,
 			"requires": {
-				"lodash._baseassign": "3.2.0",
-				"lodash._basecreate": "3.0.3",
-				"lodash._isiterateecall": "3.0.9"
+				"lodash._baseassign": "^3.0.0",
+				"lodash._basecreate": "^3.0.0",
+				"lodash._isiterateecall": "^3.0.0"
 			}
 		},
 		"lodash.isarguments": {
@@ -215,9 +215,9 @@
 			"integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
 			"dev": true,
 			"requires": {
-				"lodash._getnative": "3.9.1",
-				"lodash.isarguments": "3.1.0",
-				"lodash.isarray": "3.0.4"
+				"lodash._getnative": "^3.0.0",
+				"lodash.isarguments": "^3.0.0",
+				"lodash.isarray": "^3.0.0"
 			}
 		},
 		"minimatch": {
@@ -226,7 +226,7 @@
 			"integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
 			"dev": true,
 			"requires": {
-				"brace-expansion": "1.1.8"
+				"brace-expansion": "^1.1.7"
 			}
 		},
 		"minimist": {
@@ -276,7 +276,7 @@
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 			"dev": true,
 			"requires": {
-				"wrappy": "1.0.2"
+				"wrappy": "1"
 			}
 		},
 		"path-is-absolute": {
@@ -297,7 +297,7 @@
 			"integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
 			"dev": true,
 			"requires": {
-				"resolve": "1.7.1"
+				"resolve": "^1.1.6"
 			}
 		},
 		"resolve": {
@@ -306,7 +306,7 @@
 			"integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
 			"dev": true,
 			"requires": {
-				"path-parse": "1.0.5"
+				"path-parse": "^1.0.5"
 			}
 		},
 		"rimraf": {
@@ -315,7 +315,7 @@
 			"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
 			"dev": true,
 			"requires": {
-				"glob": "7.1.1"
+				"glob": "^7.0.5"
 			}
 		},
 		"shelljs": {
@@ -324,9 +324,9 @@
 			"integrity": "sha512-YA/iYtZpzFe5HyWVGrb02FjPxc4EMCfpoU/Phg9fQoyMC72u9598OUBrsU8IrtwAKG0tO8IYaqbaLIw+k3IRGA==",
 			"dev": true,
 			"requires": {
-				"glob": "7.1.1",
-				"interpret": "1.1.0",
-				"rechoir": "0.6.2"
+				"glob": "^7.0.0",
+				"interpret": "^1.0.0",
+				"rechoir": "^0.6.2"
 			}
 		},
 		"shx": {
@@ -335,9 +335,9 @@
 			"integrity": "sha1-CjBNAgsO3xMGrYFXDoDwNG31ijk=",
 			"dev": true,
 			"requires": {
-				"es6-object-assign": "1.1.0",
-				"minimist": "1.2.0",
-				"shelljs": "0.7.8"
+				"es6-object-assign": "^1.0.3",
+				"minimist": "^1.2.0",
+				"shelljs": "^0.7.3"
 			},
 			"dependencies": {
 				"minimist": {
@@ -352,9 +352,9 @@
 					"integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
 					"dev": true,
 					"requires": {
-						"glob": "7.1.1",
-						"interpret": "1.1.0",
-						"rechoir": "0.6.2"
+						"glob": "^7.0.0",
+						"interpret": "^1.0.0",
+						"rechoir": "^0.6.2"
 					}
 				}
 			}
@@ -365,7 +365,7 @@
 			"integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
 			"dev": true,
 			"requires": {
-				"has-flag": "1.0.0"
+				"has-flag": "^1.0.0"
 			}
 		},
 		"typescript": {

--- a/protocol/package-lock.json
+++ b/protocol/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "vscode-languageserver-protocol",
-	"version": "3.8.0",
+	"version": "3.8.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -10,9 +10,9 @@
 			"integrity": "sha512-T24Jb5V48e4VgYliUXMnZ379ItbrXgOimweKaJshD84z+8q7ZOZjJan0MeDe+Ugb+uqERDVV8SBmemaGMSMugA=="
 		},
 		"vscode-languageserver-types": {
-			"version": "3.8.0",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.8.0.tgz",
-			"integrity": "sha512-ssiFoZtQqsnmEdvVTdYnSOKbSF8LvlwVzEDUcNL0py2SLiOdcIarLbet5EIwDgXu4WrpOqjHW1O3leiYFcgWLA=="
+			"version": "3.8.1",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.8.1.tgz",
+			"integrity": "sha512-O8IBrxSBp2AJALIZBwT2Gd6gX67MMtwCwnfzT9T3QynE+dqikoj7x3kOb3fdIjd9hIoAB2yc38XcJJDw8H1cpw=="
 		}
 	}
 }

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,29 +1,27 @@
 {
 	"name": "vscode-languageserver",
-	"version": "4.2.0",
+	"version": "4.2.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"vscode-jsonrpc": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-3.6.2.tgz",
+			"integrity": "sha512-T24Jb5V48e4VgYliUXMnZ379ItbrXgOimweKaJshD84z+8q7ZOZjJan0MeDe+Ugb+uqERDVV8SBmemaGMSMugA=="
+		},
 		"vscode-languageserver-protocol": {
-			"version": "3.8.0",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.8.0.tgz",
-			"integrity": "sha512-gqNrpD27rTZ9b401ppoz9jb6vmZU06v6sHipHjq5PBYitET7XNHpxXlT92+jqE2LRp8ezuwEyhNcVoRb3B6eIA==",
+			"version": "3.8.1",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.8.1.tgz",
+			"integrity": "sha512-KdeetvQ2JavRiuE9afNrV5+xJZocj7NGPQwH4kpSFw5cp+0wijv87qgXfSEvmwPUaknhMBoSuSrSIG/LRrzWJQ==",
 			"requires": {
-				"vscode-jsonrpc": "3.6.2",
-				"vscode-languageserver-types": "3.8.0"
-			},
-			"dependencies": {
-				"vscode-jsonrpc": {
-					"version": "3.6.2",
-					"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-3.6.2.tgz",
-					"integrity": "sha512-T24Jb5V48e4VgYliUXMnZ379ItbrXgOimweKaJshD84z+8q7ZOZjJan0MeDe+Ugb+uqERDVV8SBmemaGMSMugA=="
-				},
-				"vscode-languageserver-types": {
-					"version": "3.8.0",
-					"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.8.0.tgz",
-					"integrity": "sha512-ssiFoZtQqsnmEdvVTdYnSOKbSF8LvlwVzEDUcNL0py2SLiOdcIarLbet5EIwDgXu4WrpOqjHW1O3leiYFcgWLA=="
-				}
+				"vscode-jsonrpc": "^3.6.2",
+				"vscode-languageserver-types": "^3.8.1"
 			}
+		},
+		"vscode-languageserver-types": {
+			"version": "3.8.1",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.8.1.tgz",
+			"integrity": "sha512-O8IBrxSBp2AJALIZBwT2Gd6gX67MMtwCwnfzT9T3QynE+dqikoj7x3kOb3fdIjd9hIoAB2yc38XcJJDw8H1cpw=="
 		},
 		"vscode-uri": {
 			"version": "1.0.3",

--- a/types/src/main.ts
+++ b/types/src/main.ts
@@ -53,7 +53,7 @@ export namespace Position {
 	 */
 	export function is(value: any): value is Position {
 		let candidate = value as Position;
-		return Is.defined(candidate) && Is.number(candidate.line) && Is.number(candidate.character);
+		return typeof candidate === 'object' && candidate !== null && Is.number(candidate.line) && Is.number(candidate.character);
 	}
 }
 
@@ -115,7 +115,7 @@ export namespace Range {
 	 */
 	export function is(value: any): value is Range {
 		let candidate = value as Range;
-		return Is.defined(candidate) && Position.is(candidate.start) && Position.is(candidate.end);
+		return typeof candidate === 'object' && candidate !== null && Position.is(candidate.start) && Position.is(candidate.end);
 	}
 }
 

--- a/types/src/main.ts
+++ b/types/src/main.ts
@@ -758,6 +758,16 @@ export namespace MarkupKind {
 }
 export type MarkupKind = 'plaintext' | 'markdown';
 
+export namespace MarkupKind {
+	/**
+	 * Checks whether the given value is a value of the [MarkupKind](#MarkupKind) type.
+	 */
+	export function is(value: any): value is MarkupKind {
+		const candidate = value as MarkupKind
+		return candidate === MarkupKind.PlainText || candidate === MarkupKind.Markdown
+	}
+}
+
 /**
  * A `MarkupContent` literal represents a string value which content is interpreted base on its
  * kind flag. Currently the protocol supports `plaintext` and `markdown` as markup kinds.
@@ -792,6 +802,16 @@ export interface MarkupContent {
 	 * The content itself
 	 */
 	value: string;
+}
+
+export namespace MarkupContent {
+	/**
+	 * Checks whether the given value conforms to the [MarkupContent](#MarkupContent) interface.
+	 */
+	export function is(value: any): value is MarkupContent {
+		const candidate = value as MarkupContent
+		return typeof candidate === 'object' && candidate !== null && MarkupKind.is(candidate.kind) && typeof candidate.value === 'string'
+	}
 }
 
 /**
@@ -1038,6 +1058,17 @@ export namespace MarkedString {
 	export function fromPlainText(plainText: string): string {
 		return plainText.replace(/[\\`*_{}[\]()#+\-.!]/g, "\\$&"); // escape markdown syntax tokens: http://daringfireball.net/projects/markdown/syntax#backslash
 	}
+
+	/**
+	 * Checks whether the given value conforms to the [MarkedString](#MarkedString) type.
+	 */
+	export function is(value: any): value is MarkedString {
+		const candidate = value as MarkedString
+		return (
+			typeof candidate === 'string' ||
+    		(typeof candidate === 'object' && candidate !== null && typeof candidate.language === 'string' && typeof candidate.value === 'string')
+		)
+	}
 }
 
 /**
@@ -1053,6 +1084,23 @@ export interface Hover {
 	 * An optional range
 	 */
 	range?: Range;
+}
+
+export namespace Hover {
+	/**
+	 * Checks whether the given value conforms to the [Hover](#Hover) interface.
+	 */
+	export function is(value: any): value is Hover {
+		let candidate = value as Hover;
+		return (
+			typeof candidate === 'object' &&
+			candidate !== null &&
+			(MarkupContent.is(candidate.contents) ||
+				MarkedString.is(candidate.contents) ||
+				(Array.isArray(candidate.contents) && candidate.contents.every(MarkedString.is))) &&
+			(value.range === undefined || Range.is(value.range))
+		)
+	}
 }
 
 /**

--- a/types/src/test/typeguards.test.ts
+++ b/types/src/test/typeguards.test.ts
@@ -1,5 +1,5 @@
 import * as assert from 'assert'
-import { Range, Position } from '../main';
+import { Range, Position, Hover, MarkedString } from '../main';
 
 suite('Type guards', () => {
 	suite('Position.is', () => {
@@ -54,6 +54,89 @@ suite('Type guards', () => {
 		test('undefined', () => {
 			const range = undefined
 			assert.strictEqual(Range.is(range), false)
+		})
+	})
+	suite('MarkedString.is', () => {
+		test('string', () => {
+			const markedString = 'test'
+			assert.strictEqual(MarkedString.is(markedString), true)
+		})
+		test('language and value', () => {
+			const markedString = { language: 'foo', value: 'test' }
+			assert.strictEqual(MarkedString.is(markedString), true)
+		})
+		test('null', () => {
+			const markedString = null
+			assert.strictEqual(MarkedString.is(markedString), false)
+		})
+		test('undefined', () => {
+			const markedString = undefined
+			assert.strictEqual(MarkedString.is(markedString), false)
+		})
+	})
+	suite('Hover.is', () => {
+		test('string contents', () => {
+			const hover = {
+				contents: 'test'
+			}
+			assert.strictEqual(Hover.is(hover), true)
+		})
+		test('MarkupContent contents', () => {
+			const hover = {
+				contents: {
+					kind: 'plaintext',
+					value: 'test'
+				}
+			}
+			assert.strictEqual(Hover.is(hover), true)
+		})
+		test('MarkupContent contents array', () => {
+			const hover = {
+				contents: [{
+					kind: 'plaintext',
+					value: 'test'
+				}]
+			}
+			assert.strictEqual(Hover.is(hover), false)
+		})
+		test('contents array', () => {
+			const hover = {
+				contents: [
+					'test',
+					{
+						language: 'foo',
+						value: 'test'
+					}
+				]
+			}
+			assert.strictEqual(Hover.is(hover), true)
+		})
+		test('null range', () => {
+			const hover = {
+				contents: 'test',
+				range: null
+			}
+			assert.strictEqual(Hover.is(hover), false)
+		})
+		test('null contents', () => {
+			const hover = {
+				contents: null
+			}
+			assert.strictEqual(Hover.is(hover), false)
+		})
+		test('contents array with null', () => {
+			const hover = {
+				contents: [null]
+			}
+			assert.strictEqual(Hover.is(hover), false)
+		})
+		test('null', () => {
+			const hover = null
+			assert.strictEqual(Hover.is(hover), false)
+		})
+		test('undefined', () => {
+			const hover = undefined
+			assert.strictEqual(Hover.is(hover), false)
 		})
 	})
 })

--- a/types/src/test/typeguards.test.ts
+++ b/types/src/test/typeguards.test.ts
@@ -1,0 +1,59 @@
+import * as assert from 'assert'
+import { Range, Position } from '../main';
+
+suite('Type guards', () => {
+	suite('Position.is', () => {
+		test('Position', () => {
+			const position: Position = {
+				line: 0,
+				character: 0
+			}
+			assert.strictEqual(Position.is(position), true)
+		})
+		test('empty object', () => {
+			const position = {}
+			assert.strictEqual(Position.is(position), false)
+		})
+		test('missing character', () => {
+			const position = {
+				line: 0,
+			}
+			assert.strictEqual(Position.is(position), false)
+		})
+		test('null', () => {
+			const position = null
+			assert.strictEqual(Position.is(position), false)
+		})
+		test('undefined', () => {
+			const position = undefined
+			assert.strictEqual(Position.is(position), false)
+		})
+	})
+	suite('Range.is', () => {
+		test('Range', () => {
+			const range: Range = {
+				start: {
+					line: 0,
+					character: 0
+				},
+				end: {
+					line: 1,
+					character: 1
+				}
+			}
+			assert.strictEqual(Range.is(range), true)
+		})
+		test('empty object', () => {
+			const range = {}
+			assert.strictEqual(Range.is(range), false)
+		})
+		test('null', () => {
+			const range = null
+			assert.strictEqual(Range.is(range), false)
+		})
+		test('undefined', () => {
+			const range = undefined
+			assert.strictEqual(Range.is(range), false)
+		})
+	})
+})


### PR DESCRIPTION
- Adds tests for some typeguards.
- While writing tests, I noticed bugs - `Position.is()` and `Range.is()` would return `true` for `null` (but not for `undefined`). That made `Position.is` and `Range.is` ineffective as validating for a valid Position or Range, as there are no guarantees that the properties of a Position/Range can actually be accessed (and the LSP spec only allows `null` in specific places). As an example of why this is surprising, `Array.isArray()` returns `false` for `null`.
- Add typeguard and tests for `Hover` and contained types. I found myself needing these in multiple projects and given most interfaces have typeguards I thought it would be good to add them to the official package.
- package-lock.json changes came automatically from running `npm install`, seems like they weren't up to date with their package.json.