### PR TITLE
Add optional reason for why the client failed to apply an edit

### DIFF
--- a/protocol/src/protocol.ts
+++ b/protocol/src/protocol.ts
@@ -1930,6 +1930,14 @@ export interface ApplyWorkspaceEditResponse {
 	 * Indicates whether the edit was applied or not.
 	 */
 	applied: boolean;
+				    
+	/**
+	 * An optional textual description for why the edit was not applied.
+	 * This may be used may be used by the server for diagnostic
+	 * logging or to provide a suitable error for a request that
+	 * triggered the edit.
+	 */
+	failureReason?: string;
 
 	/**
 	 * Depending on the client's failure handling strategy `failedChange` might


### PR DESCRIPTION
See https://github.com/Microsoft/language-server-protocol/issues/618 and https://github.com/Microsoft/language-server-protocol/pull/637


@dbaeumer 