### PR TITLE
Provide metadata about symbols with DefinitionLink

### DIFF
--- a/client/src/client.ts
+++ b/client/src/client.ts
@@ -1477,7 +1477,7 @@ class DefinitionFeature extends TextDocumentFeature<TextDocumentRegistrationOpti
 	public fillClientCapabilities(capabilites: ClientCapabilities): void {
 		let definitionSupport = ensure(ensure(capabilites, 'textDocument')!, 'definition')!;
 		definitionSupport.dynamicRegistration = true;
-		definitionSupport.definitionLinkSupport = true;
+		definitionSupport.locationLinkSupport = true;
 	}
 
 	public initialize(capabilities: ServerCapabilities, documentSelector: DocumentSelector): void {

--- a/client/src/implementation.ts
+++ b/client/src/implementation.ts
@@ -39,7 +39,7 @@ export class ImplementationFeature extends TextDocumentFeature<TextDocumentRegis
 	public fillClientCapabilities(capabilites: ClientCapabilities): void {
 		let implementationSupport = ensure(ensure(capabilites, 'textDocument')!, 'implementation')!;
 		implementationSupport.dynamicRegistration = true;
-		implementationSupport.definitionLinkSupport = true;
+		implementationSupport.locationLinkSupport = true;
 	}
 
 	public initialize(capabilities: ServerCapabilities, documentSelector: DocumentSelector): void {

--- a/client/src/implementation.ts
+++ b/client/src/implementation.ts
@@ -7,7 +7,7 @@
 import * as UUID from './utils/uuid';
 import * as Is from  './utils/is';
 
-import { languages as Languages, Disposable, TextDocument, ProviderResult, Position as VPosition, Definition as VDefinition } from 'vscode';
+import { languages as Languages, Disposable, TextDocument, ProviderResult, Position as VPosition, Definition as VDefinition, DefinitionLink as VDefinitionLink } from 'vscode';
 
 import {
 	ClientCapabilities, CancellationToken, ServerCapabilities, TextDocumentRegistrationOptions, DocumentSelector, ImplementationRequest
@@ -23,11 +23,11 @@ function ensure<T, K extends keyof T>(target: T, key: K): T[K] {
 }
 
 export interface ProvideImplementationSignature {
-	(document: TextDocument, position: VPosition, token: CancellationToken): ProviderResult<VDefinition>;
+	(document: TextDocument, position: VPosition, token: CancellationToken): ProviderResult<VDefinition | VDefinitionLink[]>;
 }
 
 export interface ImplementationMiddleware {
-	provideImplementation?: (this: void, document: TextDocument, position: VPosition, token: CancellationToken, next: ProvideImplementationSignature) => ProviderResult<VDefinition>;
+	provideImplementation?: (this: void, document: TextDocument, position: VPosition, token: CancellationToken, next: ProvideImplementationSignature) => ProviderResult<VDefinition | VDefinitionLink[]>;
 }
 
 export class ImplementationFeature extends TextDocumentFeature<TextDocumentRegistrationOptions> {
@@ -37,7 +37,9 @@ export class ImplementationFeature extends TextDocumentFeature<TextDocumentRegis
 	}
 
 	public fillClientCapabilities(capabilites: ClientCapabilities): void {
-		ensure(ensure(capabilites, 'textDocument')!, 'implementation')!.dynamicRegistration = true;
+		let implementationSupport = ensure(ensure(capabilites, 'textDocument')!, 'implementation')!;
+		implementationSupport.dynamicRegistration = true;
+		implementationSupport.definitionLinkSupport = true;
 	}
 
 	public initialize(capabilities: ServerCapabilities, documentSelector: DocumentSelector): void {
@@ -78,7 +80,7 @@ export class ImplementationFeature extends TextDocumentFeature<TextDocumentRegis
 		};
 		let middleware = client.clientOptions.middleware!;
 		return Languages.registerImplementationProvider(options.documentSelector!, {
-			provideImplementation: (document: TextDocument, position: VPosition, token: CancellationToken): ProviderResult<VDefinition> => {
+			provideImplementation: (document: TextDocument, position: VPosition, token: CancellationToken): ProviderResult<VDefinition | VDefinitionLink[]> => {
 				return middleware.provideImplementation
 					? middleware.provideImplementation(document, position, token, provideImplementation)
 					: provideImplementation(document, position, token);

--- a/client/src/protocolConverter.ts
+++ b/client/src/protocolConverter.ts
@@ -61,8 +61,9 @@ export interface Converter {
 	asParameterInformations(item: ls.ParameterInformation[]): code.ParameterInformation[];
 
 	asDefinitionResult(item: ls.Definition): code.Definition;
+	asDefinitionResult(item: ls.LocationLink[]): code.Definition;
 	asDefinitionResult(item: undefined | null): undefined;
-	asDefinitionResult(item: ls.Definition | undefined | null): code.Definition | code.DefinitionLink[] | undefined;
+	asDefinitionResult(item: ls.Definition | ls.LocationLink[] | undefined | null): code.Definition | code.DefinitionLink[] | undefined;
 
 	asLocation(item: ls.Location): code.Location;
 	asLocation(item: undefined | null): undefined;
@@ -433,23 +434,24 @@ export function createConverter(uriConverter?: URIConverter): Converter {
 	}
 
 	function asDefinitionResult(item: ls.Definition): code.Definition;
+	function asDefinitionResult(item: ls.LocationLink[]): code.Definition;
 	function asDefinitionResult(item: undefined | null): undefined;
-	function asDefinitionResult(item: ls.Definition | undefined | null): code.Definition | code.DefinitionLink[] | undefined;
-	function asDefinitionResult(item: ls.Definition | undefined | null): code.Definition | code.DefinitionLink[] | undefined {
+	function asDefinitionResult(item: ls.Definition | ls.LocationLink[] | undefined | null): code.Definition | code.DefinitionLink[] | undefined;
+	function asDefinitionResult(item: ls.Definition | ls.LocationLink[] | undefined | null): code.Definition | code.DefinitionLink[] | undefined {
 		if (!item) {
 			return undefined;
 		}
 		if (Is.array(item)) {
 			if (item.length === 0) {
 				return[];
-			} else if (ls.DefinitionLink.is(item[0])) {
-				let links = item as ls.DefinitionLink[];
+			} else if (ls.LocationLink.is(item[0])) {
+				let links = item as ls.LocationLink[];
 				return links.map((links) => asDefinitionLink(links));
 			} else {
 				let locations = item as ls.Location[];
 				return locations.map((location) => asLocation(location));
 			}
-		} else if (ls.DefinitionLink.is(item)) {
+		} else if (ls.LocationLink.is(item)) {
 			return [ asDefinitionLink(item) ];
 		} else {
 			return asLocation(item);
@@ -466,10 +468,10 @@ export function createConverter(uriConverter?: URIConverter): Converter {
 		return new code.Location(_uriConverter(item.uri), asRange(item.range));
 	}
 
-	function asDefinitionLink(item: ls.DefinitionLink): code.DefinitionLink;
+	function asDefinitionLink(item: ls.LocationLink): code.DefinitionLink;
 	function asDefinitionLink(item: undefined | null): undefined;
-	function asDefinitionLink(item: ls.DefinitionLink | undefined | null): code.DefinitionLink | undefined;
-	function asDefinitionLink(item: ls.DefinitionLink | undefined | null): code.DefinitionLink | undefined {
+	function asDefinitionLink(item: ls.LocationLink | undefined | null): code.DefinitionLink | undefined;
+	function asDefinitionLink(item: ls.LocationLink | undefined | null): code.DefinitionLink | undefined {
 		if (!item) {
 			return undefined;
 		}

--- a/client/src/test/servers/testInitializeResult.ts
+++ b/client/src/test/servers/testInitializeResult.ts
@@ -24,6 +24,9 @@ connection.onInitialize((params: InitializeParams): any => {
 	assert.equal(params.capabilities.workspace!.workspaceEdit!.failureHandling, FailureHandlingKind.TextOnlyTransactional);
 	assert.equal(params.capabilities.textDocument!.completion!.completionItem!.deprecatedSupport, true);
 	assert.equal(params.capabilities.textDocument!.completion!.completionItem!.preselectSupport, true);
+	assert.equal(params.capabilities.textDocument!.definition!.definitionLinkSupport, true);
+	assert.equal(params.capabilities.textDocument!.implementation!.definitionLinkSupport, true);
+	assert.equal(params.capabilities.textDocument!.typeDefinition!.definitionLinkSupport, true);
 	assert.equal(params.capabilities.textDocument!.rename!.prepareSupport, true);
 	let valueSet = params.capabilities.textDocument!.completion!.completionItemKind!.valueSet!;
 	assert.equal(valueSet[0], 1);

--- a/client/src/test/servers/testInitializeResult.ts
+++ b/client/src/test/servers/testInitializeResult.ts
@@ -24,9 +24,9 @@ connection.onInitialize((params: InitializeParams): any => {
 	assert.equal(params.capabilities.workspace!.workspaceEdit!.failureHandling, FailureHandlingKind.TextOnlyTransactional);
 	assert.equal(params.capabilities.textDocument!.completion!.completionItem!.deprecatedSupport, true);
 	assert.equal(params.capabilities.textDocument!.completion!.completionItem!.preselectSupport, true);
-	assert.equal(params.capabilities.textDocument!.definition!.definitionLinkSupport, true);
-	assert.equal(params.capabilities.textDocument!.implementation!.definitionLinkSupport, true);
-	assert.equal(params.capabilities.textDocument!.typeDefinition!.definitionLinkSupport, true);
+	assert.equal(params.capabilities.textDocument!.definition!.locationLinkSupport, true);
+	assert.equal(params.capabilities.textDocument!.implementation!.locationLinkSupport, true);
+	assert.equal(params.capabilities.textDocument!.typeDefinition!.locationLinkSupport, true);
 	assert.equal(params.capabilities.textDocument!.rename!.prepareSupport, true);
 	let valueSet = params.capabilities.textDocument!.completion!.completionItemKind!.valueSet!;
 	assert.equal(valueSet[0], 1);

--- a/client/src/typeDefinition.ts
+++ b/client/src/typeDefinition.ts
@@ -40,7 +40,7 @@ export class TypeDefinitionFeature extends TextDocumentFeature<TextDocumentRegis
 		ensure(ensure(capabilites, 'textDocument')!, 'typeDefinition')!.dynamicRegistration = true;
 		let typeDefinitionSupport = ensure(ensure(capabilites, 'textDocument')!, 'typeDefinition')!;
 		typeDefinitionSupport.dynamicRegistration = true;
-		typeDefinitionSupport.definitionLinkSupport = true;
+		typeDefinitionSupport.locationLinkSupport = true;
 	}
 
 	public initialize(capabilities: ServerCapabilities, documentSelector: DocumentSelector): void {

--- a/client/src/typeDefinition.ts
+++ b/client/src/typeDefinition.ts
@@ -7,7 +7,7 @@
 import * as UUID from './utils/uuid';
 import * as Is from  './utils/is';
 
-import { languages as Languages, Disposable, TextDocument, ProviderResult, Position as VPosition, Definition as VDefinition } from 'vscode';
+import { languages as Languages, Disposable, TextDocument, ProviderResult, Position as VPosition, Definition as VDefinition, DefinitionLink as VDefinitionLink } from 'vscode';
 
 import {
 	ClientCapabilities, CancellationToken, ServerCapabilities, TextDocumentRegistrationOptions, DocumentSelector, TypeDefinitionRequest
@@ -23,11 +23,11 @@ function ensure<T, K extends keyof T>(target: T, key: K): T[K] {
 }
 
 export interface ProvideTypeDefinitionSignature {
-	(document: TextDocument, position: VPosition, token: CancellationToken): ProviderResult<VDefinition>;
+	(document: TextDocument, position: VPosition, token: CancellationToken): ProviderResult<VDefinition | VDefinitionLink[]>;
 }
 
 export interface TypeDefinitionMiddleware {
-	provideTypeDefinition?: (this: void, document: TextDocument, position: VPosition, token: CancellationToken, next: ProvideTypeDefinitionSignature) => ProviderResult<VDefinition>;
+	provideTypeDefinition?: (this: void, document: TextDocument, position: VPosition, token: CancellationToken, next: ProvideTypeDefinitionSignature) => ProviderResult<VDefinition | VDefinitionLink[]>;
 }
 
 export class TypeDefinitionFeature extends TextDocumentFeature<TextDocumentRegistrationOptions> {
@@ -38,6 +38,9 @@ export class TypeDefinitionFeature extends TextDocumentFeature<TextDocumentRegis
 
 	public fillClientCapabilities(capabilites: ClientCapabilities): void {
 		ensure(ensure(capabilites, 'textDocument')!, 'typeDefinition')!.dynamicRegistration = true;
+		let typeDefinitionSupport = ensure(ensure(capabilites, 'textDocument')!, 'typeDefinition')!;
+		typeDefinitionSupport.dynamicRegistration = true;
+		typeDefinitionSupport.definitionLinkSupport = true;
 	}
 
 	public initialize(capabilities: ServerCapabilities, documentSelector: DocumentSelector): void {
@@ -78,7 +81,7 @@ export class TypeDefinitionFeature extends TextDocumentFeature<TextDocumentRegis
 		};
 		let middleware = client.clientOptions.middleware!;
 		return Languages.registerTypeDefinitionProvider(options.documentSelector!, {
-			provideTypeDefinition: (document: TextDocument, position: VPosition, token: CancellationToken): ProviderResult<VDefinition> => {
+			provideTypeDefinition: (document: TextDocument, position: VPosition, token: CancellationToken): ProviderResult<VDefinition | VDefinitionLink[]> => {
 				return middleware.provideTypeDefinition
 					? middleware.provideTypeDefinition(document, position, token, provideTypeDefinition)
 					: provideTypeDefinition(document, position, token);

--- a/protocol/src/protocol.implementation.ts
+++ b/protocol/src/protocol.implementation.ts
@@ -23,6 +23,11 @@ export interface ImplementationClientCapabilities {
 			 * return value for the corresponding server capability as well.
 			 */
 			dynamicRegistration?: boolean;
+
+			/**
+			 * The client supports additional metadata in the form of definition links.
+			 */
+			definitionLinkSupport?: boolean;
 		};
 	}
 }

--- a/protocol/src/protocol.implementation.ts
+++ b/protocol/src/protocol.implementation.ts
@@ -25,9 +25,9 @@ export interface ImplementationClientCapabilities {
 			dynamicRegistration?: boolean;
 
 			/**
-			 * The client supports additional metadata in the form of definition links.
+			 * The client supports additional metadata in the form of location links.
 			 */
-			definitionLinkSupport?: boolean;
+			locationLinkSupport?: boolean;
 		};
 	}
 }

--- a/protocol/src/protocol.ts
+++ b/protocol/src/protocol.ts
@@ -529,6 +529,11 @@ export interface TextDocumentClientCapabilities {
 		 * Whether definition supports dynamic registration.
 		 */
 		dynamicRegistration?: boolean;
+
+		/**
+		 * The client supports additional metadata in the form of definition links.
+		 */
+		definitionLinkSupport?: boolean;
 	};
 
 	/**

--- a/protocol/src/protocol.ts
+++ b/protocol/src/protocol.ts
@@ -13,7 +13,7 @@ import {
 	TextEdit, WorkspaceEdit, WorkspaceSymbolParams,
 	TextDocumentIdentifier, VersionedTextDocumentIdentifier, TextDocumentItem, TextDocumentSaveReason,
 	CompletionItem, CompletionList, Hover, SignatureHelp,
-	Definition, ReferenceContext, DocumentHighlight, DocumentSymbolParams,
+	Definition, LocationLink, ReferenceContext, DocumentHighlight, DocumentSymbolParams,
 	SymbolInformation, CodeLens, CodeActionContext, FormattingOptions, DocumentLink, MarkupKind,
 	SymbolKind, CompletionItemKind, CodeAction, CodeActionKind, DocumentSymbol
 } from 'vscode-languageserver-types';
@@ -531,9 +531,9 @@ export interface TextDocumentClientCapabilities {
 		dynamicRegistration?: boolean;
 
 		/**
-		 * The client supports additional metadata in the form of definition links.
+		 * The client supports additional metadata in the form of location links.
 		 */
-		definitionLinkSupport?: boolean;
+		locationLinkSupport?: boolean;
 	};
 
 	/**
@@ -1569,11 +1569,12 @@ export namespace SignatureHelpRequest {
 /**
  * A request to resolve the definition location of a symbol at a given text
  * document position. The request's parameter is of type [TextDocumentPosition]
- * (#TextDocumentPosition) the response is of type [Definition](#Definition) or a
- * Thenable that resolves to such.
+ * (#TextDocumentPosition) the response is of either type [Definition](#Definition)
+ * or a typed array of [LocationLinks](#LocationLink) or a Thenable that resolves
+ * to such.
  */
 export namespace DefinitionRequest {
-	export const type = new RequestType<TextDocumentPositionParams, Definition | null, void, TextDocumentRegistrationOptions>('textDocument/definition');
+	export const type = new RequestType<TextDocumentPositionParams, Definition | LocationLink[] | null, void, TextDocumentRegistrationOptions>('textDocument/definition');
 }
 
 //---- Reference Provider ----------------------------------

--- a/protocol/src/protocol.typeDefinition.ts
+++ b/protocol/src/protocol.typeDefinition.ts
@@ -25,9 +25,9 @@ export interface TypeDefinitionClientCapabilities {
 			dynamicRegistration?: boolean;
 
 			/**
-			 * The client supports additional metadata in the form of definition links.
+			 * The client supports additional metadata in the form of location links.
 			 */
-			definitionLinkSupport?: boolean;
+			locationLinkSupport?: boolean;
 		};
 	}
 }

--- a/protocol/src/protocol.typeDefinition.ts
+++ b/protocol/src/protocol.typeDefinition.ts
@@ -23,6 +23,11 @@ export interface TypeDefinitionClientCapabilities {
 			 * return value for the corresponding server capability as well.
 			 */
 			dynamicRegistration?: boolean;
+
+			/**
+			 * The client supports additional metadata in the form of definition links.
+			 */
+			definitionLinkSupport?: boolean;
 		};
 	}
 }

--- a/types/src/main.ts
+++ b/types/src/main.ts
@@ -150,6 +150,46 @@ export namespace Location {
 }
 
 /**
+ * Represents the range and location of where a symbol is defined.
+ * Also includes information about the originating source.
+ */
+export interface DefinitionLink {
+	targetUri: string;
+	targetRange: Range;
+	targetSelectionRange?: Range;
+	originSelectionRange?: Range;
+}
+
+/**
+ * The DefinitionLink namespace provides helper functions to work with
+ * [DefinitionLink](#DefinitionLink) literals.
+ */
+export namespace DefinitionLink {
+
+	/**
+	 * Creates a DefinitionLink literal.
+	 * @param targetUri The definition's uri.
+	 * @param targetRange The full range of the definition.
+	 * @param targetSelectionRange The span of the symbol definition at the target.
+	 * @param originSelectionRange The span of the symbol being defined in the originating source file.
+	 */
+	export function create(targetUri: string, targetRange: Range, targetSelectionRange?: Range, originSelectionRange?: Range): DefinitionLink {
+		return { targetUri, targetRange, targetSelectionRange, originSelectionRange };
+	}
+
+	/**
+	 * Checks whether the given literal conforms to the [DefinitionLink](#DefinitionLink) interface.
+	 */
+	export function is(value: any): value is DefinitionLink {
+		let candidate = value as DefinitionLink;
+		return Range.is(candidate.targetRange) && Is.defined(candidate)
+			&& Is.string(candidate.targetUri) && Is.defined(candidate.targetUri)
+			&& (Range.is(candidate.targetSelectionRange) || Is.undefined(candidate.targetSelectionRange))
+			&& (Range.is(candidate.originSelectionRange) || Is.undefined(candidate.originSelectionRange));
+	}
+}
+
+/**
  * Represents a color in RGBA space.
  */
 export interface Color {
@@ -1656,7 +1696,7 @@ export interface SignatureHelp {
  * For most programming languages there is only one location at which a symbol is
  * defined. If no definition can be found `null` is returned.
  */
-export type Definition = Location | Location[] | null;
+export type Definition = Location | Location[] | DefinitionLink | DefinitionLink[] | null;
 
 /**
  * Value-object that contains additional information when

--- a/types/src/main.ts
+++ b/types/src/main.ts
@@ -153,7 +153,7 @@ export namespace Location {
  * Represents the range and location of where a symbol is defined.
  * Also includes information about the originating source.
  */
-export interface DefinitionLink {
+export interface LocationLink {
 	targetUri: string;
 	targetRange: Range;
 	targetSelectionRange?: Range;
@@ -161,27 +161,27 @@ export interface DefinitionLink {
 }
 
 /**
- * The DefinitionLink namespace provides helper functions to work with
- * [DefinitionLink](#DefinitionLink) literals.
+ * The LocationLink namespace provides helper functions to work with
+ * [LocationLink](#LocationLink) literals.
  */
-export namespace DefinitionLink {
+export namespace LocationLink {
 
 	/**
-	 * Creates a DefinitionLink literal.
+	 * Creates a LocationLink literal.
 	 * @param targetUri The definition's uri.
 	 * @param targetRange The full range of the definition.
 	 * @param targetSelectionRange The span of the symbol definition at the target.
 	 * @param originSelectionRange The span of the symbol being defined in the originating source file.
 	 */
-	export function create(targetUri: string, targetRange: Range, targetSelectionRange?: Range, originSelectionRange?: Range): DefinitionLink {
+	export function create(targetUri: string, targetRange: Range, targetSelectionRange?: Range, originSelectionRange?: Range): LocationLink {
 		return { targetUri, targetRange, targetSelectionRange, originSelectionRange };
 	}
 
 	/**
-	 * Checks whether the given literal conforms to the [DefinitionLink](#DefinitionLink) interface.
+	 * Checks whether the given literal conforms to the [LocationLink](#LocationLink) interface.
 	 */
-	export function is(value: any): value is DefinitionLink {
-		let candidate = value as DefinitionLink;
+	export function is(value: any): value is LocationLink {
+		let candidate = value as LocationLink;
 		return Range.is(candidate.targetRange) && Is.defined(candidate)
 			&& Is.string(candidate.targetUri) && Is.defined(candidate.targetUri)
 			&& (Range.is(candidate.targetSelectionRange) || Is.undefined(candidate.targetSelectionRange))

--- a/types/src/main.ts
+++ b/types/src/main.ts
@@ -1696,7 +1696,7 @@ export interface SignatureHelp {
  * For most programming languages there is only one location at which a symbol is
  * defined. If no definition can be found `null` is returned.
  */
-export type Definition = Location | Location[] | DefinitionLink | DefinitionLink[] | null;
+export type Definition = Location | Location[] | null;
 
 /**
  * Value-object that contains additional information when

--- a/types/src/main.ts
+++ b/types/src/main.ts
@@ -1695,6 +1695,9 @@ export interface SignatureHelp {
  * The definition of a symbol represented as one or many [locations](#Location).
  * For most programming languages there is only one location at which a symbol is
  * defined. If no definition can be found `null` is returned.
+ *
+ * @deprecated This type has been deprecated in favour of
+ * [LocationLink](#LocationLink).
  */
 export type Definition = Location | Location[] | null;
 


### PR DESCRIPTION
I've updated `textDocument/definition`, `textDocument/implementation`, and `textDocument/typeDefinition`, to potentially return a `DefinitionLink`. This new interface includes metadata about the ranges of both the originating source symbol and the target symbol. This will help provide more context to the user while navigating between different symbols in an editor.

For example, instead of simply highlighting a word, the editor can now understand that the source symbol's range extends beyond standard word boundaries. This will allow it to highlight/underline stuff like an entire `java.util.List` in a Java `import` statement.

This implements Microsoft/language-server-protocol#524.