### PR TITLE
Change textDocument/foldingRange to textDocument/foldingRanges

### DIFF
--- a/protocol/src/protocol.foldingRange.ts
+++ b/protocol/src/protocol.foldingRange.ts
@@ -15,7 +15,7 @@ export interface FoldingRangeClientCapabilities {
 	 */
 	textDocument?: {
 		/**
-		 * Capabilities specific to `textDocument/foldingRange` requests
+		 * Capabilities specific to `textDocument/foldingRanges` requests
 		 */
 		foldingRange?: {
 			/**
@@ -116,5 +116,5 @@ export interface FoldingRangeRequestParam {
  * that resolves to such.
  */
 export namespace FoldingRangeRequest {
-	export const type: RequestType<FoldingRangeRequestParam, FoldingRange[] | null, any, any> = new RequestType('textDocument/foldingRange');
+	export const type: RequestType<FoldingRangeRequestParam, FoldingRange[] | null, any, any> = new RequestType('textDocument/foldingRanges');
 }


### PR DESCRIPTION
According to the 3.10.0 specification, the request should be `textDocument/foldingRanges` and not `textDocument/foldingRange`. If you take a look at the [original specification in the Microsoft/vscode-languageserver-protocol-foldingprovider](https://github.com/Microsoft/vscode-languageserver-protocol-foldingprovider/blob/f0db4c8a93468888b3d7b4694acf8345c989a6cf/protocol.foldingProvider.md), you can see that the confusion was already there as both `textDocument/foldingRange` and `textDocument/foldingRanges` is mentioned.