### PR TITLE
Allow customizing typing latency

### DIFF
--- a/client/src/common/client.ts
+++ b/client/src/common/client.ts
@@ -512,7 +512,8 @@ export interface LanguageClientOptions {
 	connectionOptions?: ConnectionOptions;
 	markdown?: {
 		isTrusted?: boolean;
-	}
+	};
+	changeDelay?: number;
 }
 
 interface ResolvedClientOptions {
@@ -535,7 +536,8 @@ interface ResolvedClientOptions {
 	connectionOptions?: ConnectionOptions;
 	markdown: {
 		isTrusted: boolean;
-	}
+	};
+	changeDelay: number;
 }
 
 export enum State {
@@ -1019,7 +1021,7 @@ class DidChangeTextDocumentFeature implements DynamicFeature<TextDocumentChangeR
 						} else {
 							this._changeDelayer = {
 								uri: event.document.uri.toString(),
-								delayer: new Delayer<void>(200)
+								delayer: new Delayer<void>(this._client.clientOptions.changeDelay)
 							};
 							this._changeDelayer.delayer.trigger(() => {
 								this._client.sendNotification(DidChangeTextDocumentNotification.type, this._client.code2ProtocolConverter.asChangeTextDocumentParams(event.document));
@@ -2650,7 +2652,8 @@ export abstract class BaseLanguageClient {
 			uriConverters: clientOptions.uriConverters,
 			workspaceFolder: clientOptions.workspaceFolder,
 			connectionOptions: clientOptions.connectionOptions,
-			markdown
+			markdown,
+			changeDelay: clientOptions.changeDelay ?? 200,
 		};
 		this._clientOptions.synchronize = this._clientOptions.synchronize || {};
 
@@ -2818,7 +2821,7 @@ export abstract class BaseLanguageClient {
 		}
 	}
 
-	public get clientOptions(): LanguageClientOptions {
+	public get clientOptions(): ResolvedClientOptions {
 		return this._clientOptions;
 	}
 


### PR DESCRIPTION
The default document change delay of 200 milliseconds is too high or too
low for some Visual Studio Code plugins. Allow users to customize the
document change delay to any number (including 0).

QUESTIONS FOR CODE REVIEWERS:

* Where should documentation for this option go?
* Is there a better spot for the changeDelay option? Is
  SynchronizeOptions a good place?
* Should we validate the option, disallowing negative numbers, NaN,
  Infinity, etc.?