### PR TITLE
Introduce Traceformat to allow JSON format log

### DIFF
--- a/jsonrpc/src/main.ts
+++ b/jsonrpc/src/main.ts
@@ -239,7 +239,7 @@ export namespace LogTraceNotification {
 }
 
 export interface Tracer {
-	log(data: Object): void;
+	log(data: any): void;
 	log(message: string, data?: string): void;
 }
 
@@ -1051,7 +1051,6 @@ function _createMessageConnection(messageReader: MessageReader, messageWriter: M
 		},
 		trace: (_value: Trace, _tracer: Tracer, _sendNotification: boolean = false, _traceFormat: TraceFormat = TraceFormat.Text) => {
 			trace = _value;
-
 			traceFormat = _traceFormat;
 			if (trace === Trace.Off) {
 				tracer = undefined;

--- a/jsonrpc/src/main.ts
+++ b/jsonrpc/src/main.ts
@@ -15,7 +15,8 @@ import {
 	ResponseMessage, isResponseMessage, ResponseError, ErrorCodes,
 	NotificationMessage, isNotificationMessage,
 	NotificationType, NotificationType0, NotificationType1, NotificationType2, NotificationType3, NotificationType4,
-	NotificationType5, NotificationType6, NotificationType7, NotificationType8, NotificationType9
+	NotificationType5, NotificationType6, NotificationType7, NotificationType8, NotificationType9,
+	LSPMessageType
 } from './messages';
 
 import { MessageReader, DataCallback, StreamMessageReader, IPCMessageReader, SocketMessageReader } from './messageReader';
@@ -205,6 +206,36 @@ export namespace Trace {
 	}
 }
 
+export enum TraceFormat {
+	Text, JSON
+}
+
+export type TraceFormatValues = 'text' | 'json'
+export namespace TraceFormat {
+	export function fromString(value: string): TraceFormat {
+		value = value.toLowerCase();
+		switch (value) {
+			case 'text':
+				return TraceFormat.Text;
+			case 'json':
+				return TraceFormat.JSON;
+			default:
+				return TraceFormat.Text;
+		}
+	}
+
+	export function toString(value: TraceFormat): TraceFormatValues {
+		switch (value) {
+			case TraceFormat.Text:
+				return 'text';
+			case TraceFormat.JSON:
+				return 'json';
+			default:
+				return 'text';
+		}
+	}
+}
+
 export interface SetTraceParams {
 	value: TraceValues;
 }
@@ -224,6 +255,7 @@ export namespace LogTraceNotification {
 
 export interface Tracer {
 	log(message: string, data?: string): void;
+	logLSP(message: string): void;
 }
 
 export enum ConnectionErrors {
@@ -320,7 +352,7 @@ export interface MessageConnection {
 	onNotification(method: string, handler: GenericNotificationHandler): void;
 	onNotification(handler: StarNotificationHandler): void;
 
-	trace(value: Trace, tracer: Tracer, sendNotification?: boolean): void;
+	trace(value: Trace, traceFormat: TraceFormat, tracer: Tracer, sendNotification?: boolean): void;
 
 	onError: Event<[Error, Message | undefined, number | undefined]>;
 	onClose: Event<void>;
@@ -365,12 +397,13 @@ function _createMessageConnection(messageReader: MessageReader, messageWriter: M
 	let starNotificationHandler: StarNotificationHandler | undefined = undefined;
 	let notificationHandlers: { [name: string]: NotificationHandlerElement | undefined } = Object.create(null);
 
-	let  timer:  NodeJS.Timer | undefined;
+	let timer: NodeJS.Timer | undefined;
 	let messageQueue: MessageQueue = new LinkedMap<string, Message>();
 	let responsePromises: { [name: string]: ResponsePromise } = Object.create(null);
 	let requestTokens: { [id: string]: CancellationTokenSource } = Object.create(null);
 
 	let trace: Trace = Trace.Off;
+	let traceFormat: TraceFormat = TraceFormat.Text;
 	let tracer: Tracer | undefined;
 
 	let state: ConnectionState = ConnectionState.New;
@@ -713,95 +746,139 @@ function _createMessageConnection(messageReader: MessageReader, messageWriter: M
 		if (trace === Trace.Off || !tracer) {
 			return;
 		}
-		let data: string | undefined = undefined;
-		if (trace === Trace.Verbose && message.params) {
-			data = `Params: ${JSON.stringify(message.params, null, 4)}\n\n`;
+
+		if (traceFormat === TraceFormat.Text) {
+			let data: string | undefined = undefined;
+			if (trace === Trace.Verbose && message.params) {
+				data = `Params: ${JSON.stringify(message.params, null, 4)}\n\n`;
+			}
+			tracer.log(`Sending request '${message.method} - (${message.id})'.`, data);
+		} else {
+			logLSPMessage('send-request', message);
 		}
-		tracer.log(`Sending request '${message.method} - (${message.id})'.`, data);
 	}
 
-	function traceSendNotification(message: NotificationMessage): void {
+	function traceSendingNotification(message: NotificationMessage): void {
 		if (trace === Trace.Off || !tracer) {
 			return;
 		}
-		let data: string | undefined = undefined;
-		if (trace === Trace.Verbose) {
-			if (message.params) {
-				data = `Params: ${JSON.stringify(message.params, null, 4)}\n\n`;
-			} else {
-				data = 'No parameters provided.\n\n';
+
+		if (traceFormat === TraceFormat.Text) {
+			let data: string | undefined = undefined;
+			if (trace === Trace.Verbose) {
+				if (message.params) {
+					data = `Params: ${JSON.stringify(message.params, null, 4)}\n\n`;
+				} else {
+					data = 'No parameters provided.\n\n';
+				}
 			}
+			tracer.log(`Sending notification '${message.method}'.`, data);
+		} else {
+			logLSPMessage('send-notification', message);
 		}
-		tracer.log(`Sending notification '${message.method}'.`, data);
 	}
 
 	function traceSendingResponse(message: ResponseMessage, method: string, startTime: number): void {
 		if (trace === Trace.Off || !tracer) {
 			return;
 		}
-		let data: string | undefined = undefined;
-		if (trace === Trace.Verbose) {
-			if (message.error && message.error.data) {
-				data = `Error data: ${JSON.stringify(message.error.data, null, 4)}\n\n`;
-			} else {
-				if (message.result) {
-					data = `Result: ${JSON.stringify(message.result, null, 4)}\n\n`;
-				} else if (message.error === void 0) {
-					data = 'No result returned.\n\n';
+
+		if (traceFormat === TraceFormat.Text) {
+			let data: string | undefined = undefined;
+			if (trace === Trace.Verbose) {
+				if (message.error && message.error.data) {
+					data = `Error data: ${JSON.stringify(message.error.data, null, 4)}\n\n`;
+				} else {
+					if (message.result) {
+						data = `Result: ${JSON.stringify(message.result, null, 4)}\n\n`;
+					} else if (message.error === void 0) {
+						data = 'No result returned.\n\n';
+					}
 				}
 			}
+			tracer.log(`Sending response '${method} - (${message.id})'. Processing request took ${Date.now() - startTime}ms`, data)
+		} else {
+			logLSPMessage('send-response', message);
 		}
-		tracer.log(`Sending response '${method} - (${message.id})'. Processing request took ${Date.now() - startTime}ms`, data)
 	}
 
 	function traceReceivedRequest(message: RequestMessage): void {
 		if (trace === Trace.Off || !tracer) {
 			return;
 		}
-		let data: string | undefined = undefined;
-		if (trace === Trace.Verbose && message.params) {
-			data = `Params: ${JSON.stringify(message.params, null, 4)}\n\n`;
+
+		if (traceFormat === TraceFormat.Text) {
+			let data: string | undefined = undefined;
+			if (trace === Trace.Verbose && message.params) {
+				data = `Params: ${JSON.stringify(message.params, null, 4)}\n\n`;
+			}
+			tracer.log(`Received request '${message.method} - (${message.id})'.`, data);
+		} else {
+			logLSPMessage('receive-request', message);
 		}
-		tracer.log(`Received request '${message.method} - (${message.id})'.`, data);
 	}
 
 	function traceReceivedNotification(message: NotificationMessage): void {
 		if (trace === Trace.Off || !tracer || message.method === LogTraceNotification.type.method) {
 			return;
 		}
-		let data: string | undefined = undefined;
-		if (trace === Trace.Verbose) {
-			if (message.params) {
-				data = `Params: ${JSON.stringify(message.params, null, 4)}\n\n`;
-			} else {
-				data = 'No parameters provided.\n\n';
+
+		if (traceFormat === TraceFormat.Text) {
+			let data: string | undefined = undefined;
+			if (trace === Trace.Verbose) {
+				if (message.params) {
+					data = `Params: ${JSON.stringify(message.params, null, 4)}\n\n`;
+				} else {
+					data = 'No parameters provided.\n\n';
+				}
 			}
+			tracer.log(`Received notification '${message.method}'.`, data);
+		} else {
+			logLSPMessage('receive-notification', message);
 		}
-		tracer.log(`Received notification '${message.method}'.`, data);
 	}
 
 	function traceReceivedResponse(message: ResponseMessage, responsePromise: ResponsePromise): void {
 		if (trace === Trace.Off || !tracer) {
 			return;
 		}
-		let data: string | undefined = undefined;
-		if (trace === Trace.Verbose) {
-			if (message.error && message.error.data) {
-				data = `Error data: ${JSON.stringify(message.error.data, null, 4)}\n\n`;
-			} else {
-				if (message.result) {
-					data = `Result: ${JSON.stringify(message.result, null, 4)}\n\n`;
-				} else if (message.error === void 0) {
-					data = 'No result returned.\n\n';
+
+		if (traceFormat === TraceFormat.Text) {
+			let data: string | undefined = undefined;
+			if (trace === Trace.Verbose) {
+				if (message.error && message.error.data) {
+					data = `Error data: ${JSON.stringify(message.error.data, null, 4)}\n\n`;
+				} else {
+					if (message.result) {
+						data = `Result: ${JSON.stringify(message.result, null, 4)}\n\n`;
+					} else if (message.error === void 0) {
+						data = 'No result returned.\n\n';
+					}
 				}
 			}
-		}
-		if (responsePromise) {
-			let error = message.error ? ` Request failed: ${message.error.message} (${message.error.code}).` : '';
-			tracer.log(`Received response '${responsePromise.method} - (${message.id})' in ${Date.now() - responsePromise.timerStart}ms.${error}`, data);
+			if (responsePromise) {
+				let error = message.error ? ` Request failed: ${message.error.message} (${message.error.code}).` : '';
+				tracer.log(`Received response '${responsePromise.method} - (${message.id})' in ${Date.now() - responsePromise.timerStart}ms.${error}`, data);
+			} else {
+				tracer.log(`Received response ${message.id} without active response promise.`, data);
+			}
 		} else {
-			tracer.log(`Received response ${message.id} without active response promise.`, data);
+			logLSPMessage('receive-response', message);
 		}
+	}
+
+	function logLSPMessage(type: LSPMessageType, message: RequestMessage | ResponseMessage | NotificationMessage): void {
+		if (!tracer || trace === Trace.Off) {
+			return;
+		}
+
+		const lspMessage = {
+			type,
+			message,
+			timestamp: Date.now()
+		}
+
+		tracer.logLSP(JSON.stringify(lspMessage));
 	}
 
 	function throwIfClosedOrDisposed() {
@@ -886,7 +963,7 @@ function _createMessageConnection(messageReader: MessageReader, messageWriter: M
 				method: method,
 				params: messageParams
 			}
-			traceSendNotification(notificationMessage);
+			traceSendingNotification(notificationMessage);
 			messageWriter.write(notificationMessage);
 		},
 		onNotification: (type: string | MessageType | StarNotificationHandler, handler?: GenericNotificationHandler): void => {
@@ -985,8 +1062,9 @@ function _createMessageConnection(messageReader: MessageReader, messageWriter: M
 				}
 			}
 		},
-		trace: (_value: Trace, _tracer: Tracer, sendNotification: boolean = false) => {
+		trace: (_value: Trace, _traceFormat: TraceFormat, _tracer: Tracer, sendNotification: boolean = false) => {
 			trace = _value;
+			traceFormat = _traceFormat;
 			if (trace === Trace.Off) {
 				tracer = undefined;
 			} else {

--- a/jsonrpc/src/main.ts
+++ b/jsonrpc/src/main.ts
@@ -221,6 +221,11 @@ export namespace TraceFormat {
 	}
 }
 
+export interface TraceOptions {
+	sendNotification?: boolean;
+	traceFormat?: TraceFormat;
+}
+
 export interface SetTraceParams {
 	value: TraceValues;
 }
@@ -239,7 +244,7 @@ export namespace LogTraceNotification {
 }
 
 export interface Tracer {
-	log(data: any): void;
+	log(dataObject: any): void;
 	log(message: string, data?: string): void;
 }
 
@@ -338,7 +343,7 @@ export interface MessageConnection {
 	onNotification(handler: StarNotificationHandler): void;
 
 	trace(value: Trace, tracer: Tracer, sendNotification?: boolean): void;
-	trace(value: Trace, tracer: Tracer, sendNotification?: boolean, traceFormat?: TraceFormat): void;
+	trace(value: Trace, tracer: Tracer, traceOptions?: TraceOptions): void;
 
 	onError: Event<[Error, Message | undefined, number | undefined]>;
 	onClose: Event<void>;
@@ -1049,7 +1054,19 @@ function _createMessageConnection(messageReader: MessageReader, messageWriter: M
 				}
 			}
 		},
-		trace: (_value: Trace, _tracer: Tracer, _sendNotification: boolean = false, _traceFormat: TraceFormat = TraceFormat.Text) => {
+		trace: (_value: Trace, _tracer: Tracer, sendNotificationOrTraceOptions?: boolean | TraceOptions) => {
+			let _sendNotification: boolean = false;
+			let _traceFormat: TraceFormat = TraceFormat.Text;
+
+			if (sendNotificationOrTraceOptions !== void 0) {
+				if (Is.boolean(sendNotificationOrTraceOptions)) {
+					_sendNotification = sendNotificationOrTraceOptions;
+				} else {
+					_sendNotification = sendNotificationOrTraceOptions.sendNotification || false;
+					_traceFormat = sendNotificationOrTraceOptions.traceFormat || TraceFormat.Text;
+				}
+			}
+
 			trace = _value;
 			traceFormat = _traceFormat;
 			if (trace === Trace.Off) {

--- a/jsonrpc/src/main.ts
+++ b/jsonrpc/src/main.ts
@@ -207,31 +207,16 @@ export namespace Trace {
 }
 
 export enum TraceFormat {
-	Text, JSON
+	Text = 'text',
+	JSON = 'json'
 }
-
-export type TraceFormatValues = 'text' | 'json'
 export namespace TraceFormat {
 	export function fromString(value: string): TraceFormat {
 		value = value.toLowerCase();
-		switch (value) {
-			case 'text':
-				return TraceFormat.Text;
-			case 'json':
-				return TraceFormat.JSON;
-			default:
-				return TraceFormat.Text;
-		}
-	}
-
-	export function toString(value: TraceFormat): TraceFormatValues {
-		switch (value) {
-			case TraceFormat.Text:
-				return 'text';
-			case TraceFormat.JSON:
-				return 'json';
-			default:
-				return 'text';
+		if (value === 'json') {
+			return TraceFormat.JSON;
+		} else {
+			return TraceFormat.Text;
 		}
 	}
 }

--- a/jsonrpc/src/messages.ts
+++ b/jsonrpc/src/messages.ts
@@ -133,9 +133,9 @@ export type LSPMessageType =
 	| 'receive-notification';
 
 export interface LSPLogMessage {
-    type: LSPMessageType;
-    message: RequestMessage | ResponseMessage | NotificationMessage;
-    timestamp: number;
+	type: LSPMessageType;
+	message: RequestMessage | ResponseMessage | NotificationMessage;
+	timestamp: number;
 }
 
 /**

--- a/jsonrpc/src/messages.ts
+++ b/jsonrpc/src/messages.ts
@@ -122,6 +122,23 @@ export interface ResponseMessage extends Message {
 }
 
 /**
+ * A LSP Log Entry.
+ */
+export type LSPMessageType =
+  | 'send-request'
+  | 'receive-request'
+  | 'send-response'
+  | 'receive-response'
+  | 'send-notification'
+  | 'receive-notification';
+
+export interface LSPLogMessage {
+    type: LSPMessageType;
+    message: RequestMessage | ResponseMessage | NotificationMessage;
+    timestamp: number;
+}
+
+/**
  * An interface to type messages.
  */
 export interface MessageType {

--- a/jsonrpc/src/messages.ts
+++ b/jsonrpc/src/messages.ts
@@ -125,12 +125,12 @@ export interface ResponseMessage extends Message {
  * A LSP Log Entry.
  */
 export type LSPMessageType =
-  | 'send-request'
-  | 'receive-request'
-  | 'send-response'
-  | 'receive-response'
-  | 'send-notification'
-  | 'receive-notification';
+	| 'send-request'
+	| 'receive-request'
+	| 'send-response'
+	| 'receive-response'
+	| 'send-notification'
+	| 'receive-notification';
 
 export interface LSPLogMessage {
     type: LSPMessageType;

--- a/protocol/src/main.ts
+++ b/protocol/src/main.ts
@@ -6,7 +6,7 @@
 
 import {
 	ErrorCodes, ResponseError, CancellationToken, CancellationTokenSource,
-	Disposable, Event, Emitter, Trace, SetTraceNotification, LogTraceNotification,
+	Disposable, Event, Emitter, Trace, TraceFormat, SetTraceNotification, LogTraceNotification,
 	Message, NotificationMessage, RequestMessage, MessageType as RPCMessageType,
 	RequestType, RequestType0, RequestHandler, RequestHandler0, GenericRequestHandler, StarRequestHandler,
 	NotificationType, NotificationType0, NotificationHandler, NotificationHandler0, GenericNotificationHandler, StarNotificationHandler,
@@ -19,7 +19,7 @@ import {
 
 export {
 	ErrorCodes, ResponseError, CancellationToken, CancellationTokenSource,
-	Disposable, Event, Emitter, Trace, SetTraceNotification, LogTraceNotification,
+	Disposable, Event, Emitter, Trace, TraceFormat, SetTraceNotification, LogTraceNotification,
 	Message, NotificationMessage, RequestMessage, RPCMessageType,
 	RequestType, RequestType0, RequestHandler, RequestHandler0, GenericRequestHandler, StarRequestHandler,
 	NotificationType, NotificationType0, NotificationHandler, NotificationHandler0, GenericNotificationHandler, StarNotificationHandler,
@@ -157,7 +157,7 @@ export interface ProtocolConnection {
 	/**
 	 * Enables tracing mode for the connection.
 	 */
-	trace(value: Trace, tracer: Tracer, sendNotification?: boolean): void;
+	trace(value: Trace, traceFormat: TraceFormat, tracer: Tracer, sendNotification?: boolean): void;
 
 	/**
 	 * An event emitter firing when an error occurs on the connection.

--- a/protocol/src/main.ts
+++ b/protocol/src/main.ts
@@ -157,7 +157,8 @@ export interface ProtocolConnection {
 	/**
 	 * Enables tracing mode for the connection.
 	 */
-	trace(value: Trace, traceFormat: TraceFormat, tracer: Tracer, sendNotification?: boolean): void;
+	trace(value: Trace, tracer: Tracer, sendNotification?: boolean): void;
+	trace(value: Trace, tracer: Tracer, sendNotification?: boolean, traceFormat?: TraceFormat): void;
 
 	/**
 	 * An event emitter firing when an error occurs on the connection.

--- a/protocol/src/main.ts
+++ b/protocol/src/main.ts
@@ -6,7 +6,7 @@
 
 import {
 	ErrorCodes, ResponseError, CancellationToken, CancellationTokenSource,
-	Disposable, Event, Emitter, Trace, TraceFormat, SetTraceNotification, LogTraceNotification,
+	Disposable, Event, Emitter, Trace, Tracer, TraceFormat, TraceOptions, SetTraceNotification, LogTraceNotification,
 	Message, NotificationMessage, RequestMessage, MessageType as RPCMessageType,
 	RequestType, RequestType0, RequestHandler, RequestHandler0, GenericRequestHandler, StarRequestHandler,
 	NotificationType, NotificationType0, NotificationHandler, NotificationHandler0, GenericNotificationHandler, StarNotificationHandler,
@@ -14,12 +14,12 @@ import {
 	StreamMessageReader, StreamMessageWriter, IPCMessageReader, IPCMessageWriter,
 	createClientPipeTransport, createServerPipeTransport, generateRandomPipeName, DataCallback,
 	createClientSocketTransport, createServerSocketTransport,
-	createMessageConnection, Tracer
+	createMessageConnection
 } from 'vscode-jsonrpc';
 
 export {
 	ErrorCodes, ResponseError, CancellationToken, CancellationTokenSource,
-	Disposable, Event, Emitter, Trace, TraceFormat, SetTraceNotification, LogTraceNotification,
+	Disposable, Event, Emitter, Trace, Tracer, TraceFormat, TraceOptions, SetTraceNotification, LogTraceNotification,
 	Message, NotificationMessage, RequestMessage, RPCMessageType,
 	RequestType, RequestType0, RequestHandler, RequestHandler0, GenericRequestHandler, StarRequestHandler,
 	NotificationType, NotificationType0, NotificationHandler, NotificationHandler0, GenericNotificationHandler, StarNotificationHandler,
@@ -28,8 +28,8 @@ export {
 	IPCMessageReader, IPCMessageWriter,
 	createClientPipeTransport, createServerPipeTransport, generateRandomPipeName, DataCallback,
 	createClientSocketTransport, createServerSocketTransport,
-	Tracer
 }
+
 export * from 'vscode-languageserver-types';
 export * from './protocol';
 
@@ -158,7 +158,7 @@ export interface ProtocolConnection {
 	 * Enables tracing mode for the connection.
 	 */
 	trace(value: Trace, tracer: Tracer, sendNotification?: boolean): void;
-	trace(value: Trace, tracer: Tracer, sendNotification?: boolean, traceFormat?: TraceFormat): void;
+	trace(value: Trace, tracer: Tracer, traceOptions?: TraceOptions): void;
 
 	/**
 	 * An event emitter firing when an error occurs on the connection.


### PR DESCRIPTION
Things I plan to do but haven't done yet:

- [ ] When `verbosity` is set to `message`, ignore `params` on Request / Notification messages
- [ ] Expose `traceFormat` to client's initialization params

Questions:

- [ ] Can we rename this to `[langId].lsp.trace`? `server` is misleading as the logs are actually logged from the client perspective. I'll write documentation for this too so I hope we can get this right.

@dbaeumer Would like to get some high-level insight - let me know if this is the right direction, what more things you would want to me to add, etc.

More details are at https://github.com/Microsoft/language-server-protocol-inspector/issues/8