### PR TITLE
Fix leftover reference to WorkDoneProgressStart

### DIFF
--- a/protocol/src/protocol.progress.ts
+++ b/protocol/src/protocol.progress.ts
@@ -67,7 +67,7 @@ export interface WorkDoneProgressReport {
 
 	/**
 	 * Controls enablement state of a cancel button. This property is only valid if a cancel
-	 * button got requested in the `WorkDoneProgressStart` payload.
+	 * button got requested in the `window/workDoneProgress/create` payload.
 	 *
 	 * Clients that don't support cancellation or don't support control the button's
 	 * enablement state are allowed to ignore the setting.


### PR DESCRIPTION
I think `WorkDoneProgressStart` got removed during some of the initial experimentation / refactoring.