### PR TITLE
Update version in lockfile to match package.json

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "vscode-languageclient",
-	"version": "5.1.0",
+	"version": "5.1.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {


### PR DESCRIPTION
Spotted while running `npm install` in local development. npm automatically syncs the `package.json` and the lockfile, which creates this change.

The 5.1.1 version bump is from 9c26d2b58a441698a8e7790ce46c667dc4e2e199.