### PR TITLE
fix unhandled promise rejection in getConfiguration

### DIFF
--- a/server/src/common/configuration.ts
+++ b/server/src/common/configuration.ts
@@ -36,7 +36,11 @@ export const ConfigurationFeature: Feature<_RemoteWorkspace, Configuration> = (B
 				items: Array.isArray(arg) ? arg : [arg]
 			};
 			return this.connection.sendRequest(ConfigurationRequest.type, params).then((result) => {
-				return Array.isArray(arg) ? result : result[0];
+				if (Array.isArray(result)) {
+					return Array.isArray(arg) ? result : result[0];
+				} else {
+					return Array.isArray(arg) ? [] : null;
+				}
 			});
 		}
 	};


### PR DESCRIPTION
Hi @dbaeumer , I've had reports of `UnhandledPromiseRejectionWarning: TypeError: Cannot read property '0' of null` because the result of `workspace/configuration` is expected to be an array. It looks like the client is not following LSP here which states the response should be `any[]`. Regardless, this PR aims to safely handle the unexpected response.