### PR TITLE
[Proposal] Document on Paste Formatting

### DIFF
--- a/client/src/common/onPasteFormatting.proposed.ts
+++ b/client/src/common/onPasteFormatting.proposed.ts
@@ -1,0 +1,91 @@
+import { CancellationToken, Disposable, ProviderResult, Range as VRange, TextDocument, TextEdit as VTextEdit, workspace as Workspace, FormattingOptions as VFormattingOptions } from "vscode";
+import { DocumentSelector, ServerCapabilities, TextEdit } from "vscode-languageserver-protocol";
+import { DocumentOnPasteFormattingParams, DocumentOnPasteFormattingRegistrationOptions, DocumentOnPasteFormattingRequest } from "vscode-languageserver-protocol/src/common/protocol.onPasteFormatting.proposed";
+import { ClientCapabilities, Proposed } from "./api";
+import { BaseLanguageClient, TextDocumentFeature } from "./client";
+import * as UUID from './utils/uuid';
+import * as c2p from './codeConverter';
+
+namespace vscode {
+	export interface OnPasteFormattingEditProvider {
+		provideOnPasteFormattingEdits(document: TextDocument, range: VRange, options: VFormattingOptions, token: CancellationToken): ProviderResult<TextEdit[]>;
+	}
+
+	export namespace languages {
+        export function registerOnPasteFormattingEditProvider(selector: DocumentSelector, provider: OnPasteFormattingEditProvider): Disposable;
+	}
+}
+
+function ensure<T, K extends keyof T>(target: T, key: K): T[K] {
+	if (target[key] === undefined) {
+		target[key] = {} as any;
+	}
+	return target[key];
+}
+
+namespace FileFormattingOptions {
+	export function fromConfiguration(document: TextDocument): c2p.FileFormattingOptions {
+		const filesConfig = Workspace.getConfiguration('files', document);
+		return {
+			trimTrailingWhitespace: filesConfig.get('trimTrailingWhitespace'),
+			trimFinalNewlines: filesConfig.get('trimFinalNewlines'),
+			insertFinalNewline: filesConfig.get('insertFinalNewline'),
+		};
+	}
+}
+
+export interface ProvideOnPasteFormattingEditsSignature {
+	(this: void, document: TextDocument, position: VRange, options: VFormattingOptions, token: CancellationToken): ProviderResult<VTextEdit[]>;
+}
+
+export interface OnPasteFormattingMiddleware {
+	provideOnPasteFormattingEdits?: (this: void, document: TextDocument, range: VRange, options: VFormattingOptions, token: CancellationToken, next: ProvideOnPasteFormattingEditsSignature) => ProviderResult<VTextEdit[]>;
+}
+
+export class DocumentOnPasteFormattingFeature extends TextDocumentFeature<Proposed.DocumentOnPasteFormattingOptions, Proposed.DocumentOnPasteFormattingRegistrationOptions, vscode.OnPasteFormattingEditProvider> {
+
+	constructor(client: BaseLanguageClient) {
+		super(client, Proposed.DocumentOnPasteFormattingRequest.type);
+	}
+
+	public fillClientCapabilities(cap: ClientCapabilities): void {
+		const capabilities: ClientCapabilities & { textDocument: { onPasteFormatting: Proposed.DocumentOnPasteFormattingClientCapabilities } } = cap as any;
+		ensure(ensure(capabilities, 'textDocument')!, 'onPasteFormatting')!.dynamicRegistration = true;
+	}
+
+	public initialize(cap: ServerCapabilities, documentSelector: DocumentSelector): void {
+		const capabilities: ServerCapabilities & { documentOnPasteFormattingProvider: Proposed.DocumentOnPasteFormattingOptions } = cap as any;
+		const options = this.getRegistrationOptions(documentSelector, capabilities.documentOnPasteFormattingProvider);
+		if (!options) {
+			return;
+		}
+		this.register({ id: UUID.generateUuid(), registerOptions: options });
+	}
+
+	protected registerLanguageProvider(options: DocumentOnPasteFormattingRegistrationOptions): [Disposable, vscode.OnPasteFormattingEditProvider] {
+		const provider: vscode.OnPasteFormattingEditProvider = {
+			provideOnPasteFormattingEdits: (document, range, options, token) => {
+				const client = this._client;
+				const provideOnPasteFormattingEdits: ProvideOnPasteFormattingEditsSignature = (document, range, options, token) => {
+					const params: DocumentOnPasteFormattingParams = {
+						textDocument: client.code2ProtocolConverter.asTextDocumentIdentifier(document),
+						range: client.code2ProtocolConverter.asRange(range),
+						options: client.code2ProtocolConverter.asFormattingOptions(options, FileFormattingOptions.fromConfiguration(document)),
+					};
+					return client.sendRequest(DocumentOnPasteFormattingRequest.type, params, token).then(
+						client.protocol2CodeConverter.asTextEdits,
+						(error) => {
+							return client.handleFailedRequest(DocumentOnPasteFormattingRequest.type, token, error, null);
+						}
+					);
+				};
+				const middleware = client.clientOptions.middleware! as OnPasteFormattingMiddleware;
+				return middleware.provideOnPasteFormattingEdits
+					? middleware.provideOnPasteFormattingEdits(document, range, options, token, provideOnPasteFormattingEdits)
+					: provideOnPasteFormattingEdits(document, range, options, token);
+			}
+		}
+
+		return [vscode.languages.registerOnPasteFormattingEditProvider(options.documentSelector!, provider), provider];
+	}
+}

--- a/protocol/src/common/api.ts
+++ b/protocol/src/common/api.ts
@@ -34,5 +34,12 @@ export namespace LSPErrorCodes {
 	export const lspReservedErrorRangeEnd: integer = -32800;
 }
 
+import * as op from './protocol.onPasteFormatting.proposed';
+
 export namespace Proposed {
+	export type DocumentOnPasteFormattingClientCapabilities = op.DocumentOnPasteFormattingClientCapabilities;
+	export type DocumentOnPasteFormattingOptions = op.DocumentOnPasteFormattingOptions;
+	export type DocumentOnPasteFormattingRegistrationOptions = op.DocumentOnPasteFormattingRegistrationOptions;
+	export type DocumentOnPasteFormattingParams = op.DocumentOnPasteFormattingParams;
+	export const DocumentOnPasteFormattingRequest = op.DocumentOnPasteFormattingRequest;
 }

--- a/protocol/src/common/protocol.onPasteFormatting.proposed.md
+++ b/protocol/src/common/protocol.onPasteFormatting.proposed.md
@@ -1,0 +1,63 @@
+#### Document on Paste Formatting Request
+
+The document on paste formatting request is sent from the client to the server to format parts of the document after content has been pasted into the document.
+
+_Client capability_:
+
+* property name (optional): `textDocument.onPasteFormatting`
+* property type: `DocumentOnPasteFormattingClientCapabilities` defined as follows:
+
+```ts
+export interface DocumentOnPasteFormattingClientCapabilities {
+	/**
+	 * Whether on paste formatting supports dynamic registration
+	 */
+	dynamicRegistration?: boolean;
+}
+```
+
+_Server capability_:
+
+* property name (optional): `documentOnPasteFormattingProvider`
+* property type: `DocumentOnPasteFormattingOptions` defined as follows:
+
+```ts
+export interface DocumentOnPasteFormattingOptions {
+}
+```
+
+_Registration options_: `DocumentOnPasteFormattingRegistrationOptions` defined as follows:
+
+```ts
+export interface DocumentOnPasteFormattingRegistrationOptions extends TextDocumentRegistrationOptions, DocumentOnPasteFormattingOptions {
+}
+```
+
+_Request_:
+
+* method: 'textDocument/onPasteFormatting'
+* params: `DocumentOnPasteFormattingParams` defined as follows:
+
+```ts
+export interface DocumentOnPasteFormattingParams {
+	/**
+	 * The document to format.
+	 */
+	textDocument: TextDocumentIdentifier;
+
+	/**
+	 * The range of the text that has been pasted into the document.
+	 */
+	range: Range;
+
+	/**
+	 * The formatting options.
+	 */
+	options: FormattingOptions;
+}
+```
+
+_Response_:
+
+* result: `TextEdit[] | null` describing the modification to the document.
+* error: code and message sent in case an exception happens during the on paste formatting request.

--- a/protocol/src/common/protocol.onPasteFormatting.proposed.ts
+++ b/protocol/src/common/protocol.onPasteFormatting.proposed.ts
@@ -1,0 +1,43 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import { FormattingOptions, Range, TextDocumentIdentifier, TextEdit } from "./api";
+import { ProtocolRequestType } from "./messages";
+import { TextDocumentRegistrationOptions } from "./protocol";
+
+export interface DocumentOnPasteFormattingClientCapabilities {
+	/**
+	 * Whether on paste formatting supports dynamic registration
+	 */
+	dynamicRegistration?: boolean;
+}
+
+export interface DocumentOnPasteFormattingOptions {
+}
+
+export interface DocumentOnPasteFormattingRegistrationOptions extends TextDocumentRegistrationOptions, DocumentOnPasteFormattingOptions {
+}
+
+export namespace DocumentOnPasteFormattingRequest {
+	export const method: 'textDocument/onPasteFormatting' = 'textDocument/onPasteFormatting';
+	export const type = new ProtocolRequestType<DocumentOnPasteFormattingParams, TextEdit[] | null, never, void, DocumentOnPasteFormattingRegistrationOptions>(method);
+}
+
+export interface DocumentOnPasteFormattingParams {
+	/**
+	 * The document to format.
+	 */
+	textDocument: TextDocumentIdentifier;
+
+	/**
+	 * The range of the text that has been pasted into the document.
+	 */
+	range: Range;
+
+	/**
+	 * The formatting options.
+	 */
+	options: FormattingOptions;
+}


### PR DESCRIPTION
This adds a new proposed LSP endpoint, `textDocument/onPasteFormatting`, which follows the same general structure as the `onTypeFormatting` and `rangeFormatting` features, originally discussed here: https://github.com/microsoft/language-server-protocol/issues/767. I opted to go for the separate endpoint for on-paste formatting, as I don't believe fixing imports is the only thing that an on-paste handler would want to: it could, for example, try to figure out if the content that was pasted in is in a string and handle some escaping of special characters. Therefore, the separate request seemed the better approach to my mind. I could also see a context on a `rangeFormatting` request that mentions "this range was pasted in" working as well, but to be frank my knowledge of the codebase and typescript is not up to adding a new context to an existing type, so I'd need help implementing that in the client.

@dbaeumer, as it is I've made a stab at implementing this in the client by basing the design off the DocumentOnTypeFormattingFeature, but the issue I've run into is that that feature is mainly a delegation to the native vscode implementation. I've added stubs to this PR, but they obviously don't work (and/or don't compile because they have no bodies). What would the next step here be? Implement the feature in vscode? Implement the feature by essentially just forwarding to the rangeFormatting feature?