### PR TITLE
fix DidSaveTextDocumentParams.textDocument comment

### DIFF
--- a/protocol/src/protocol.ts
+++ b/protocol/src/protocol.ts
@@ -1149,7 +1149,7 @@ export namespace DidCloseTextDocumentNotification {
  */
 export interface DidSaveTextDocumentParams {
 	/**
-	 * The document that was closed.
+	 * The document that was saved.
 	 */
 	textDocument: VersionedTextDocumentIdentifier;
 


### PR DESCRIPTION
Fixes small typo in DidSaveTextDocumentParams.textDocument comment.