### PR TITLE
Fix hang when server crashes during shutdown

### DIFF
--- a/client-node-tests/src/servers/crashOnShutdownServer.ts
+++ b/client-node-tests/src/servers/crashOnShutdownServer.ts
@@ -1,0 +1,15 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { createConnection, Connection, InitializeParams } from '../../../server/node';
+
+let connection: Connection = createConnection();
+connection.onInitialize((_params: InitializeParams): any => {
+	return { capabilities: {} };
+});
+connection.onShutdown(() => {
+	process.exit(100);
+});
+connection.listen();

--- a/client/src/common/client.ts
+++ b/client/src/common/client.ts
@@ -3372,7 +3372,7 @@ export abstract class BaseLanguageClient {
 
 	protected handleConnectionClosed() {
 		// Check whether this is a normal shutdown in progress or the client stopped normally.
-		if (this.state === ClientState.Stopping || this.state === ClientState.Stopped) {
+		if (this.state === ClientState.Stopped) {
 			return;
 		}
 		try {
@@ -3383,10 +3383,12 @@ export abstract class BaseLanguageClient {
 			// Disposing a connection could fail if error cases.
 		}
 		let action = CloseAction.DoNotRestart;
-		try {
-			action = this._clientOptions.errorHandler!.closed();
-		} catch (error) {
-			// Ignore errors coming from the error handler.
+		if (this.state !== ClientState.Stopping) {
+			try {
+				action = this._clientOptions.errorHandler!.closed();
+			} catch (error) {
+				// Ignore errors coming from the error handler.
+			}
 		}
 		this._connectionPromise = undefined;
 		this._resolvedConnection = undefined;


### PR DESCRIPTION
LanguageClient#stop sends a shutdown request to the language server. If
the server crashes/exits before sending a response, the promise returned
by LanguageClient#stop never settles. This happens because the
disconnect event is ignored during shutdown.

Fix the hang by not ignoring disconnects during shutdown. This will
cause LanguageClient#stop to throw an exception ("Connection got
disposed") if the server crashes or exits unexpectedly during shutdown.