### PR TITLE
Fix broken doc markdown link

### DIFF
--- a/types/src/main.ts
+++ b/types/src/main.ts
@@ -2164,11 +2164,10 @@ export interface CompletionItem {
 	command?: Command;
 
 	/**
-	 * A data entry field that is preserved on a completion item between
-	 * a [CompletionRequest](#CompletionRequest) and a [CompletionResolveRequest]
-	 * (#CompletionResolveRequest)
+	 * A data entry field that is preserved on a completion item between a
+	 * [CompletionRequest](#CompletionRequest) and a [CompletionResolveRequest](#CompletionResolveRequest).
 	 */
-	data?: any
+	data?: any;
 }
 
 /**


### PR DESCRIPTION
Minor, fixes a broken markdown link in the documentation of `CompletionItem.data`:

<img width="527" alt="Schermata 2021-02-05 alle 17 32 38" src="https://user-images.githubusercontent.com/4611392/107061184-27026f80-67d8-11eb-81b3-6e827abdec85.png">
