### PR TITLE
Add textDocument/prepareRename for preparing a rename request

### DIFF
--- a/client/src/client.ts
+++ b/client/src/client.ts
@@ -49,11 +49,11 @@ import {
 	CodeLensRequest, CodeLensResolveRequest, CodeLensRegistrationOptions,
 	DocumentFormattingRequest, DocumentFormattingParams, DocumentRangeFormattingRequest, DocumentRangeFormattingParams,
 	DocumentOnTypeFormattingRequest, DocumentOnTypeFormattingParams, DocumentOnTypeFormattingRegistrationOptions,
-	RenameRequest, RenameParams,
+	RenameRequest, RenameParams, RenameRegistrationOptions, PrepareRenameRequest, TextDocumentPositionParams,
 	DocumentLinkRequest, DocumentLinkResolveRequest, DocumentLinkRegistrationOptions,
 	ExecuteCommandRequest, ExecuteCommandParams, ExecuteCommandRegistrationOptions,
 	ApplyWorkspaceEditRequest, ApplyWorkspaceEditParams, ApplyWorkspaceEditResponse,
-	MarkupKind, SymbolKind, CompletionItemKind, Command, CodeActionKind, DocumentSymbol, SymbolInformation,
+	MarkupKind, SymbolKind, CompletionItemKind, Command, CodeActionKind, DocumentSymbol, SymbolInformation, Range,
 	CodeActionRegistrationOptions
 } from 'vscode-languageserver-protocol';
 
@@ -354,6 +354,10 @@ export interface ProvideRenameEditsSignature {
 	(document: TextDocument, position: VPosition, newName: string, token: CancellationToken): ProviderResult<VWorkspaceEdit>;
 }
 
+export interface PrepareRenameSignature {
+	(document: TextDocument, position: VPosition, token: CancellationToken): ProviderResult<VRange | { range: VRange, placeholder: string }>;
+}
+
 export interface ProvideDocumentLinksSignature {
 	(document: TextDocument, token: CancellationToken): ProviderResult<VDocumentLink[]>;
 }
@@ -405,6 +409,7 @@ export interface _Middleware {
 	provideDocumentRangeFormattingEdits?: (this: void, document: TextDocument, range: VRange, options: VFormattingOptions, token: CancellationToken, next: ProvideDocumentRangeFormattingEditsSignature) => ProviderResult<VTextEdit[]>;
 	provideOnTypeFormattingEdits?: (this: void, document: TextDocument, position: VPosition, ch: string, options: VFormattingOptions, token: CancellationToken, next: ProvideOnTypeFormattingEditsSignature) => ProviderResult<VTextEdit[]>;
 	provideRenameEdits?: (this: void, document: TextDocument, position: VPosition, newName: string, token: CancellationToken, next: ProvideRenameEditsSignature) => ProviderResult<VWorkspaceEdit>;
+	prepareRename?: (this: void, document: TextDocument, position: VPosition, token: CancellationToken, next: PrepareRenameSignature) => ProviderResult<VRange | { range: VRange, placeholder: string }>;
 	provideDocumentLinks?: (this: void, document: TextDocument, token: CancellationToken, next: ProvideDocumentLinksSignature) => ProviderResult<VDocumentLink[]>;
 	resolveDocumentLink?: (this: void, link: VDocumentLink, token: CancellationToken, next: ResolveDocumentLinkSignature) => ProviderResult<VDocumentLink>;
 	workspace?: WorkspaceMiddleware;
@@ -1959,7 +1964,9 @@ class RenameFeature extends TextDocumentFeature<TextDocumentRegistrationOptions>
 	}
 
 	public fillClientCapabilities(capabilites: ClientCapabilities): void {
-		ensure(ensure(capabilites, 'textDocument')!, 'rename')!.dynamicRegistration = true;
+		let rename = ensure(ensure(capabilites, 'textDocument')!, 'rename')!;
+		rename.dynamicRegistration = true;
+		rename.prepareSupport = true;
 	}
 
 	public initialize(capabilities: ServerCapabilities, documentSelector: DocumentSelector): void {
@@ -1972,7 +1979,7 @@ class RenameFeature extends TextDocumentFeature<TextDocumentRegistrationOptions>
 		});
 	}
 
-	protected registerLanguageProvider(options: TextDocumentRegistrationOptions): Disposable {
+	protected registerLanguageProvider(options: RenameRegistrationOptions): Disposable {
 		let client = this._client;
 		let provideRenameEdits: ProvideRenameEditsSignature = (document, position, newName, token) => {
 			let params: RenameParams = {
@@ -1988,13 +1995,43 @@ class RenameFeature extends TextDocumentFeature<TextDocumentRegistrationOptions>
 				}
 			);
 		};
+		let prepareRename: PrepareRenameSignature = (document, position, token) => {
+			let params: TextDocumentPositionParams = {
+				textDocument: client.code2ProtocolConverter.asTextDocumentIdentifier(document),
+				position: client.code2ProtocolConverter.asPosition(position),
+			};
+			return client.sendRequest(PrepareRenameRequest.type, params, token).then((result) => {
+					if (Range.is(result)) {
+						return client.protocol2CodeConverter.asRange(result);
+					} else if (result && result.range) {
+						return {
+							range: client.protocol2CodeConverter.asRange(result.range),
+							placeholder: result.placeholder
+						}
+					}
+					return null;
+				},
+				(error: ResponseError<void>) => {
+					client.logFailedRequest(PrepareRenameRequest.type, error);
+					return Promise.reject(new Error(error.message));
+				}
+			);
+		};
 		let middleware = client.clientOptions.middleware!;
 		return Languages.registerRenameProvider(options.documentSelector!, {
 			provideRenameEdits: (document: TextDocument, position: VPosition, newName: string, token: CancellationToken): ProviderResult<VWorkspaceEdit> => {
 				return middleware.provideRenameEdits
 					? middleware.provideRenameEdits(document, position, newName, token, provideRenameEdits)
 					: provideRenameEdits(document, position, newName, token);
-			}
+			},
+
+			prepareRename: options.prepareProvider
+				? (document: TextDocument, position: VPosition, token: CancellationToken): ProviderResult<VRange | { range: VRange, placeholder: string }> => {
+					return middleware.prepareRename
+						? middleware.prepareRename(document, position, token, prepareRename)
+						: prepareRename(document, position, token);
+				}
+				: undefined
 		});
 	}
 }

--- a/client/src/client.ts
+++ b/client/src/client.ts
@@ -1957,7 +1957,7 @@ class DocumentOnTypeFormattingFeature extends TextDocumentFeature<DocumentOnType
 	}
 }
 
-class RenameFeature extends TextDocumentFeature<TextDocumentRegistrationOptions> {
+class RenameFeature extends TextDocumentFeature<RenameRegistrationOptions> {
 
 	constructor(client: BaseLanguageClient) {
 		super(client, RenameRequest.type);

--- a/client/src/test/integration.test.ts
+++ b/client/src/test/integration.test.ts
@@ -41,7 +41,10 @@ suite('Client integration', () => {
                     capabilities: {
                         textDocumentSync: 1,
                         completionProvider: { resolveProvider: true, triggerCharacters: ['"', ':'] },
-                        hoverProvider: true
+                        hoverProvider: true,
+                        renameProvider: {
+                            prepareProvider: true
+                        }
                     },
                     customResults: {
                         "hello": "world"

--- a/client/src/test/servers/testInitializeResult.ts
+++ b/client/src/test/servers/testInitializeResult.ts
@@ -22,6 +22,7 @@ connection.onInitialize((params: InitializeParams): any => {
 	assert.equal(params.capabilities.workspace!.workspaceEdit!.documentChanges, true);
 	assert.equal(params.capabilities.textDocument!.completion!.completionItem!.deprecatedSupport, true);
 	assert.equal(params.capabilities.textDocument!.completion!.completionItem!.preselectSupport, true);
+	assert.equal(params.capabilities.textDocument!.rename!.prepareSupport, true);
 	let valueSet = params.capabilities.textDocument!.completion!.completionItemKind!.valueSet!;
 	assert.equal(valueSet[0], 1);
 	assert.equal(valueSet[valueSet.length - 1], CompletionItemKind.TypeParameter);
@@ -30,7 +31,10 @@ connection.onInitialize((params: InitializeParams): any => {
 	let capabilities: ServerCapabilities = {
 		textDocumentSync: documents.syncKind,
 		completionProvider: { resolveProvider: true, triggerCharacters: ['"', ':'] },
-		hoverProvider: true
+		hoverProvider: true,
+		renameProvider: {
+			prepareProvider: true
+		}
 	};
 	return { capabilities, customResults: { "hello": "world" } };
 });

--- a/protocol/src/protocol.ts
+++ b/protocol/src/protocol.ts
@@ -524,6 +524,11 @@ export interface TextDocumentClientCapabilities {
 		 * Whether rename supports dynamic registration.
 		 */
 		dynamicRegistration?: boolean;
+		/**
+		 * Client supports testing for validity of rename operations
+		 * before execution.
+		 */
+		prepareSupport?: boolean;
 	};
 
 	/**
@@ -681,6 +686,16 @@ export interface DocumentOnTypeFormattingOptions {
 }
 
 /**
+ * Rename options
+ */
+export interface RenameOptions {
+	/**
+	 * Renames should be checked and tested before being executed.
+	 */
+	prepareProvider?: boolean;
+}
+
+/**
  * Document link options
  */
 export interface DocumentLinkOptions {
@@ -808,7 +823,7 @@ export interface _ServerCapabilities {
 	/**
 	 * The server provides rename support.
 	 */
-	renameProvider?: boolean;
+	renameProvider?: boolean | RenameOptions;
 	/**
 	 * The server provides document link support.
 	 */
@@ -1712,7 +1727,20 @@ export interface RenameParams {
  * A request to rename a symbol.
  */
 export namespace RenameRequest {
-	export const type = new RequestType<RenameParams, WorkspaceEdit | null, void, TextDocumentRegistrationOptions>('textDocument/rename');
+	export const type = new RequestType<RenameParams, WorkspaceEdit | null, void, RenameRegistrationOptions>('textDocument/rename');
+}
+
+/**
+ * A request to test and perform the setup necessary for a rename.
+ */
+export namespace PrepareRenameRequest {
+	export const type = new RequestType<TextDocumentPositionParams, Range | { range: Range, placeholder: string } | null, void, void>('textDocument/prepareRename');
+}
+
+/**
+ * Rename registration options.
+ */
+export interface RenameRegistrationOptions extends TextDocumentRegistrationOptions, RenameOptions {
 }
 
 //---- Document Links ----------------------------------------------

--- a/protocol/src/protocol.ts
+++ b/protocol/src/protocol.ts
@@ -821,7 +821,9 @@ export interface _ServerCapabilities {
 		moreTriggerCharacter?: string[]
 	};
 	/**
-	 * The server provides rename support.
+	 * The server provides rename support. RenameOptions may only be
+	 * specified if the client states that it supports
+	 * `prepareSupport` in its initial `initialize` request.
 	 */
 	renameProvider?: boolean | RenameOptions;
 	/**

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -9,7 +9,7 @@ import {
 	TextDocument, TextDocumentChangeEvent, TextDocumentContentChangeEvent, TextDocumentWillSaveEvent,
 	Location, Command, TextEdit, WorkspaceEdit, CompletionItem, CompletionList, Hover,
 	SignatureHelp, Definition, DocumentHighlight, SymbolInformation, DocumentSymbol, WorkspaceSymbolParams, DocumentSymbolParams,
-	CodeLens, DocumentLink,
+	CodeLens, DocumentLink, Range,
 	RequestType, RequestType0, RequestHandler, RequestHandler0, GenericRequestHandler, StarRequestHandler,
 	NotificationType, NotificationType0, NotificationHandler, NotificationHandler0, GenericNotificationHandler, StarNotificationHandler,
 	RPCMessageType, ResponseError,
@@ -39,7 +39,7 @@ import {
 	CodeActionRequest, CodeActionParams, CodeLensRequest, CodeLensParams, CodeLensResolveRequest,
 	DocumentFormattingRequest, DocumentFormattingParams, DocumentRangeFormattingRequest, DocumentRangeFormattingParams,
 	DocumentOnTypeFormattingRequest, DocumentOnTypeFormattingParams,
-	RenameRequest, RenameParams,
+	RenameRequest, RenameParams, PrepareRenameRequest,
 	DocumentLinkRequest, DocumentLinkResolveRequest, DocumentLinkParams,
 	ExecuteCommandRequest, ExecuteCommandParams,
 	ApplyWorkspaceEditRequest, ApplyWorkspaceEditParams, ApplyWorkspaceEditResponse,
@@ -1298,6 +1298,13 @@ export interface Connection<PConsole = _, PTracer = _, PTelemetry = _, PClient =
 	onRenameRequest(handler: RequestHandler<RenameParams, WorkspaceEdit | undefined | null, void>): void;
 
 	/**
+	 * Installs a handler for the prepare rename request.
+	 *
+	 * @param handler The corresponding handler.
+	 */
+	onPrepareRename(handler: RequestHandler<TextDocumentPositionParams, Range | { range: Range, placeholder: string } | undefined | null, void>): void;
+
+	/**
 	 * Installs a handler for the document links request.
 	 *
 	 * @param handler The corresponding handler.
@@ -1655,6 +1662,7 @@ function _createConnection<PConsole = _, PTracer = _, PTelemetry = _, PClient = 
 		onDocumentRangeFormatting: (handler) => connection.onRequest(DocumentRangeFormattingRequest.type, handler),
 		onDocumentOnTypeFormatting: (handler) => connection.onRequest(DocumentOnTypeFormattingRequest.type, handler),
 		onRenameRequest: (handler) => connection.onRequest(RenameRequest.type, handler),
+		onPrepareRename: (handler) => connection.onRequest(PrepareRenameRequest.type, handler),
 		onDocumentLinks: (handler) => connection.onRequest(DocumentLinkRequest.type, handler),
 		onDocumentLinkResolve: (handler) => connection.onRequest(DocumentLinkResolveRequest.type, handler),
 		onDocumentColor: (handler) => connection.onRequest(DocumentColorRequest.type, handler),


### PR DESCRIPTION
Implemented a new `textDocument/resolveRenameLocation` request for preparing and validation before a `textDocument/rename` happens.

This request allows a language server to resolve and validate the current cursor location before a rename is actually attempted. This allows clients to interrupt a rename request if for example the user's text cursor is currently within a language keyword and as such cannot be renamed.

This addresses Microsoft/language-server-protocol#455.