### PR TITLE
Address #362

### DIFF
--- a/types/src/main.ts
+++ b/types/src/main.ts
@@ -151,6 +151,148 @@ export namespace Location {
 }
 
 /**
+ * Represents a color in RGBA space.
+ */
+export interface Color {
+
+	/**
+	 * The red component of this color in the range [0-1].
+	 */
+	readonly red: number;
+
+	/**
+	 * The green component of this color in the range [0-1].
+	 */
+	readonly green: number;
+
+	/**
+	 * The blue component of this color in the range [0-1].
+	 */
+	readonly blue: number;
+
+	/**
+	 * The alpha component of this color in the range [0-1].
+	 */
+	readonly alpha: number;
+}
+
+/**
+ * The Color namespace provides helper functions to work with
+ * [Color](#Color) literals.
+ */
+export namespace Color {
+	/**
+	 * Creates a new Color literal.
+	 */
+	export function create(red: number, green: number, blue: number, alpha: number): Color {
+		return {
+			red,
+			green,
+			blue,
+			alpha,
+		};
+	}
+
+	/**
+	 * Checks whether the given literal conforms to the [Color](#Color) interface.
+	 */
+	export function is(value: any): value is Color {
+		const candidate = value as Color;
+		return Is.number(candidate.red)
+			&& Is.number(candidate.green)
+			&& Is.number(candidate.blue)
+			&& Is.number(candidate.alpha);
+	}
+}
+
+/**
+ * Represents a color range from a document.
+ */
+export interface ColorInformation {
+
+	/**
+	 * The range in the document where this color appers.
+	 */
+	range: Range;
+
+	/**
+	 * The actual color value for this color range.
+	 */
+	color: Color;
+}
+
+/**
+ * The ColorInformation namespace provides helper functions to work with
+ * [ColorInformation](#ColorInformation) literals.
+ */
+export namespace ColorInformation {
+	/**
+	 * Creates a new ColorInformation literal.
+	 */
+	export function create(range: Range, color: Color): ColorInformation {
+		return {
+			range,
+			color,
+		};
+	}
+
+	/**
+	 * Checks whether the given literal conforms to the [ColorInformation](#ColorInformation) interface.
+	 */
+	export function is(value: any): value is ColorInformation {
+		const candidate = value as ColorInformation;
+		return Range.is(candidate.range) && Color.is(candidate.color);
+	}
+}
+
+export interface ColorPresentation {
+	/**
+	 * The label of this color presentation. It will be shown on the color
+	 * picker header. By default this is also the text that is inserted when selecting
+	 * this color presentation.
+	 */
+	label: string;
+	/**
+	 * An [edit](#TextEdit) which is applied to a document when selecting
+	 * this presentation for the color.  When `falsy` the [label](#ColorPresentation.label)
+	 * is used.
+	 */
+	textEdit?: TextEdit;
+	/**
+	 * An optional array of additional [text edits](#TextEdit) that are applied when
+	 * selecting this color presentation. Edits must not overlap with the main [edit](#ColorPresentation.textEdit) nor with themselves.
+	 */
+	additionalTextEdits?: TextEdit[];
+}
+
+/**
+ * The Color namespace provides helper functions to work with
+ * [ColorPresentation](#ColorPresentation) literals.
+ */
+export namespace ColorPresentation {
+	/**
+	 * Creates a new ColorInformation literal.
+	 */
+	export function create(label: string, textEdit?: TextEdit, additionalTextEdits?: TextEdit[]): ColorPresentation {
+		return {
+			label,
+			textEdit,
+			additionalTextEdits,
+		};
+	}
+
+	/**
+	 * Checks whether the given literal conforms to the [ColorInformation](#ColorInformation) interface.
+	 */
+	export function is(value: any): value is ColorPresentation {
+		const candidate = value as ColorPresentation;
+		return Is.string(candidate.label)
+				&& (Is.undefined(candidate.textEdit) || TextEdit.is(candidate))
+				&& (Is.undefined(candidate.additionalTextEdits) || Is.typedArray<DiagnosticRelatedInformation>(candidate.additionalTextEdits, TextEdit.is));
+	}
+}
+
+/**
  * Represents a related message and source code location for a diagnostic. This should be
  * used to point to code locations that cause or related to a diagnostics, e.g when duplicating
  * a symbol in a scope.

--- a/types/src/main.ts
+++ b/types/src/main.ts
@@ -388,6 +388,11 @@ export namespace TextEdit {
 	export function del(range: Range): TextEdit {
 		return { range, newText: '' };
 	}
+
+	export function is(value: any): value is TextEdit {
+		const candidate = value as TextEdit;
+		return Is.string(candidate.newText) && Range.is(candidate.range);
+	}
 }
 
 

--- a/types/src/main.ts
+++ b/types/src/main.ts
@@ -533,7 +533,9 @@ export namespace TextEdit {
 
 	export function is(value: any): value is TextEdit {
 		const candidate = value as TextEdit;
-		return Is.string(candidate.newText) && Range.is(candidate.range);
+		return Is.objectLiteral(candidate)
+				&& Is.string(candidate.newText)
+				&& Range.is(candidate.range);
 	}
 }
 

--- a/types/src/test/typeguards.test.ts
+++ b/types/src/test/typeguards.test.ts
@@ -5,7 +5,7 @@
 'use strict';
 
 import * as assert from 'assert'
-import { Range, Position, Hover, MarkedString } from '../main';
+import { Range, Position, Hover, MarkedString, TextEdit } from '../main';
 
 suite('Type guards', () => {
 	suite('Position.is', () => {
@@ -143,6 +143,51 @@ suite('Type guards', () => {
 		test('undefined', () => {
 			const hover = undefined
 			assert.strictEqual(Hover.is(hover), false)
+		})
+	})
+	suite('TextEdit.is', () => {
+		test('string contents, range defined', () => {
+			const edit = {
+				newText: 'test',
+				range: Range.create(Position.create(0, 0), Position.create(0, 1)),
+			}
+			assert.strictEqual(TextEdit.is(edit), true)
+		})
+		test('string contents, range undefined', () => {
+			const edit = {
+				newText: 'test',
+				range: undefined,
+			}
+			assert.strictEqual(TextEdit.is(edit), false)
+		})
+		test('string contents, range null', () => {
+			const edit = {
+				newText: 'test',
+				range: null,
+			}
+			assert.strictEqual(TextEdit.is(edit), false)
+		})
+		test('null contents, range defined', () => {
+			const edit = {
+				contents: null,
+				range: Range.create(Position.create(0, 0), Position.create(0, 1)),
+			}
+			assert.strictEqual(TextEdit.is(edit), false)
+		})
+		test('undefined contents, range defined', () => {
+			const edit = {
+				contents: undefined,
+				range: Range.create(Position.create(0, 0), Position.create(0, 1)),
+			}
+			assert.strictEqual(TextEdit.is(edit), false)
+		})
+		test('null', () => {
+			const edit = null
+			assert.strictEqual(TextEdit.is(edit), false)
+		})
+		test('undefined', () => {
+			const edit = undefined
+			assert.strictEqual(TextEdit.is(edit), false)
 		})
 	})
 })


### PR DESCRIPTION
Also, there was no `TextEdit.is`, which I also added.

Currently, this build fails. If the types package is published, we can remove the definitions in `protocol/src/protocol.colorProvider.ts` and use the ones shipped in `vscode-languageserver-types`.