### PR TITLE
Send workspace folder diff upon listener notification

### DIFF
--- a/client-tests/package-lock.json
+++ b/client-tests/package-lock.json
@@ -4,6 +4,42 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@sinonjs/commons": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.6.0.tgz",
+			"integrity": "sha512-w4/WHG7C4WWFyE5geCieFJF6MZkbW4VAriol5KlmQXpAQdxvV0p26sqNZOW6Qyw6Y0l9K4g+cHvvczR2sEEpqg==",
+			"dev": true,
+			"requires": {
+				"type-detect": "4.0.8"
+			}
+		},
+		"@sinonjs/formatio": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.2.1.tgz",
+			"integrity": "sha512-tsHvOB24rvyvV2+zKMmPkZ7dXX6LSLKZ7aOtXY6Edklp0uRcgGpOsQTTGTcWViFyx4uhWc6GV8QdnALbIbIdeQ==",
+			"dev": true,
+			"requires": {
+				"@sinonjs/commons": "^1",
+				"@sinonjs/samsam": "^3.1.0"
+			}
+		},
+		"@sinonjs/samsam": {
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.3.tgz",
+			"integrity": "sha512-bKCMKZvWIjYD0BLGnNrxVuw4dkWCYsLqFOUWw8VgKF/+5Y+mE7LfHWPIYoDXowH+3a9LsWDMo0uAP8YDosPvHQ==",
+			"dev": true,
+			"requires": {
+				"@sinonjs/commons": "^1.3.0",
+				"array-from": "^2.1.1",
+				"lodash": "^4.17.15"
+			}
+		},
+		"@sinonjs/text-encoding": {
+			"version": "0.7.1",
+			"resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+			"integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+			"dev": true
+		},
 		"@types/events": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
@@ -33,6 +69,18 @@
 			"integrity": "sha512-dyYO+f6ihZEtNPDcWNR1fkoTDf3zAK3lAABDze3mz6POyIercH0lEUawUFXlG8xaQZmm1yEBON/4TsYv/laDYg==",
 			"dev": true
 		},
+		"@types/sinon": {
+			"version": "7.0.13",
+			"resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-7.0.13.tgz",
+			"integrity": "sha512-d7c/C/+H/knZ3L8/cxhicHUiTDxdgap0b/aNJfsmLwFu/iOP17mdgbQsbHA3SJmrzsjD0l3UEE5SN4xxuz5ung==",
+			"dev": true
+		},
+		"@types/vscode": {
+			"version": "1.37.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.37.0.tgz",
+			"integrity": "sha512-PRfeuqYuzk3vjf+puzxltIUWC+AhEGYpFX29/37w30DQSQnpf5AgMVf7GDBAdmTbWTBou+EMFz/Ne6XCM/KxzQ==",
+			"dev": true
+		},
 		"agent-base": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
@@ -41,6 +89,12 @@
 			"requires": {
 				"es6-promisify": "^5.0.0"
 			}
+		},
+		"array-from": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
+			"integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=",
+			"dev": true
 		},
 		"balanced-match": {
 			"version": "1.0.0",
@@ -72,6 +126,12 @@
 			"requires": {
 				"ms": "2.0.0"
 			}
+		},
+		"diff": {
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+			"dev": true
 		},
 		"es6-promise": {
 			"version": "4.2.8",
@@ -107,6 +167,12 @@
 				"once": "^1.3.0",
 				"path-is-absolute": "^1.0.0"
 			}
+		},
+		"has-flag": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+			"dev": true
 		},
 		"http-proxy-agent": {
 			"version": "2.1.0",
@@ -144,6 +210,30 @@
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
 			"dev": true
 		},
+		"isarray": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+			"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+			"dev": true
+		},
+		"just-extend": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.0.2.tgz",
+			"integrity": "sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==",
+			"dev": true
+		},
+		"lodash": {
+			"version": "4.17.15",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+			"dev": true
+		},
+		"lolex": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/lolex/-/lolex-4.2.0.tgz",
+			"integrity": "sha512-gKO5uExCXvSm6zbF562EvM+rd1kQDnB9AZBbiQVzf1ZmdDpxUSvpnAaVOP83N/31mRK8Ml8/VE8DMvsAZQ+7wg==",
+			"dev": true
+		},
 		"minimatch": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -158,6 +248,19 @@
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
 			"dev": true
+		},
+		"nise": {
+			"version": "1.5.2",
+			"resolved": "https://registry.npmjs.org/nise/-/nise-1.5.2.tgz",
+			"integrity": "sha512-/6RhOUlicRCbE9s+94qCUsyE+pKlVJ5AhIv+jEE7ESKwnbXqulKZ1FYU+XAtHHWE9TinYvAxDUJAb912PwPoWA==",
+			"dev": true,
+			"requires": {
+				"@sinonjs/formatio": "^3.2.1",
+				"@sinonjs/text-encoding": "^0.7.1",
+				"just-extend": "^4.0.2",
+				"lolex": "^4.1.0",
+				"path-to-regexp": "^1.7.0"
+			}
 		},
 		"once": {
 			"version": "1.4.0",
@@ -174,6 +277,15 @@
 			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
 			"dev": true
 		},
+		"path-to-regexp": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+			"integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+			"dev": true,
+			"requires": {
+				"isarray": "0.0.1"
+			}
+		},
 		"rimraf": {
 			"version": "2.7.1",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
@@ -182,6 +294,36 @@
 			"requires": {
 				"glob": "^7.1.3"
 			}
+		},
+		"sinon": {
+			"version": "7.4.1",
+			"resolved": "https://registry.npmjs.org/sinon/-/sinon-7.4.1.tgz",
+			"integrity": "sha512-7s9buHGHN/jqoy/v4bJgmt0m1XEkCEd/tqdHXumpBp0JSujaT4Ng84JU5wDdK4E85ZMq78NuDe0I3NAqXY8TFg==",
+			"dev": true,
+			"requires": {
+				"@sinonjs/commons": "^1.4.0",
+				"@sinonjs/formatio": "^3.2.1",
+				"@sinonjs/samsam": "^3.3.2",
+				"diff": "^3.5.0",
+				"lolex": "^4.2.0",
+				"nise": "^1.5.1",
+				"supports-color": "^5.5.0"
+			}
+		},
+		"supports-color": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+			"dev": true,
+			"requires": {
+				"has-flag": "^3.0.0"
+			}
+		},
+		"type-detect": {
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+			"dev": true
 		},
 		"vscode-jsonrpc": {
 			"version": "4.1.0-next.3",

--- a/client-tests/package.json
+++ b/client-tests/package.json
@@ -27,6 +27,9 @@
 	"devDependencies": {
 		"vscode-test": "^1.2.0",
 		"glob": "^7.1.4",
-		"@types/glob": "^7.1.1"
+		"@types/glob": "^7.1.1",
+		"@types/sinon": "^7.0.13",
+		"@types/vscode": "^1.37.0",
+		"sinon": "7.4.1"
 	}
 }

--- a/client-tests/src/workspaceFolders.test.ts
+++ b/client-tests/src/workspaceFolders.test.ts
@@ -1,0 +1,103 @@
+'use strict';
+
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import * as sinon from 'sinon';
+import { WorkspaceFoldersFeature } from 'vscode-languageclient/lib/workspaceFolders';
+import { BaseLanguageClient, MessageTransports, DidChangeWorkspaceFoldersParams } from 'vscode-languageclient';
+import * as proto from 'vscode-languageserver-protocol';
+
+class TestLanguageClient extends BaseLanguageClient {
+	protected createMessageTransports(): Thenable<MessageTransports> {
+		throw new Error('Method not implemented.');
+	}
+	onRequest() {
+	}
+}
+
+type MaybeFolders = vscode.WorkspaceFolder[] | undefined;
+
+class TestWorkspaceFoldersFeature extends WorkspaceFoldersFeature {
+	public sendInitialEvent(currentWorkspaceFolders: MaybeFolders): void {
+		super.sendInitialEvent(currentWorkspaceFolders);
+	}
+
+	public initializeWithFolders(currentWorkspaceFolders: MaybeFolders) {
+		super.initializeWithFolders(currentWorkspaceFolders);
+	}
+}
+
+function testEvent(initial: MaybeFolders, then: MaybeFolders, added: proto.WorkspaceFolder[], removed: proto.WorkspaceFolder[]) {
+	const client = new TestLanguageClient('foo', 'bar', {});
+
+	const send = sinon.spy();
+	sinon.replace(client, 'sendNotification', send);
+
+	const feature = new TestWorkspaceFoldersFeature(client);
+
+	feature.initializeWithFolders(initial);
+	feature.sendInitialEvent(then);
+
+	assert.equal(send.callCount, 1, 'call count wrong');
+	assert.equal(send.args[0].length, 2);
+
+	const notification: DidChangeWorkspaceFoldersParams = send.args[0][1];
+	assert.deepEqual(notification.event.added, added);
+	assert.deepEqual(notification.event.removed, removed);
+}
+
+function testNoEvent(initial: MaybeFolders, then: MaybeFolders) {
+	const client = new TestLanguageClient('foo', 'bar', {});
+
+	const send = sinon.spy();
+	sinon.replace(client, 'sendNotification', send);
+
+	const feature = new TestWorkspaceFoldersFeature(client);
+
+	feature.initializeWithFolders(initial);
+	feature.sendInitialEvent(then);
+
+	assert.equal(send.callCount, 0, 'call count wrong');
+}
+
+suite('Workspace Folder Feature Tests', () => {
+	const removedFolder = { uri: vscode.Uri.parse('file://xox/removed'), name: 'removedName', index: 0 };
+	const addedFolder = { uri: vscode.Uri.parse('file://foo/added'), name: 'addedName', index: 0 };
+	const addedProto = { uri: 'file://foo/added', name: 'addedName' };
+	const removedProto = { uri: 'file://xox/removed', name: 'removedName' };
+
+	test('remove/add', async () => {
+		testEvent([removedFolder], [addedFolder], [addedProto], [removedProto]);
+	});
+
+	test('remove', async () => {
+		testEvent([removedFolder], [], [], [removedProto]);
+	});
+
+	test('remove2', async () => {
+		testEvent([removedFolder], undefined, [], [removedProto]);
+	});
+
+	test('add', async () => {
+		testEvent([], [addedFolder], [addedProto], []);
+	});
+
+	test('add2', async () => {
+		testEvent(undefined, [addedFolder], [addedProto], []);
+	});
+
+	test('noChange1', async () => {
+		testNoEvent([addedFolder, removedFolder], [addedFolder, removedFolder]);
+	});
+
+	test('noChange2', async () => {
+		testNoEvent([], []);
+	});
+
+	test('noChange3', async () => {
+		testNoEvent(undefined, undefined);
+	});
+});
+
+
+

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -89,7 +89,7 @@
 		"minimatch": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
 			"dev": true,
 			"requires": {
 				"brace-expansion": "^1.1.7"

--- a/client/src/workspaceFolders.ts
+++ b/client/src/workspaceFolders.ts
@@ -92,7 +92,6 @@ export class WorkspaceFoldersFeature implements DynamicFeature<undefined> {
 				id: id,
 				registerOptions: undefined
 			});
-			this.sendInitialEvent(workspace.workspaceFolders);
 		}
 	}
 
@@ -133,6 +132,7 @@ export class WorkspaceFoldersFeature implements DynamicFeature<undefined> {
 				: didChangeWorkspaceFolders(event);
 		});
 		this._listeners.set(id, disposable);
+		this.sendInitialEvent(workspace.workspaceFolders);
 	}
 
 	public unregister(id: string): void {

--- a/client/src/workspaceFolders.ts
+++ b/client/src/workspaceFolders.ts
@@ -21,6 +21,10 @@ function access<T, K extends keyof T>(target: T | undefined, key: K): T[K] | und
 	return target[key];
 }
 
+export function arrayDiff<T>(left: T[], right: T[]): T[] {
+	return left.filter(element => right.indexOf(element) < 0);
+}
+
 export interface WorkspaceFolderWorkspaceMiddleware {
 	workspaceFolders?: WorkspaceFoldersRequest.MiddlewareSignature;
 	didChangeWorkspaceFolders?: NextSignature<VWorkspaceFoldersChangeEvent, void>
@@ -29,6 +33,7 @@ export interface WorkspaceFolderWorkspaceMiddleware {
 export class WorkspaceFoldersFeature implements DynamicFeature<undefined> {
 
 	private _listeners: Map<string, Disposable> = new Map<string, Disposable>();
+	private _initialFolders: VWorkspaceFolder[] | undefined;
 
 	constructor(private _client: BaseLanguageClient) {
 	}
@@ -39,12 +44,17 @@ export class WorkspaceFoldersFeature implements DynamicFeature<undefined> {
 
 	public fillInitializeParams(params: InitializeParams): void {
 		let folders = workspace.workspaceFolders;
+		this.initializeWithFolders(folders);
 
 		if (folders === void 0) {
 			params.workspaceFolders = null;
 		} else {
 			params.workspaceFolders = folders.map(folder => this.asProtocol(folder));
 		}
+	}
+
+	protected initializeWithFolders(currentWorkspaceFolders: VWorkspaceFolder[] | undefined) {
+		this._initialFolders = currentWorkspaceFolders;
 	}
 
 	public fillClientCapabilities(capabilities: ClientCapabilities): void {
@@ -82,7 +92,32 @@ export class WorkspaceFoldersFeature implements DynamicFeature<undefined> {
 				id: id,
 				registerOptions: undefined
 			});
+			this.sendInitialEvent(workspace.workspaceFolders);
 		}
+	}
+
+	protected sendInitialEvent(currentWorkspaceFolders: VWorkspaceFolder[] | undefined) {
+		if (this._initialFolders && currentWorkspaceFolders) {
+			const removed: VWorkspaceFolder[] = arrayDiff(this._initialFolders, currentWorkspaceFolders);
+			const added: VWorkspaceFolder[] = arrayDiff(currentWorkspaceFolders, this._initialFolders);
+			if (added.length > 0 || removed.length > 0) {
+				this.doSendEvent(added, removed);
+			}
+		} else if (this._initialFolders) {
+			this.doSendEvent([], this._initialFolders);
+		} else if (currentWorkspaceFolders) {
+			this.doSendEvent(currentWorkspaceFolders, []);
+		}
+	}
+
+	private doSendEvent(addedFolders: ReadonlyArray<VWorkspaceFolder>, removedFolders: ReadonlyArray<VWorkspaceFolder>) {
+		let params: DidChangeWorkspaceFoldersParams = {
+			event: {
+				added: addedFolders.map(folder => this.asProtocol(folder)),
+				removed: removedFolders.map(folder => this.asProtocol(folder))
+			}
+		};
+		this._client.sendNotification(DidChangeWorkspaceFoldersNotification.type, params);
 	}
 
 	public register(_message: RPCMessageType, data: RegistrationData<undefined>): void {
@@ -90,13 +125,7 @@ export class WorkspaceFoldersFeature implements DynamicFeature<undefined> {
 		let client = this._client;
 		let disposable = workspace.onDidChangeWorkspaceFolders((event) => {
 			let didChangeWorkspaceFolders = (event: VWorkspaceFoldersChangeEvent) => {
-				let params: DidChangeWorkspaceFoldersParams = {
-					event: {
-						added: event.added.map(folder => this.asProtocol(folder)),
-						removed: event.removed.map(folder => this.asProtocol(folder))
-					}
-				};
-				this._client.sendNotification(DidChangeWorkspaceFoldersNotification.type, params);
+				this.doSendEvent(event.added, event.removed);
 			};
 			let middleware = client.clientOptions.middleware!.workspace;
 			middleware && middleware.didChangeWorkspaceFolders


### PR DESCRIPTION
This is a fix for 

Workspace folder changes are not sent to the server if they occur during initialisation #451

The gist of the fix is to remember the workspace folders sent to a language server during the "initialize" call and then send the diff between that state and the current WS folders when registering the workspace change listener.

Signed-off-by: Thomas Mäder <tmader@redhat.com>