### PR TITLE
Support using a seperate output channel for trace messages

### DIFF
--- a/client/src/client.ts
+++ b/client/src/client.ts
@@ -2369,7 +2369,6 @@ export abstract class BaseLanguageClient {
 	private _outputChannel: OutputChannel | undefined;
 	private _disposeOutputChannel: boolean;
 	private _traceOutputChannel: OutputChannel | undefined;
-	private _disposeTraceOutputChannel: boolean;
 	private _capabilities: ServerCapabilities & ResolvedTextDocumentSyncCapabilities;
 
 	private _listeners: Disposable[] | undefined;
@@ -2422,14 +2421,7 @@ export abstract class BaseLanguageClient {
 			this._outputChannel = undefined;
 			this._disposeOutputChannel = true;
 		}
-		if (clientOptions.traceOutputChannel) {
-			this._traceOutputChannel = clientOptions.traceOutputChannel;
-			this._disposeTraceOutputChannel = false;
-		} else {
-			this._traceOutputChannel = undefined;
-			this._disposeTraceOutputChannel = true;
-		}
-
+		this._traceOutputChannel = clientOptions.traceOutputChannel;
 		this._listeners = undefined;
 		this._providers = undefined;
 		this._diagnostics = undefined;
@@ -2916,10 +2908,6 @@ export abstract class BaseLanguageClient {
 		if (channel && this._outputChannel && this._disposeOutputChannel) {
 			this._outputChannel.dispose();
 			this._outputChannel = undefined;
-		}
-		if (channel && this._traceOutputChannel && this._disposeTraceOutputChannel) {
-			this._traceOutputChannel.dispose();
-			this._traceOutputChannel = undefined;
 		}
 		if (diagnostics && this._diagnostics) {
 			this._diagnostics.dispose();

--- a/client/src/client.ts
+++ b/client/src/client.ts
@@ -453,7 +453,6 @@ export interface LanguageClientOptions {
 	outputChannel?: OutputChannel;
 	outputChannelName?: string;
 	traceOutputChannel?: OutputChannel;
-	traceOutputChannelName?: string;
 	revealOutputChannelOn?: RevealOutputChannelOn;
 	/**
 	 * The encoding use to read stdout and stderr. Defaults
@@ -476,7 +475,6 @@ interface ResolvedClientOptions {
 	synchronize: SynchronizeOptions;
 	diagnosticCollectionName?: string;
 	outputChannelName: string;
-	traceOutputChannelName?: string;
 	revealOutputChannelOn: RevealOutputChannelOn;
 	stdioEncoding: string;
 	initializationOptions?: any | (() => any);
@@ -1759,19 +1757,19 @@ class CodeActionFeature extends TextDocumentFeature<CodeActionRegistrationOption
 				context: client.code2ProtocolConverter.asCodeActionContext(context)
 			};
 			return client.sendRequest(CodeActionRequest.type, params, token).then((values) => {
-					if (values === null) {
-						return undefined;
-					}
-					let result: (VCommand | VCodeAction)[] = [];
-					for (let item of values) {
-						if (Command.is(item)) {
-							result.push(client.protocol2CodeConverter.asCommand(item))
-						} else {
-							result.push(client.protocol2CodeConverter.asCodeAction(item));
-						};
-					}
-					return result;
-				},
+				if (values === null) {
+					return undefined;
+				}
+				let result: (VCommand | VCodeAction)[] = [];
+				for (let item of values) {
+					if (Command.is(item)) {
+						result.push(client.protocol2CodeConverter.asCommand(item))
+					} else {
+						result.push(client.protocol2CodeConverter.asCodeAction(item));
+					};
+				}
+				return result;
+			},
 				(error) => {
 					client.logFailedRequest(CodeActionRequest.type, error);
 					return Promise.resolve([]);
@@ -1786,8 +1784,8 @@ class CodeActionFeature extends TextDocumentFeature<CodeActionRegistrationOption
 					: provideCodeActions(document, range, context, token);
 			}
 		}, options.codeActionKinds
-			? { providedCodeActionKinds: client.protocol2CodeConverter.asCodeActionKinds(options.codeActionKinds) }
-			: undefined
+				? { providedCodeActionKinds: client.protocol2CodeConverter.asCodeActionKinds(options.codeActionKinds) }
+				: undefined
 		);
 	}
 }
@@ -2042,16 +2040,16 @@ class RenameFeature extends TextDocumentFeature<RenameRegistrationOptions> {
 				position: client.code2ProtocolConverter.asPosition(position),
 			};
 			return client.sendRequest(PrepareRenameRequest.type, params, token).then((result) => {
-					if (Range.is(result)) {
-						return client.protocol2CodeConverter.asRange(result);
-					} else if (result && result.range) {
-						return {
-							range: client.protocol2CodeConverter.asRange(result.range),
-							placeholder: result.placeholder
-						}
+				if (Range.is(result)) {
+					return client.protocol2CodeConverter.asRange(result);
+				} else if (result && result.range) {
+					return {
+						range: client.protocol2CodeConverter.asRange(result.range),
+						placeholder: result.placeholder
 					}
-					return null;
-				},
+				}
+				return null;
+			},
 				(error: ResponseError<void>) => {
 					client.logFailedRequest(PrepareRenameRequest.type, error);
 					return Promise.reject(new Error(error.message));
@@ -2402,7 +2400,6 @@ export abstract class BaseLanguageClient {
 			synchronize: clientOptions.synchronize || {},
 			diagnosticCollectionName: clientOptions.diagnosticCollectionName,
 			outputChannelName: clientOptions.outputChannelName || this._name,
-			traceOutputChannelName: clientOptions.traceOutputChannelName,
 			revealOutputChannelOn: clientOptions.revealOutputChannelOn || RevealOutputChannelOn.Error,
 			stdioEncoding: clientOptions.stdioEncoding || 'utf8',
 			initializationOptions: clientOptions.initializationOptions,
@@ -2580,10 +2577,6 @@ export abstract class BaseLanguageClient {
 
 	public get traceOutputChannel(): OutputChannel {
 		if (this._traceOutputChannel) {
-			return this._traceOutputChannel;
-		}
-		if (this._clientOptions.traceOutputChannelName !== undefined) {
-			this._traceOutputChannel = Window.createOutputChannel(this._clientOptions.traceOutputChannelName);
 			return this._traceOutputChannel;
 		}
 		return this.outputChannel;


### PR DESCRIPTION
This allows setting `traceOutputChannelName` in the `LanguageClientOptions` to use a different output channel. Otherwise, this falls back onto the default output channel. `traceOutputChannel` can also be set directly.

Just a note: The current formatting settings are not actually consistently applied on all of the files, so I have been caught out by format on save whilst creating this PR.

TODO: test this - I couldn't get `npm` to work properly (it was giving me really obtuse error messages) when I tried to install my local copy of the client into an extension. (@matklad, how did you do it?)

TODO: determine if the output channel should be automatically shown. My inclination is to say not, but I'm not sure.