### PR TITLE
Use appName as client info instead of 'vscode'

### DIFF
--- a/client/src/common/client.ts
+++ b/client/src/common/client.ts
@@ -3122,7 +3122,7 @@ export abstract class BaseLanguageClient {
 		let initParams: InitializeParams = {
 			processId: null,
 			clientInfo: {
-				name: 'vscode',
+				name: env.appName,
 				version: VSCodeVersion
 			},
 			locale: this.getLocale(),


### PR DESCRIPTION
Using `env.appName` will return `Visual Studio Code` or `VSCodium` for example (and I hope another label for GitHub Codespaces). This is more useful IMHO than hardcoding `vscode`.