### PR TITLE
Expand/restrict types per the JSON-RPC spec

### DIFF
--- a/jsonrpc/src/common/connection.ts
+++ b/jsonrpc/src/common/connection.ts
@@ -491,8 +491,8 @@ export function createMessageConnection(messageReader: MessageReader, messageWri
 	const disposeEmitter: Emitter<void> = new Emitter<void>();
 	const cancellationStrategy = (options && options.cancellationStrategy) ? options.cancellationStrategy : CancellationStrategy.Message;
 
-	function createRequestQueueKey(id: string | number): string {
-		return 'req-' + id.toString();
+	function createRequestQueueKey(id: string | number | null): string {
+		return 'req-' + id?.toString();
 	}
 
 	function createResponseQueueKey(id: string | number | null): string {
@@ -1019,12 +1019,12 @@ export function createMessageConnection(messageReader: MessageReader, messageWri
 			throwIfClosedOrDisposed();
 
 			let method: string;
-			let messageParams: any | any[] | null;
+			let messageParams: object | [] | undefined;
 			if (Is.string(type)) {
 				method = type;
 				switch (params.length) {
 					case 0:
-						messageParams = null;
+						messageParams = undefined;
 						break;
 					case 1:
 						messageParams = params[0];
@@ -1077,18 +1077,18 @@ export function createMessageConnection(messageReader: MessageReader, messageWri
 			throwIfNotListening();
 
 			let method: string;
-			let messageParams: object | object[] | null;
+			let messageParams: object | [] | undefined;
 			let token: CancellationToken | undefined = undefined;
 			if (Is.string(type)) {
 				method = type;
 				switch (params.length) {
 					case 0:
-						messageParams = null;
+						messageParams = undefined;
 						break;
 					case 1:
 						// The cancellation token is optional so it can also be undefined.
 						if (CancellationToken.is(params[0])) {
-							messageParams = null;
+							messageParams = undefined;
 							token = params[0];
 						} else {
 							messageParams = undefinedToNull(params[0]);

--- a/jsonrpc/src/common/messages.ts
+++ b/jsonrpc/src/common/messages.ts
@@ -20,7 +20,7 @@ export interface RequestMessage extends Message {
 	/**
 	 * The request id.
 	 */
-	id: number | string;
+	id: number | string | null;
 
 	/**
 	 * The method to be invoked.
@@ -30,7 +30,7 @@ export interface RequestMessage extends Message {
 	/**
 	 * The method's params.
 	 */
-	params?: any
+	params?: [] | object
 }
 
 /**
@@ -298,7 +298,7 @@ export interface NotificationMessage extends Message {
 	/**
 	 * The notification's params.
 	 */
-	params?: any
+	params?: [] | object
 }
 
 /**


### PR DESCRIPTION
The `id` and `params` fields of a JSON-RPC request were not typed consistently with [the JSON-RPC spec for request objects](https://www.jsonrpc.org/specification#request_object).

In particular:
1. `id` *may* be `null` (although such would be quite bizarre)
1. `params` *must* be omitted (i.e. _not_ null) or an array or an object. It may *not* be a number or a string.