### PR TITLE
Added an optional `uri` property to the `DocumentSymbol`.

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -365,7 +365,7 @@
 		},
 		"event-stream": {
 			"version": "3.3.4",
-			"resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+			"resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
 			"integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
 			"dev": true,
 			"requires": {

--- a/types/src/main.ts
+++ b/types/src/main.ts
@@ -1870,6 +1870,16 @@ export class DocumentSymbol {
 	 * Children of this symbol, e.g. properties of a class.
 	 */
 	children?: DocumentSymbol[];
+
+	/**
+	 * The URI of the text document this symbol belongs to. Can be set by the language server,
+	 * if the URI of the text document is not available or cannot be inferred from the request context.
+	 *
+	 * If not defined, it can be inferred from the context of the request. For example, when calling the
+	 * `textDocument/documentSymbol` method, the `DocumentUri` (`string`) can be inferred from the request
+	 * parameter: `DocumentSymbolParams.textDocument.uri`.
+	 */
+	uri?: string;
 }
 
 export namespace DocumentSymbol {


### PR DESCRIPTION
Clients can use this when the URI of the text document
cannot be inferred from the request context.

Issue: https://github.com/Microsoft/language-server-protocol/issues/582

Signed-off-by: Akos Kitta <kittaakos@typefox.io>