### PR TITLE
remove update from types

### DIFF
--- a/textDocument/src/main.ts
+++ b/textDocument/src/main.ts
@@ -174,14 +174,6 @@ export interface TextDocument {
 	offsetAt(position: Position): number;
 
 	/**
-	 * Updates the text document to a new state using the provided change events.
-	 *
-	 * @param changes the text document changes
-	 * @param version the version number after all changes have been applied
-	 */
-	update(changes: TextDocumentContentChangeEvent[], version: number): void;
-
-	/**
 	 * The number of lines in this document.
 	 *
 	 * @readonly
@@ -343,7 +335,7 @@ export namespace TextDocument {
 		return {
 			create: TextDocument.create,
 			update: (document, changes, version) => {
-				document.update(changes, version);
+				(document as FullTextDocument).update(changes, version);
 				return document;
 			}
 		};


### PR DESCRIPTION
Having 'update' on the new vscode-languageserver-textdocuments.TextDocument makes it hard to adopt for existing client that have a TextDocument in their API.
e.g. https://github.com/microsoft/vscode-json-languageservice/blob/1eca6c2ee964be30a3a0d7c3b3fc8ba234be265b/src/jsonLanguageService.ts#L32

It's a breaking change that will then also ripple through to all client of the service