### PR TITLE
Make the moniker capability optional as per the spec

### DIFF
--- a/protocol/src/common/protocol.ts
+++ b/protocol/src/common/protocol.ts
@@ -519,7 +519,7 @@ export interface TextDocumentClientCapabilities {
 	 *
 	 * @since 3.16.0
 	 */
-	moniker: MonikerClientCapabilities;
+	moniker?: MonikerClientCapabilities;
 }
 
 export interface WindowClientCapabilities {


### PR DESCRIPTION
According to the [LSP specification](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#initialize), the `moniker` property of the `TextDocumentCapabilities` may be undefined as all the other capabilities. Perhaps, the omission of the optionality marker here is a typo.