### PR TITLE
Ensure exit notification is sent before closing connection

### DIFF
--- a/client/src/common/client.ts
+++ b/client/src/common/client.ts
@@ -3346,7 +3346,7 @@ export abstract class BaseLanguageClient {
 		// unhook listeners
 		return this._onStop = this.resolveConnection().then(connection => {
 			return connection.shutdown().then(() => {
-				connection.exit().then(() => {
+				return connection.exit().then(() => {
 					connection.end();
 					connection.dispose();
 					this.state = ClientState.Stopped;

--- a/client/src/common/client.ts
+++ b/client/src/common/client.ts
@@ -97,13 +97,13 @@ interface Connection {
 	onRequest<R, E>(method: string, handler: GenericRequestHandler<R, E>): Disposable;
 	onRequest<R, E>(method: string | MessageSignature, handler: GenericRequestHandler<R, E>): Disposable;
 
-	sendNotification<RO>(type: ProtocolNotificationType0<RO>): void;
-	sendNotification<P, RO>(type: ProtocolNotificationType<P, RO>, params?: P): void;
-	sendNotification(type: NotificationType0): void;
-	sendNotification<P>(type: NotificationType<P>, params?: P): void;
-	sendNotification(method: string): void;
-	sendNotification(method: string, params: any): void;
-	sendNotification(method: string | MessageSignature, params?: any): void;
+	sendNotification<RO>(type: ProtocolNotificationType0<RO>): Promise<void>;
+	sendNotification<P, RO>(type: ProtocolNotificationType<P, RO>, params?: P): Promise<void>;
+	sendNotification(type: NotificationType0): Promise<void>;
+	sendNotification<P>(type: NotificationType<P>, params?: P): Promise<void>;
+	sendNotification(method: string): Promise<void>;
+	sendNotification(method: string, params: any): Promise<void>;
+	sendNotification(method: string | MessageSignature, params?: any): Promise<void>;
 
 	onNotification<RO>(type: ProtocolNotificationType0<RO>, handler: NotificationHandler0): Disposable;
 	onNotification<P, RO>(type: ProtocolNotificationType<P, RO>, handler: NotificationHandler<P>): Disposable;
@@ -120,7 +120,7 @@ interface Connection {
 
 	initialize(params: InitializeParams): Promise<InitializeResult>;
 	shutdown(): Promise<void>;
-	exit(): void;
+	exit(): Promise<void>;
 
 	onLogMessage(handle: NotificationHandler<LogMessageParams>): void;
 	onShowMessage(handler: NotificationHandler<ShowMessageParams>): void;
@@ -179,7 +179,7 @@ function createConnection(input: MessageReader, output: MessageWriter, errorHand
 		sendRequest: <R>(type: string | MessageSignature, ...params: any[]): Promise<R> => connection.sendRequest(Is.string(type) ? type : type.method, ...params),
 		onRequest: <R, E>(type: string | MessageSignature, handler: GenericRequestHandler<R, E>): Disposable => connection.onRequest(Is.string(type) ? type : type.method, handler),
 
-		sendNotification: (type: string | MessageSignature, params?: any): void => connection.sendNotification(Is.string(type) ? type : type.method, params),
+		sendNotification: (type: string | MessageSignature, params?: any): Promise<void> => connection.sendNotification(Is.string(type) ? type : type.method, params),
 		onNotification: (type: string | MessageSignature, handler: GenericNotificationHandler): Disposable => connection.onNotification(Is.string(type) ? type : type.method, handler),
 
 		onProgress: connection.onProgress,
@@ -3346,14 +3346,15 @@ export abstract class BaseLanguageClient {
 		// unhook listeners
 		return this._onStop = this.resolveConnection().then(connection => {
 			return connection.shutdown().then(() => {
-				connection.exit();
-				connection.end();
-				connection.dispose();
-				this.state = ClientState.Stopped;
-				this.cleanUpChannel();
-				this._onStop = undefined;
-				this._connectionPromise = undefined;
-				this._resolvedConnection = undefined;
+				connection.exit().then(() => {
+					connection.end();
+					connection.dispose();
+					this.state = ClientState.Stopped;
+					this.cleanUpChannel();
+					this._onStop = undefined;
+					this._connectionPromise = undefined;
+					this._resolvedConnection = undefined;
+				});
 			});
 		});
 	}

--- a/jsonrpc/src/common/connection.ts
+++ b/jsonrpc/src/common/connection.ts
@@ -401,18 +401,18 @@ export interface MessageConnection {
 	onRequest<R, E>(method: string, handler: GenericRequestHandler<R, E>): Disposable;
 	onRequest(handler: StarRequestHandler): Disposable;
 
-	sendNotification(type: NotificationType0): void;
-	sendNotification<P>(type: NotificationType<P>, params?: P): void;
-	sendNotification<P1>(type: NotificationType1<P1>, p1: P1): void;
-	sendNotification<P1, P2>(type: NotificationType2<P1, P2>, p1: P1, p2: P2): void;
-	sendNotification<P1, P2, P3>(type: NotificationType3<P1, P2, P3>, p1: P1, p2: P2, p3: P3): void;
-	sendNotification<P1, P2, P3, P4>(type: NotificationType4<P1, P2, P3, P4>, p1: P1, p2: P2, p3: P3, p4: P4): void;
-	sendNotification<P1, P2, P3, P4, P5>(type: NotificationType5<P1, P2, P3, P4, P5>, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5): void;
-	sendNotification<P1, P2, P3, P4, P5, P6>(type: NotificationType6<P1, P2, P3, P4, P5, P6>, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6): void;
-	sendNotification<P1, P2, P3, P4, P5, P6, P7>(type: NotificationType7<P1, P2, P3, P4, P5, P6, P7>, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7): void;
-	sendNotification<P1, P2, P3, P4, P5, P6, P7, P8>(type: NotificationType8<P1, P2, P3, P4, P5, P6, P7, P8>, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7, p8: P8): void;
-	sendNotification<P1, P2, P3, P4, P5, P6, P7, P8, P9>(type: NotificationType9<P1, P2, P3, P4, P5, P6, P7, P8, P9>, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7, p8: P8, p9: P9): void;
-	sendNotification(method: string, r0?: ParameterStructures | any, ...rest: any[]): void;
+	sendNotification(type: NotificationType0): Promise<void>;
+	sendNotification<P>(type: NotificationType<P>, params?: P): Promise<void>;
+	sendNotification<P1>(type: NotificationType1<P1>, p1: P1): Promise<void>;
+	sendNotification<P1, P2>(type: NotificationType2<P1, P2>, p1: P1, p2: P2): Promise<void>;
+	sendNotification<P1, P2, P3>(type: NotificationType3<P1, P2, P3>, p1: P1, p2: P2, p3: P3): Promise<void>;
+	sendNotification<P1, P2, P3, P4>(type: NotificationType4<P1, P2, P3, P4>, p1: P1, p2: P2, p3: P3, p4: P4): Promise<void>;
+	sendNotification<P1, P2, P3, P4, P5>(type: NotificationType5<P1, P2, P3, P4, P5>, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5): Promise<void>;
+	sendNotification<P1, P2, P3, P4, P5, P6>(type: NotificationType6<P1, P2, P3, P4, P5, P6>, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6): Promise<void>;
+	sendNotification<P1, P2, P3, P4, P5, P6, P7>(type: NotificationType7<P1, P2, P3, P4, P5, P6, P7>, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7): Promise<void>;
+	sendNotification<P1, P2, P3, P4, P5, P6, P7, P8>(type: NotificationType8<P1, P2, P3, P4, P5, P6, P7, P8>, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7, p8: P8): Promise<void>;
+	sendNotification<P1, P2, P3, P4, P5, P6, P7, P8, P9>(type: NotificationType9<P1, P2, P3, P4, P5, P6, P7, P8, P9>, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7, p8: P8, p9: P9): Promise<void>;
+	sendNotification(method: string, r0?: ParameterStructures | any, ...rest: any[]): Promise<void>;
 
 	onNotification(type: NotificationType0, handler: NotificationHandler0): Disposable;
 	onNotification<P>(type: NotificationType<P>, handler: NotificationHandler<P>): Disposable;
@@ -1108,7 +1108,7 @@ export function createMessageConnection(messageReader: MessageReader, messageWri
 	}
 
 	const connection: MessageConnection = {
-		sendNotification: (type: string | MessageSignature, ...args: any[]): void => {
+		sendNotification: (type: string | MessageSignature, ...args: any[]): Promise<void> => {
 			throwIfClosedOrDisposed();
 
 			let method: string;
@@ -1149,7 +1149,7 @@ export function createMessageConnection(messageReader: MessageReader, messageWri
 				params: messageParams
 			};
 			traceSendingNotification(notificationMessage);
-			messageWriter.write(notificationMessage).catch(() => logger.error(`Sending notification failed.`));
+			return messageWriter.write(notificationMessage).catch(() => logger.error(`Sending notification failed.`));
 		},
 		onNotification: (type: string | MessageSignature | StarNotificationHandler, handler?: GenericNotificationHandler): Disposable => {
 			throwIfClosedOrDisposed();

--- a/protocol/src/common/connection.ts
+++ b/protocol/src/common/connection.ts
@@ -87,8 +87,8 @@ export interface ProtocolConnection {
 	 *
 	 * @param type the notification's type to send.
 	 */
-	sendNotification(type: NotificationType0): void;
-	sendNotification<RO>(type: ProtocolNotificationType0<RO>): void;
+	sendNotification(type: NotificationType0): Promise<void>;
+	sendNotification<RO>(type: ProtocolNotificationType0<RO>): Promise<void>;
 
 	/**
 	 * Sends a notification.
@@ -96,15 +96,15 @@ export interface ProtocolConnection {
 	 * @param type the notification's type to send.
 	 * @param params the notification's parameters.
 	 */
-	sendNotification<P, RO>(type: ProtocolNotificationType<P, RO>, params?: P): void;
-	sendNotification<P>(type: NotificationType<P>, params?: P): void;
+	sendNotification<P, RO>(type: ProtocolNotificationType<P, RO>, params?: P): Promise<void>;
+	sendNotification<P>(type: NotificationType<P>, params?: P): Promise<void>;
 
 	/**
 	 * Sends a notification.
 	 *
 	 * @param method the notification's method name.
 	 */
-	sendNotification(method: string): void;
+	sendNotification(method: string): Promise<void>;
 
 	/**
 	 * Sends a notification.
@@ -112,7 +112,7 @@ export interface ProtocolConnection {
 	 * @param method the notification's method name.
 	 * @param params the notification's parameters.
 	 */
-	sendNotification(method: string, params: any): void;
+	sendNotification(method: string, params: any): Promise<void>;
 
 	/**
 	 * Installs a notification handler.


### PR DESCRIPTION
Currently the exit notification is not sent because the connection gets closed before the message is sent (at least on my machine in WSL). This change waits for the exit notification to be sent before closing the connection.

Fixes #726 (exit notification not received part).