### PR TITLE
Fix configuration not always using resource scope

### DIFF
--- a/client/src/configuration.ts
+++ b/client/src/configuration.ts
@@ -50,7 +50,7 @@ export class ConfigurationFeature implements StaticFeature {
 			if (index === -1) {
 				result = workspace.getConfiguration(undefined, resource).get(section);
 			} else {
-				let config = workspace.getConfiguration(section.substr(0, index));
+				let config = workspace.getConfiguration(section.substr(0, index), resource);
 				if (config) {
 					result = config.get(section.substr(index + 1))
 				}


### PR DESCRIPTION
When requesting a nested configuration section (e.g. `a.b.c`), the configuration returned isn't scoped to the requested uri, although it does so when requesting something like `a`, with no dot inside.