### PR TITLE
Fixed error msg misspellings of "received"

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -191,7 +191,7 @@ export class LanguageClient extends BaseLanguageClient {
 			codeVersion.prerelease = [];
 		}
 		if (!SemVer.satisfies(codeVersion, REQUIRED_VSCODE_VERSION)) {
-			throw new Error(`The language client requires VS Code version ${REQUIRED_VSCODE_VERSION} but recevied version ${VSCodeVersion}`);
+			throw new Error(`The language client requires VS Code version ${REQUIRED_VSCODE_VERSION} but received version ${VSCodeVersion}`);
 		}
 	}
 

--- a/jsonrpc/src/messageReader.ts
+++ b/jsonrpc/src/messageReader.ts
@@ -165,7 +165,7 @@ export abstract class AbstractMessageReader {
 		if (error instanceof Error) {
 			return error;
 		} else {
-			return new Error(`Reader recevied error. Reason: ${Is.string(error.message) ? error.message : 'unknown'}`);
+			return new Error(`Reader received error. Reason: ${Is.string(error.message) ? error.message : 'unknown'}`);
 		}
 	}
 }
@@ -229,7 +229,7 @@ export class StreamMessageReader extends AbstractMessageReader implements Messag
 			}
 			var msg = this.buffer.tryReadContent(this.nextMessageLength);
 			if (msg === null) {
-				/** We haven't recevied the full message yet. */
+				/** We haven't received the full message yet. */
 				this.setPartialMessageTimer();
 				return;
 			}

--- a/jsonrpc/src/messageWriter.ts
+++ b/jsonrpc/src/messageWriter.ts
@@ -64,7 +64,7 @@ export abstract class AbstractMessageWriter {
 		if (error instanceof Error) {
 			return error;
 		} else {
-			return new Error(`Writer recevied error. Reason: ${Is.string(error.message) ? error.message : 'unknown'}`);
+			return new Error(`Writer received error. Reason: ${Is.string(error.message) ? error.message : 'unknown'}`);
 		}
 	}
 }

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -262,7 +262,7 @@ export class TextDocuments {
 				let document = this._documents[td.uri];
 				if (document && isUpdateableDocument(document)) {
 					if (td.version === null || td.version === void 0) {
-						throw new Error(`Recevied document change event for ${td.uri} without valid version identifier`);
+						throw new Error(`Received document change event for ${td.uri} without valid version identifier`);
 					}
 					document.update(last, td.version);
 					this._onDidChangeContent.fire(Object.freeze({ document }));


### PR DESCRIPTION
I've had an issue with an extension that wouldn't load because of a version dependency and a misspelling of the word "received" (as "recevied") in the error message made me go bonkers.

Corrected 5 instances of this misspelling across the project, no functional changes