### PR TITLE
Add support for url attribute of Diagnostic API

### DIFF
--- a/client/src/codeConverter.ts
+++ b/client/src/codeConverter.ts
@@ -266,6 +266,7 @@ export function createConverter(uriConverter?: URIConverter): Converter {
 		let result: proto.Diagnostic = proto.Diagnostic.create(asRange(item.range), item.message);
 		if (Is.number(item.severity)) { result.severity = asDiagnosticSeverity(item.severity); }
 		if (Is.number(item.code) || Is.string(item.code)) { result.code = item.code; }
+		if (Is.string(item.url)) { result.url = item.url; }
 		if (item.source) { result.source = item.source; }
 		return result;
 	}

--- a/client/src/protocolConverter.ts
+++ b/client/src/protocolConverter.ts
@@ -185,6 +185,7 @@ export function createConverter(uriConverter?: URIConverter): Converter {
 	function asDiagnostic(diagnostic: ls.Diagnostic): code.Diagnostic {
 		let result = new code.Diagnostic(asRange(diagnostic.range), diagnostic.message, asDiagnosticSeverity(diagnostic.severity));
 		if (Is.number(diagnostic.code) || Is.string(diagnostic.code)) { result.code = diagnostic.code; }
+		if (Is.string(diagnostic.url)) { result.url = diagnostic.url; }
 		if (diagnostic.source) { result.source = diagnostic.source; }
 		if (diagnostic.relatedInformation) { result.relatedInformation = asRelatedInformation(diagnostic.relatedInformation); }
 		return result;

--- a/client/src/test/converter.test.ts
+++ b/client/src/test/converter.test.ts
@@ -68,6 +68,7 @@ suite('Protocol Converter', () => {
 			message: 'error',
 			severity: proto.DiagnosticSeverity.Error,
 			code: 99,
+			url: 'https://www.example.com/',
 			source: 'source'
 		};
 
@@ -79,6 +80,7 @@ suite('Protocol Converter', () => {
 		strictEqual(range.end.character, end.character);
 		strictEqual(result.message, diagnostic.message);
 		strictEqual(result.code, diagnostic.code);
+		strictEqual(result.url, diagnostic.url);
 		strictEqual(result.source, diagnostic.source);
 		strictEqual(result.severity, vscode.DiagnosticSeverity.Error);
 
@@ -802,6 +804,7 @@ suite('Code Converter', () => {
 	test('Diagnostic', () => {
 		let item: vscode.Diagnostic = new vscode.Diagnostic(new vscode.Range(1, 2, 8, 9), "message", vscode.DiagnosticSeverity.Warning);
 		item.code = 99;
+		item.url = 'https://www.example.com/';
 		item.source = 'source';
 
 		let result = c2p.asDiagnostic(<any>item);
@@ -809,6 +812,7 @@ suite('Code Converter', () => {
 		strictEqual(result.message, item.message);
 		strictEqual(result.severity, proto.DiagnosticSeverity.Warning);
 		strictEqual(result.code, item.code);
+		strictEqual(result.url, item.url);
 		strictEqual(result.source, item.source);
 		ok(c2p.asDiagnostics(<any>[item]).every(elem => proto.Diagnostic.is(elem)));
 	});

--- a/client/src/test/helpers.test.ts
+++ b/client/src/test/helpers.test.ts
@@ -78,12 +78,13 @@ suite('Protocol Helper Tests', () => {
 	});
 
 	test('Diagnostic', () => {
-		let diagnostic = Diagnostic.create(Range.create(1,2,8,9), 'message', DiagnosticSeverity.Warning, 99, 'source');
+		let diagnostic = Diagnostic.create(Range.create(1,2,8,9), 'message', DiagnosticSeverity.Warning, 99, 'source', 'https://www.example.com/');
 		ok(Range.is(diagnostic.range));
 		strictEqual(diagnostic.message, 'message');
 		strictEqual(diagnostic.severity, DiagnosticSeverity.Warning);
 		strictEqual(diagnostic.code, 99);
 		strictEqual(diagnostic.source, 'source');
+		strictEqual(diagnostic.url, 'https://www.example.com/');
 	});
 
 	test('Command', () => {

--- a/types/src/main.ts
+++ b/types/src/main.ts
@@ -467,6 +467,11 @@ export interface Diagnostic {
 	code?: number | string;
 
 	/**
+	 * A HTTP URL to a resource explaining the diagnostic.
+	 */
+	url?: string;
+
+	/**
 	 * A human-readable string describing the source of this
 	 * diagnostic, e.g. 'typescript' or 'super lint'.
 	 */
@@ -492,13 +497,16 @@ export namespace Diagnostic {
 	/**
 	 * Creates a new Diagnostic literal.
 	 */
-	export function create(range: Range, message: string, severity?: DiagnosticSeverity, code?: number | string, source?: string, relatedInformation?: DiagnosticRelatedInformation[]): Diagnostic {
+	export function create(range: Range, message: string, severity?: DiagnosticSeverity, code?: number | string, source?: string, url?: string, relatedInformation?: DiagnosticRelatedInformation[]): Diagnostic {
 		let result: Diagnostic = { range, message };
 		if (Is.defined(severity)) {
 			result.severity = severity;
 		}
 		if (Is.defined(code)) {
 			result.code = code;
+		}
+		if (Is.defined(url)) {
+			result.url = url;
 		}
 		if (Is.defined(source)) {
 			result.source = source;
@@ -519,6 +527,7 @@ export namespace Diagnostic {
 			&& Is.string(candidate.message)
 			&& (Is.number(candidate.severity) || Is.undefined(candidate.severity))
 			&& (Is.number(candidate.code) || Is.string(candidate.code) || Is.undefined(candidate.code))
+			&& (Is.number(candidate.url) || Is.string(candidate.url) || Is.undefined(candidate.url))
 			&& (Is.string(candidate.source) || Is.undefined(candidate.source))
 			&& (Is.undefined(candidate.relatedInformation) || Is.typedArray<DiagnosticRelatedInformation>(candidate.relatedInformation, DiagnosticRelatedInformation.is));
 	}


### PR DESCRIPTION
See https://github.com/Microsoft/vscode/pull/61436. This adds support for the new `url` attribute of Diagnostic objects in the converters, so they can be forwarded to extensions using language servers like `vscode-eslint` (https://github.com/Microsoft/vscode-eslint/pull/562).

Edit: as far as I can see, the CI failure is because the Diagnostic `url` doesn't exist _yet_.