### PR TITLE
Add repository.directory field to package.json

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -9,7 +9,8 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/Microsoft/vscode-languageserver-node.git"
+		"url": "https://github.com/Microsoft/vscode-languageserver-node.git",
+		"directory": "client"
 	},
 	"bugs": {
 		"url": "https://github.com/Microsoft/vscode-languageserver-node/issues"

--- a/jsonrpc/package.json
+++ b/jsonrpc/package.json
@@ -6,7 +6,8 @@
 	"license": "MIT",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/Microsoft/vscode-languageserver-node.git"
+		"url": "https://github.com/Microsoft/vscode-languageserver-node.git",
+		"directory": "jsonrpc"
 	},
 	"bugs": {
 		"url": "https://github.com/Microsoft/vscode-languageserver-node/issues"

--- a/protocol/package.json
+++ b/protocol/package.json
@@ -6,7 +6,8 @@
 	"license": "MIT",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/Microsoft/vscode-languageserver-node.git"
+		"url": "https://github.com/Microsoft/vscode-languageserver-node.git",
+		"directory": "protocol"
 	},
 	"bugs": {
 		"url": "https://github.com/Microsoft/vscode-languageserver-node/issues"

--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,8 @@
 	"license": "MIT",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/Microsoft/vscode-languageserver-node.git"
+		"url": "https://github.com/Microsoft/vscode-languageserver-node.git",
+		"directory": "server"
 	},
 	"bugs": {
 		"url": "https://github.com/Microsoft/vscode-languageserver-node/issues"

--- a/types/package.json
+++ b/types/package.json
@@ -6,7 +6,8 @@
 	"license": "MIT",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/Microsoft/vscode-languageserver-node.git"
+		"url": "https://github.com/Microsoft/vscode-languageserver-node.git",
+		"directory": "types"
 	},
 	"bugs": {
 		"url": "https://github.com/Microsoft/vscode-languageserver-node/issues"


### PR DESCRIPTION
This adds a `directory` field to the `repository` objects in package.json. This is a new field for monorepos specced in this npm RFC: https://github.com/npm/rfcs/blob/d39184cdedc000aa8e60b4d63878b834aa5f0ff0/accepted/0000-monorepo-subdirectory-declaration.md

It enables cross-repository go-to-definition on [Sourcegraph](https://sourcegraph.com), as Sourcegraph can resolve packages to a specific directory in the angular monorepo.
Clients that don't know this field simply ignore it (as with any other arbitrary field in package.json).
