### PR TITLE
export common `createConnection` method

### DIFF
--- a/server/src/browser/main.ts
+++ b/server/src/browser/main.ts
@@ -5,7 +5,7 @@
 
 import {
 	MessageReader, MessageWriter, Logger, ConnectionStrategy, ConnectionOptions, ProtocolConnection, WatchDog, InitializeParams, createProtocolConnection,
-	createConnection as createCommonConnection, Connection, Features, _Connection, _
+	createCommonConnection, Connection, Features, _Connection, _
 } from '../common/api';
 
 export * from 'vscode-languageserver-protocol/browser';

--- a/server/src/common/server.ts
+++ b/server/src/common/server.ts
@@ -1526,7 +1526,7 @@ export interface WatchDog {
 	exit(code: number): void;
 }
 
-export function createConnection<PConsole = _, PTracer = _, PTelemetry = _, PClient = _, PWindow = _, PWorkspace = _, PLanguages = _>(
+export function createCommonConnection<PConsole = _, PTracer = _, PTelemetry = _, PClient = _, PWindow = _, PWorkspace = _, PLanguages = _>(
 	connectionFactory: (logger: Logger) => ProtocolConnection, watchDog: WatchDog,
 	factories?: Features<PConsole, PTracer, PTelemetry, PClient, PWindow, PWorkspace, PLanguages>,
 ): _Connection<PConsole, PTracer, PTelemetry, PClient, PWindow, PWorkspace, PLanguages> {

--- a/server/src/node/main.ts
+++ b/server/src/node/main.ts
@@ -5,7 +5,7 @@
 /// <reference path="../../typings/thenable.d.ts" />
 
 import * as Is from '../common/utils/is';
-import { Connection, _, _Connection, Features, WatchDog, createConnection as createCommonConnection } from '../common/server';
+import { Connection, _, _Connection, Features, WatchDog, createCommonConnection } from '../common/server';
 
 import * as fm from './files';
 import {


### PR DESCRIPTION
When I saw that there is a wildcard export of `server/common/api` in `server/node/main`, I assumed the intention might have been to allow people to create their own service interface, similar to `node/main` or `browser/main`. however, the `createConnection` method from `common` is not available in node obviously because it's overwritten!

If this was the original intention, to only export one `createConnection` interface, then here is our use case: Our language server that is used by a number of popular extensions originally adopted `vscode-jsonrpc` `createMessageConnection` directly in 2017. we've just recently hit a ceiling of course, as we have a lot of missing features from the `createConnection` interface in the docs. We have our ownt= similar [service interface for choosing the transport](https://github.com/graphql/graphiql/blob/main/packages/graphql-language-service-server/src/startServer.ts#L146), for example. 

Is there a reason those process argument flags (`--node-ipc`, etc) are baked in? Are those used by vscode, or *only* for the `server/node/main` `_createConnection`?

if it wasn't the original intention, then, and you _did_ in fact want to export the common `createServer` - well you have a bugfix!