### PR TITLE
Remove duplicated semantic token type

### DIFF
--- a/client/src/semanticTokens.proposed.ts
+++ b/client/src/semanticTokens.proposed.ts
@@ -291,7 +291,6 @@ export class SemanticTokensFeature extends TextDocumentFeature<boolean | Propose
 		capability.dynamicRegistration = true;
 		capability.tokenTypes = [
 			Proposed.SemanticTokenTypes.comment,
-			Proposed.SemanticTokenTypes.comment,
 			Proposed.SemanticTokenTypes.keyword,
 			Proposed.SemanticTokenTypes.number,
 			Proposed.SemanticTokenTypes.regexp,


### PR DESCRIPTION
The client capability is sending back `Proposed.SemanticTokenTypes.comment` two times. I am assuming this is wrong...