### PR TITLE
Fix client capabilities in window/progress proposed doc

### DIFF
--- a/protocol/src/protocol.progress.proposed.md
+++ b/protocol/src/protocol.progress.proposed.md
@@ -8,11 +8,11 @@ The client sets the following capability if it is supporting notifying task prog
 
 ```ts
 /**
- * Experimental client capabilities.
+ * Window specific client capabilities.
  */
-experimental: {
+window?: {
   /**
-   * The client has support for reporting progress.
+   * Whether client supports handling progress notifications.
    */
   progress?: boolean;
 }


### PR DESCRIPTION
Fixes wrong `ClientCapabilities` extension from #261. 

@dbaeumer by the way, what is the workflow for proposed features? Do they become a part of a regular protocol version but noted that they're unstable and only proposed at the moment?