### PR TITLE
Add FileSystem proposed protocol spec & documentation

### DIFF
--- a/protocol/src/common/api.ts
+++ b/protocol/src/common/api.ts
@@ -70,7 +70,10 @@ export namespace LSPErrorCodes {
 
 import * as diag from './proposed.diagnostic';
 import * as typeh from './proposed.typeHierarchy';
+import * as fs from './proposed.fileSystemProvider';
+
 export namespace Proposed {
+	// ------------------------------ Diagnostics ------------------------------
 	export type DiagnosticClientCapabilities = diag.DiagnosticClientCapabilities;
 	export type $DiagnosticClientCapabilities = diag.$DiagnosticClientCapabilities;
 	export type DiagnosticOptions = diag.DiagnosticOptions;
@@ -112,4 +115,47 @@ export namespace Proposed {
 	export const TypeHierarchySupertypesRequest: typeof typeh.TypeHierarchySupertypesRequest = typeh.TypeHierarchySupertypesRequest;
 	export const TypeHierarchySubtypesRequest: typeof typeh.TypeHierarchySubtypesRequest = typeh.TypeHierarchySubtypesRequest;
 
+	// ------------------------------ FileSystem ------------------------------
+
+	// -> Basic Structures
+	export type FileType = fs.FileType;
+	export type FileSystemErrorType = fs.FileSystemErrorType;
+
+	// -> Client & Server Capabilities
+	export type FileSystemProviderClientCapabilities = fs.FileSystemProviderClientCapabilities;
+	export type $FileSystemProviderClientCapabilities = fs.$FileSystemProviderClientCapabilities;
+	export type FileSystemProviderOptions  = fs.FileSystemProviderOptions;
+	export type FileSystemProviderRegistrationOptions  = fs.FileSystemProviderRegistrationOptions;
+	export type $FileSystemProviderServerCapabilities  = fs.$FileSystemProviderServerCapabilities;
+
+	// -> Requests & Notifications
+	export type DidChangeFileParams = fs.DidChangeFileParams;
+	export type FileChangeEvent = fs.FileChangeEvent;
+	export type FileChangeType = fs.FileChangeType;
+
+	export type WatchParams = fs.WatchParams;
+	export type WatchFileOptions = fs.WatchFileOptions;
+
+	export type StopWatchingParams = fs.StopWatchingParams;
+
+	export type FileStatParams = fs.FileStatParams;
+	export type FileStatResponse = fs.FileStatResponse;
+
+	export type ReadDirectoryParams = fs.ReadDirectoryParams;
+	export type ReadDirectoryResponse = fs.ReadDirectoryResponse;
+	export type DirectoryChild = fs.DirectoryChild;
+
+	export type CreateDirectoryParams = fs.CreateDirectoryParams;
+
+	export type ReadFileParams = fs.ReadFileParams;
+	export type ReadFileResponse = fs.ReadFileResponse;
+
+	export type WriteFileParams = fs.WriteFileParams;
+	export type WriteFileOptions = fs.WriteFileOptions;
+
+	export type DeleteFileParams = fs.DeleteFileParams;
+	export type DeleteFileOptions = fs.DeleteFileOptions;
+
+	export type RenameFileParams = fs.RenameFileParams;
+	export type RenameFileOptions = fs.RenameFileOptions;
 }

--- a/protocol/src/common/api.ts
+++ b/protocol/src/common/api.ts
@@ -103,7 +103,7 @@ export namespace Proposed {
 	export const WorkspaceDiagnosticRequest: typeof diag.WorkspaceDiagnosticRequest = diag.WorkspaceDiagnosticRequest;
 	export const DiagnosticRefreshRequest: typeof diag.DiagnosticRefreshRequest = diag.DiagnosticRefreshRequest;
 
-	// type hierarchy
+	// ------------------------------ Type Hierarchy ------------------------------
 	export type TypeHierarchyClientCapabilities = typeh.TypeHierarchyClientCapabilities;
 	export type TypeHierarchyOptions = typeh.TypeHierarchyOptions;
 	export type TypeHierarchyRegistrationOptions = typeh.TypeHierarchyRegistrationOptions;

--- a/protocol/src/common/proposed.fileSystemProvider.md
+++ b/protocol/src/common/proposed.fileSystemProvider.md
@@ -1,0 +1,588 @@
+# Expanding LSP to Support Virtual File Systems
+
+This document details a solution to creating virtual file systems in a platform agnostic way. It sits ontop of the pre-existing [language server protocol (LSP)](https://microsoft.github.io/language-server-protocol/specification), utilizing the groundwork it has laid out while building out what it means to have a general "tooling server".
+
+## Table of Contents
+
+- [Problem Background](#problemBackground)
+- [Solution](#solution)
+    - [Spec](#spec)
+        - [Basic Structures](#basicStructures)
+        - [Capabilities](#capabilities)
+        - [Requests and Notifications](#requestsAndNotifications)
+
+# <a href="#problemBackground" name="problemBackground">Problem Background</a>
+
+A virtual file system can represent remote places like ftp-servers, help power embedded languages or even describe mainstream project exporers where not everything is "real". The movement to build tooling that spans ecosystems or even crosses boundaries (remote development) has proven to be difficult. Trying to generically solve the problem of how to show or maintain a virtual file system has been a delicate road of balancing fragility, dev resources and robustness. Some concrete examples today that dance along these problem boundaries are:
+
+- LiveShare & Codespaces
+- Solution/Project Explorer
+- Folder explorers
+- Embedded languages such as Razor, PHP, HTML etc.
+- FTP
+
+Now virtual file systems aren't entirely new. VSCode recently built out a model to enable extenders to bring their own file systems in the form of [`FileSystemProvider`](https://code.visualstudio.com/api/references/vscode-api#FileSystemProvider)s. Because of their precedent, the ideas presented in this document are heavily influenced by their design and are meant to standardize what it means for a tooling server to bring its own file system for any level of use.
+
+# <a href="#solution" name="solution">Solution</a>
+
+The virtual file system spec sits ontop of LSP's [Base Protocol](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#headerPart) and versioning while also expanding its [General Messages](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#initialize) for negoatiating client/server capabilities. The intent is that it's possible to have a pure file system server (tooling server) or even a language server that has file system capabilities.
+
+The spec adds descriptive APIs to enable clients to query information of a virtual file system in order to retrieve, mutate or display content.
+
+## <a href="#spec" name="spec">Spec</a>
+
+### <a href="#basicStructures" name="basicStructures">Basic Structures</a>
+
+#### <a href="#fileType" name="fileType" class="anchor">FileType</a>
+
+The protocol currently supports several different file types and these represent what type of structures a server can virtualize.
+
+```typescript
+/**
+ * Enumeration of file types. The types `File` and `Directory` can also be
+ * a symbolic links, in that case use `FileType.File | FileType.SymbolicLink` and
+ * `FileType.Directory | FileType.SymbolicLink`.
+ */
+export namespace FileType {
+    /**
+     * The file type is unknown.
+     */
+    export const Unknown = 0;
+
+    /**
+     * A regular file.
+     */
+    export const File = 1;
+
+    /**
+     * A directory.
+     */
+    export const Directory = 2;
+
+    /**
+     * A symbolic link to a file or folder
+     */
+    export const Symbolic = 64;
+}
+```
+
+#### <a href="#fileSystemErrorType" name="fileSystemErrorType" class="anchor">fileSystemErrorType</a>
+
+File system error types represent common error codes used to indicate failed interactions with a file system. For instance, trying to read a file that doesn't exist or edit a directory you don't have permissions to edit.
+
+```typescript
+export namespace FileSystemErrorType {
+    /**
+     * An error to signal that a file or folder wasn't found.
+     */
+    export const FileNotFound = 0;
+
+    /**
+     * An error to signal that a file or folder already exists, e.g. when creating but not overwriting a file.
+     */
+    export const FileExists = 1;
+
+    /**
+     * An error to signal that a file is not a folder.
+     */
+    export const FileNotADirectory = 2;
+
+    /**
+     * An error to signal that a file is a folder.
+     */
+    export const FileIsADirectory = 3;
+
+    /**
+     * An error to signal that an operation lacks required permissions.
+     */
+    export const NoPermissions = 4;
+
+    /**
+     * An error to signal that the file system is unavailable or too busy to complete a request.
+     */
+    export const Unavailable = 5;
+
+    /**
+     * A custom error.
+     */
+    export const Other = 1000;
+}
+```
+
+### <a href="#capabilities" name="capabilities">Capabilities</a>
+
+<a href="#fileSystemProviderClientCapabilities" name="fileSystemProviderClientCapabilities" class="anchor">_Client Capabilities:_</a>
+- property name (optional): `fileSystem`
+- property type: `FileSystemProviderClientCapabilities`
+
+```typescript
+/**
+ * Client capabilities specific to file system providers
+ */
+export interface FileSystemProviderClientCapabilities {
+}
+```
+
+<a href="#fileSystemProviderServerCapabilities" name="fileSystemProviderServerCapabilities" class="anchor">_Server Capability_:</a>
+
+- property name (optional): `fileSystem`
+- property type: `FileSystemProviderOptions` defined as follows:
+
+```typescript
+/**
+ * Server capabilities specific to file system providers
+ */
+export interface FileSystemProviderOptions {
+    /**
+     * The uri-scheme the provider registers for
+     */
+    scheme: string;
+
+    /**
+     * Whether or not the file system is case sensitive.
+     */
+    isCaseSensitive?: boolean;
+
+    /**
+     * Whether or not the file system is readonly.
+     */
+    isReadonly?: boolean
+}
+```
+
+_Registration Options:_ `FileSystemProviderRegistrationOptions` defined as follows:
+
+```typescript
+export interface FileSystemProviderRegistrationOptions extends FileSystemProviderOptions {
+}
+```
+
+### <a href="#requestsAndNotifications" name="requestsAndNotifications">Requests and Notifications</a>
+
+#### <a href="#didChangeFile" name="didChangeFile" class="anchor">DidChangeFile Notification (:arrow_left:)</a>
+
+Change file notifications are sent from the server to the client to signal the change of the registered file system provider.
+
+_Client Capabilities:_ See general file system provider [client capabilities](#fileSystemProviderClientCapabilities)
+
+_Server Capabilities:_ See general file system provider [server capabilities](#fileSystemProviderServerCapabilities)
+
+_Notification:_
+- method: `fileSystem/didChangeFile`
+- params: `DidChangeFileParams` defined as follows:
+
+```typescript
+/**
+ * An event to signal that a resource has been created, changed, or deleted. This
+ * event should fire for resources that are being [watched](#FileSystemProvider.watch)
+ * by clients of this provider.
+ *
+ * *Note:* It is important that the metadata of the file that changed provides an
+ * updated `mtime` that advanced from the previous value in the [stat](#FileStat) and a
+ * correct `size` value. Otherwise there may be optimizations in place that will not show
+ * the change in an editor for example.
+ */
+export interface DidChangeFileParams {
+    /**
+     * The change events.'
+     */
+    changes: FileChangeEvent[];
+}
+
+/**
+ * The event filesystem providers must use to signal a file change.
+ */
+export interface FileChangeEvent {
+    /**
+     * The type of change.
+     */
+    uri: URI;
+
+    /**
+     * The uri of the file that has changed.
+     */
+    type: FileChangeType
+}
+
+/**
+ * Enumeration of file change types.
+ */
+export namespace FileChangeType {
+    /**
+     * The contents or metadata of a file have changed.
+     */
+    export const Changed = 1;
+
+    /**
+     * A file has been created.
+     */
+    export const Created = 2;
+
+    /**
+     * A file has been deleted.
+     */
+    export const Deleted = 3;
+}
+```
+
+#### <a href="#watch" name="watch" class="anchor">Watch Notification (:arrow_right:)</a>
+
+Watch requests are sent from the client to the server to subscribe to [DidChangeFile](#didChangeFile) events in the file or folder denoted by `uri`.
+
+_Client Capabilities:_ See general file system provider [client capabilities](#fileSystemProviderClientCapabilities)
+
+_Server Capabilities:_ See general file system provider [server capabilities](#fileSystemProviderServerCapabilities)
+
+_Notification:_
+- method: `fileSystem/watch`
+- params: `WatchParams` defined as follows:
+
+```typescript
+export interface WatchParams {
+    /**
+     * The uri of the file or folder to be watched.
+     */
+    uri: URI;
+
+    /**
+     * The subscription ID to be used in order to stop watching the provided file or folder uri via the [StopWatching](#stopWatching) notification.
+     */
+    subscriptionId: string;
+
+    /**
+     * Configures the watch
+     */
+    options: WatchFileOptions
+}
+
+export interface WatchFileOptions {
+    /**
+     * If a folder should be recursively subscribed to
+     */
+    recursive: boolean;
+
+    /**
+     * Folders or files to exclude from being watched.
+     */
+    excludes: string[];
+}
+```
+
+#### <a href="#stopWatching" name="stopWatching" class="anchor">StopWatching Notification (:arrow_right:)</a>
+
+A notification sent from client to server to unsubscribe from a watched file or folder.
+
+_Client Capabilities:_ See general file system provider [client capabilities](#fileSystemProviderClientCapabilities)
+
+_Server Capabilities:_ See general file system provider [server capabilities](#fileSystemProviderServerCapabilities)
+
+_Notification:_
+- method: `fileSystem/stopWatching`
+- params: `StopWatchingParams` defined as follows:
+
+```typescript
+/**
+ * A notification to signal an unsubscribe from a corresponding [watch](#watch) request.
+ */
+export interface StopWatchingParams {
+    /**
+     * The subscription id.
+     */
+    subscriptionId: string;
+}
+```
+
+#### <a href="#stat" name="stat" class="anchor">Stat Request (:arrow_right_hook:)</a>
+
+Stat requests are sent from the client to the server to request metadata about a URI.
+
+_Client Capabilities:_ See general file system provider [client capabilities](#fileSystemProviderClientCapabilities)
+
+_Server Capabilities:_ See general file system provider [server capabilities](#fileSystemProviderServerCapabilities)
+
+_Request:_
+- method: `fileSystem/stat`
+- params: `FileStatParams` defined as follows:
+
+```typescript
+export interface FileStatParams {
+    /**
+     * The uri to retrieve metadata about.
+     */
+    uri: URI;
+}
+```
+
+_Response:_
+- result: `FileStatResponse`
+- error: code and message set in case an exception during the `fileSystem/stat` request. Code will be of type [FileSystemErrorType](#fileSystemErrorType) with an associated message.
+
+```typescript
+export interface FileStatResponse {
+    /**
+     * The type of the file, e.g. is a regular file, a directory, or symbolic link
+     * to a file/directory.
+     *
+     * *Note:* This value might be a bitmask, e.g. `FileType.File | FileType.SymbolicLink`.
+     */
+    type: FileType;
+
+    /**
+     * The creation timestamp in milliseconds elapsed since January 1, 1970 00:00:00 UTC.
+     */
+    ctime: number;
+
+    /**
+     * The modification timestamp in milliseconds elapsed since January 1, 1970 00:00:00 UTC.
+     *
+     * *Note:* If the file changed, it is important to provide an updated `mtime` that advanced
+     * from the previous value. Otherwise there may be optimizations in place that will not show
+     * the updated file contents in an editor for example.
+     */
+    mtime: number;
+
+    /**
+     * The size in bytes.
+     *
+     * *Note:* If the file changed, it is important to provide an updated `size`. Otherwise there
+     * may be optimizations in place that will not show the updated file contents in an editor for
+     * example.
+     */
+    size: number;
+}
+```
+
+#### <a href="#readDirectory" name="readDirectory" class="anchor">ReadDirectory Request (:arrow_right_hook:)</a>
+
+Read directory requests are sent from the client to the server to retrieve all entries of a directory.
+
+_Client Capabilities:_ See general file system provider [client capabilities](#fileSystemProviderClientCapabilities)
+
+_Server Capabilities:_ See general file system provider [server capabilities](#fileSystemProviderServerCapabilities)
+
+_Request:_
+- method: `fileSystem/readDirectory`
+- params: `ReadDirectoryParams` defined as follows:
+
+```typescript
+export interface ReadDirectoryParams {
+    /**
+     * The uri of the folder.
+     */
+    uri: URI;
+}
+```
+
+_Response:_
+- result: `ReadDirectoryResponse`
+
+```typescript
+export interface ReadDirectoryResponse {
+    /**
+     * An array of nodes that represent the directories children.
+     */
+    children: DirectoryChild[]
+}
+
+/**
+ * A name/type item that represents a directory child node.
+ */
+export interface DirectoryChild {
+    /**
+     * The name of the node, e.g. a filename or directory name.
+     */
+    name: string;
+
+    /**
+     * The type of the file, e.g. is a regular file, a directory, or symbolic link to a file/directory.
+     *
+     * *Note:* This value might be a bitmask, e.g. `FileType.File | FileType.SymbolicLink`.
+     */
+    type: FileType;
+}
+```
+
+#### <a href="#createDirectory" name="createDirectory" class="anchor">CreateDirectory Request (:arrow_right_hook:)</a>
+
+Create directory requests are sent from the client to the server to create a new directory.
+
+_Client Capabilities:_ See general file system provider [client capabilities](#fileSystemProviderClientCapabilities)
+
+_Server Capabilities:_ See general file system provider [server capabilities](#fileSystemProviderServerCapabilities)
+
+_Request:_
+- method: `fileSystem/createDirectory`
+- params: `CreateDirectoryParams` defined as follows:
+
+```typescript
+export interface CreateDirectoryParams {
+    /**
+     * The uri of the folder
+     */
+    uri: URI;
+}
+```
+
+_Response:_
+- result: void
+- error: code and message set in case an exception during the `fileSystem/createDirectory` request. Code will be of type [FileSystemErrorType](#fileSystemErrorType) with an associated message.
+
+#### <a href="#readFile" name="readFile" class="anchor">ReadFile Request (:arrow_right_hook:)</a>
+
+Read file requests are sent from the client to the server to retrieve the content of a file.
+
+_Client Capabilities:_ See general file system provider [client capabilities](#fileSystemProviderClientCapabilities)
+
+_Server Capabilities:_ See general file system provider [server capabilities](#fileSystemProviderServerCapabilities)
+
+_Request:_
+- method: `fileSystem/readFile`
+- params: `ReadFileParams` defined as follows:
+
+```typescript
+export interface ReadFileParams {
+    /**
+     * The uri of the folder
+     */
+    uri: URI;
+}
+```
+
+_Response:_
+- result: `ReadFileResponse`
+- error: code and message set in case an exception during the `fileSystem/readFile` request. Code will be of type [FileSystemErrorType](#fileSystemErrorType) with an associated message.
+
+```typescript
+export interface ReadFileResponse {
+    /**
+     * The entire contents of the file `base64` encoded.
+     */
+    content: string;
+}
+```
+
+#### <a href="#writeFile" name="writeFile" class="anchor">WriteFile Request (:arrow_right_hook:)</a>
+
+Write file requests are sent from the client to the server to write data to a file, replacing its entire contents.
+
+_Client Capabilities:_ See general file system provider [client capabilities](#fileSystemProviderClientCapabilities)
+
+_Server Capabilities:_ See general file system provider [server capabilities](#fileSystemProviderServerCapabilities)
+
+_Request:_
+- method: `fileSystem/writeFile`
+- params: `WriteFileParams` defined as follows:
+
+```typescript
+export interface WriteFileParams {
+    /**
+     * The uri of the file to write
+     */
+    uri: URI;
+
+    /**
+     * The new content of the file `base64` encoded.
+     */
+    content: string;
+
+    /**
+     * Options to define if missing files should or must be created.
+     */
+    options: WriteFileOptions
+}
+
+export interface WriteFileOptions {
+    /**
+     * If a new file should be created.
+     */
+    create: boolean;
+
+    /**
+     * If a pre-existing file should be overwritten.
+     */
+    overwrite: boolean;
+}
+```
+
+_Response:_
+- result: void
+- error: code and message set in case an exception during the `fileSystem/writeFile` request. Code will be of type [FileSystemErrorType](#fileSystemErrorType) with an associated message.
+
+#### <a href="#delete" name="delete" class="anchor">Delete Request (:arrow_right_hook:)</a>
+
+Delete requests are sent from the client to the server to delete a file or folder.
+
+_Client Capabilities:_ See general file system provider [client capabilities](#fileSystemProviderClientCapabilities)
+
+_Server Capabilities:_ See general file system provider [server capabilities](#fileSystemProviderServerCapabilities)
+
+_Request:_
+- method: `fileSystem/delete`
+- params: `DeleteFileParams` defined as follows:
+
+```typescript
+export interface DeleteFileParams {
+    /**
+     * The uri of the file or folder to delete
+     */
+    uri: URI;
+
+    /**
+     * Defines if deletion of folders is recursive.
+     */
+    options: DeleteFileOptions
+}
+
+export interface DeleteFileOptions {
+    /**
+     * If a folder should be recursively deleted.
+     */
+    recursive: boolean;
+}
+```
+
+_Response:_
+- result: void
+- error: code and message set in case an exception during the `fileSystem/delete` request. Code will be of type [FileSystemErrorType](#fileSystemErrorType) with an associated message.
+
+#### <a href="#rename" name="rename" class="anchor">Rename Request (:arrow_right_hook:)</a>
+
+Rename requests are sent from the client to the server to rename a file or folder.
+
+_Client Capabilities:_ See general file system provider [client capabilities](#fileSystemProviderClientCapabilities)
+
+_Server Capabilities:_ See general file system provider [server capabilities](#fileSystemProviderServerCapabilities)
+
+_Request:_
+- method: `fileSystem/rename`
+- params: `RenameFileParams` defined as follows:
+
+```typescript
+export interface RenameFileParams {
+    /**
+     * The existing file.
+     */
+    oldUri: URI;
+
+    /**
+     * The new location.
+     */
+    newUri: URI;
+
+    /**
+     * Defines if existing files should be overwritten.
+     */
+    options: RenameFileOptions
+}
+
+export interface RenameFileOptions {
+    /**
+     * If existing files should be overwritten.
+     */
+    overwrite: boolean;
+}
+```
+
+_Response:_
+- result: void
+- error: code and message set in case an exception during the `fileSystem/rename` request. Code will be of type [FileSystemErrorType](#fileSystemErrorType) with an associated message.

--- a/protocol/src/common/proposed.fileSystemProvider.md
+++ b/protocol/src/common/proposed.fileSystemProvider.md
@@ -348,7 +348,7 @@ export interface FileStatResponse {
      * may be optimizations in place that will not show the updated file contents in an editor for
      * example.
      */
-    size: number;
+    size: uinteger;
 }
 ```
 

--- a/protocol/src/common/proposed.fileSystemProvider.ts
+++ b/protocol/src/common/proposed.fileSystemProvider.ts
@@ -4,6 +4,8 @@
  * ------------------------------------------------------------------------------------------ */
 
 import { NotificationHandler, RequestHandler } from 'vscode-jsonrpc/src/common/connection';
+import { uinteger } from 'vscode-languageserver-types';
+import { DocumentUri } from 'vscode-languageserver-types';
 import { ProtocolNotificationType, ProtocolRequestType } from './messages';
 import {
 	StaticRegistrationOptions, TextDocumentRegistrationOptions
@@ -20,23 +22,23 @@ import {
  */
 export enum FileType {
 	/**
-     * The file type is unknown.
-     */
+	 * The file type is unknown.
+	 */
 	Unknown = 0,
 
 	/**
-     * A regular file.
-     */
+	 * A regular file.
+	 */
 	File = 1,
 
 	/**
-     * A directory.
-     */
+	 * A directory.
+	 */
 	Directory = 2,
 
 	/**
-     * A symbolic link to a file or folder
-     */
+	 * A symbolic link to a file or folder
+	 */
 	Symbolic = 64,
 }
 
@@ -48,38 +50,38 @@ export enum FileType {
  */
 export enum FileSystemErrorType {
 	/**
-     * An error to signal that a file or folder wasn't found.
-     */
+	 * An error to signal that a file or folder wasn't found.
+	 */
 	FileNotFound = 0,
 
 	/**
-     * An error to signal that a file or folder already exists, e.g. when creating but not overwriting a file.
-     */
+	 * An error to signal that a file or folder already exists, e.g. when creating but not overwriting a file.
+	 */
 	FileExists = 1,
 
 	/**
-     * An error to signal that a file is not a folder.
-     */
+	 * An error to signal that a file is not a folder.
+	 */
 	FileNotADirectory = 2,
 
 	/**
-     * An error to signal that a file is a folder.
-     */
+	 * An error to signal that a file is a folder.
+	 */
 	FileIsADirectory = 3,
 
 	/**
-     * An error to signal that an operation lacks required permissions.
-     */
+	 * An error to signal that an operation lacks required permissions.
+	 */
 	NoPermissions = 4,
 
 	/**
-     * An error to signal that the file system is unavailable or too busy to complete a request.
-     */
+	 * An error to signal that the file system is unavailable or too busy to complete a request.
+	 */
 	Unavailable = 5,
 
 	/**
-     * A custom error.
-     */
+	 * A custom error.
+	 */
 	Other = 1000,
 }
 
@@ -110,18 +112,18 @@ export interface $FileSystemProviderClientCapabilities {
  */
 export interface FileSystemProviderOptions {
 	/**
-     * The uri-scheme the provider registers for
-     */
+	 * The uri-scheme the provider registers for
+	 */
 	scheme: string;
 
 	/**
-     * Whether or not the file system is case sensitive.
-     */
+	 * Whether or not the file system is case sensitive.
+	 */
 	isCaseSensitive?: boolean;
 
 	/**
-     * Whether or not the file system is readonly.
-     */
+	 * Whether or not the file system is readonly.
+	 */
 	isReadonly?: boolean
 }
 
@@ -169,25 +171,25 @@ export namespace DidChangeFileNotification {
  */
 export interface DidChangeFileParams {
 	/**
-     * The change events.'
-     */
+	 * The change events.'
+	 */
 	changes: FileChangeEvent[];
 }
 
 /**
- * The event filesystem providers must use to signal a file change.
+ * The event FileSystemProviders use to signal file changes.
  *
  * @since 3.17.0 - proposed state
  */
 export interface FileChangeEvent {
 	/**
-     * The type of change.
-     */
-	uri: string;
+	 * The type of change.
+	 */
+	uri: DocumentUri;
 
 	/**
-     * The uri of the file that has changed.
-     */
+	 * The uri of the file that has changed.
+	 */
 	type: FileChangeType
 }
 
@@ -198,18 +200,18 @@ export interface FileChangeEvent {
  */
 export enum FileChangeType {
 	/**
-     * The contents or metadata of a file have changed.
-     */
+	 * The contents or metadata of a file have changed.
+	 */
 	Changed = 1,
 
 	/**
-     * A file has been created.
-     */
+	 * A file has been created.
+	 */
 	Created = 2,
 
 	/**
-     * A file has been deleted.
-     */
+	 * A file has been deleted.
+	 */
 	Deleted = 3,
 }
 
@@ -234,18 +236,18 @@ export namespace WatchNotification {
  */
 export interface WatchParams {
 	/**
-     * The uri of the file or folder to be watched.
-     */
-	uri: string;
+	 * The uri of the file or folder to be watched.
+	 */
+	uri: DocumentUri;
 
 	/**
-     * The subscription ID to be used in order to stop watching the provided file or folder uri via the fileSystem/stopWatching notification.
-     */
+	 * The subscription ID to be used in order to stop watching the provided file or folder uri via the fileSystem/stopWatching notification.
+	 */
 	subscriptionId: string;
 
 	/**
-     * Configures the watch
-     */
+	 * Configures the watch
+	 */
 	options: WatchFileOptions
 }
 
@@ -256,13 +258,13 @@ export interface WatchParams {
  */
 export interface WatchFileOptions {
 	/**
-     * If a folder should be recursively subscribed to
-     */
+	 * If a folder should be recursively subscribed to
+	 */
 	recursive: boolean;
 
 	/**
-     * Folders or files to exclude from being watched.
-     */
+	 * Folders or files to exclude from being watched.
+	 */
 	excludes: string[];
 }
 
@@ -287,8 +289,8 @@ export namespace StopWatchingNotification {
  */
 export interface StopWatchingParams {
 	/**
-     * The subscription id.
-     */
+	 * The subscription id.
+	 */
 	subscriptionId: string;
 }
 
@@ -312,9 +314,9 @@ export namespace StatRequest {
  */
 export interface FileStatParams {
 	/**
-     * The uri to retrieve metadata about.
-     */
-	uri: string;
+	 * The uri to retrieve metadata about.
+	 */
+	uri: DocumentUri;
 }
 
 /**
@@ -324,35 +326,35 @@ export interface FileStatParams {
  */
 export interface FileStatResponse {
 	/**
-     * The type of the file, e.g. is a regular file, a directory, or symbolic link
-     * to a file/directory.
-     *
-     * *Note:* This value might be a bitmask, e.g. `FileType.File | FileType.SymbolicLink`.
-     */
+	 * The type of the file, e.g. is a regular file, a directory, or symbolic link
+	 * to a file/directory.
+	 *
+	 * *Note:* This value might be a bitmask, e.g. `FileType.File | FileType.SymbolicLink`.
+	 */
 	type: FileType;
 
 	/**
-     * The creation timestamp in milliseconds elapsed since January 1, 1970 00:00:00 UTC.
-     */
+	 * The creation timestamp in milliseconds elapsed since January 1, 1970 00:00:00 UTC.
+	 */
 	ctime: number;
 
 	/**
-     * The modification timestamp in milliseconds elapsed since January 1, 1970 00:00:00 UTC.
-     *
-     * *Note:* If the file changed, it is important to provide an updated `mtime` that advanced
-     * from the previous value. Otherwise there may be optimizations in place that will not show
-     * the updated file contents in an editor for example.
-     */
+	 * The modification timestamp in milliseconds elapsed since January 1, 1970 00:00:00 UTC.
+	 *
+	 * *Note:* If the file changed, it is important to provide an updated `mtime` that advanced
+	 * from the previous value. Otherwise there may be optimizations in place that will not show
+	 * the updated file contents in an editor for example.
+	 */
 	mtime: number;
 
 	/**
-     * The size in bytes.
-     *
-     * *Note:* If the file changed, it is important to provide an updated `size`. Otherwise there
-     * may be optimizations in place that will not show the updated file contents in an editor for
-     * example.
-     */
-	size: number;
+	 * The size in bytes.
+	 *
+	 * *Note:* If the file changed, it is important to provide an updated `size`. Otherwise there
+	 * may be optimizations in place that will not show the updated file contents in an editor for
+	 * example.
+	 */
+	size: uinteger;
 }
 
 // ReadDirectory Request (client->server) fileSystem/readDirectory
@@ -376,9 +378,9 @@ export namespace ReadDirectoryRequest {
  */
 export interface ReadDirectoryParams {
 	/**
-     * The uri of the folder.
-     */
-	uri: string;
+	 * The uri of the folder.
+	 */
+	uri: DocumentUri;
 }
 
 /**
@@ -388,8 +390,8 @@ export interface ReadDirectoryParams {
  */
 export interface ReadDirectoryResponse {
 	/**
-     * An array of nodes that represent the directories children.
-     */
+	 * An array of nodes that represent the directories children.
+	 */
 	children: DirectoryChild[]
 }
 
@@ -400,15 +402,15 @@ export interface ReadDirectoryResponse {
  */
 export interface DirectoryChild {
 	/**
-     * The name of the node, e.g. a filename or directory name.
-     */
+	 * The name of the node, e.g. a filename or directory name.
+	 */
 	name: string;
 
 	/**
-     * The type of the file, e.g. is a regular file, a directory, or symbolic link to a file/directory.
-     *
-     * *Note:* This value might be a bitmask, e.g. `FileType.File | FileType.SymbolicLink`.
-     */
+	 * The type of the file, e.g. is a regular file, a directory, or symbolic link to a file/directory.
+	 *
+	 * *Note:* This value might be a bitmask, e.g. `FileType.File | FileType.SymbolicLink`.
+	 */
 	type: FileType;
 }
 
@@ -433,9 +435,9 @@ export namespace CreateDirectoryRequest {
  */
 export interface CreateDirectoryParams {
 	/**
-     * The uri of the folder
-     */
-	uri: string;
+	 * The uri of the folder
+	 */
+	uri: DocumentUri;
 }
 
 // readFile Request (client->server) fileSystem/readFile
@@ -459,9 +461,9 @@ export namespace ReadFileRequest {
  */
 export interface ReadFileParams {
 	/**
-     * The uri of the folder
-     */
-	uri: string;
+	 * The uri of the folder
+	 */
+	uri: DocumentUri;
 }
 
 /**
@@ -471,8 +473,8 @@ export interface ReadFileParams {
  */
 export interface ReadFileResponse {
 	/**
-     * The entire contents of the file `base64` encoded.
-     */
+	 * The entire contents of the file `base64` encoded.
+	 */
 	content: string;
 }
 
@@ -497,18 +499,18 @@ export namespace WriteFileRequest {
  */
 export interface WriteFileParams {
 	/**
-     * The uri of the file to write
-     */
-	uri: string;
+	 * The uri of the file to write
+	 */
+	uri: DocumentUri;
 
 	/**
-     * The new content of the file `base64` encoded.
-     */
+	 * The new content of the file `base64` encoded.
+	 */
 	content: string;
 
 	/**
-     * Options to define if missing files should or must be created.
-     */
+	 * Options to define if missing files should or must be created.
+	 */
 	options: WriteFileOptions
 }
 
@@ -519,13 +521,13 @@ export interface WriteFileParams {
  */
 export interface WriteFileOptions {
 	/**
-     * If a new file should be created.
-     */
+	 * If a new file should be created.
+	 */
 	create: boolean;
 
 	/**
-     * If a pre-existing file should be overwritten.
-     */
+	 * If a pre-existing file should be overwritten.
+	 */
 	overwrite: boolean;
 }
 
@@ -550,13 +552,13 @@ export namespace DeleteRequest {
  */
 export interface DeleteFileParams {
 	/**
-     * The uri of the file or folder to delete
-     */
-	uri: string;
+	 * The uri of the file or folder to delete
+	 */
+	uri: DocumentUri;
 
 	/**
-     * Defines if deletion of folders is recursive.
-     */
+	 * Defines if deletion of folders is recursive.
+	 */
 	options: DeleteFileOptions
 }
 
@@ -567,8 +569,8 @@ export interface DeleteFileParams {
  */
 export interface DeleteFileOptions {
 	/**
-     * If a folder should be recursively deleted.
-     */
+	 * If a folder should be recursively deleted.
+	 */
 	recursive: boolean;
 }
 
@@ -593,18 +595,18 @@ export namespace RenameRequest {
  */
 export interface RenameFileParams {
 	/**
-     * The existing file or folder.
-     */
-	oldUri: string;
+	 * The existing file or folder.
+	 */
+	oldUri: DocumentUri;
 
 	/**
-     * The new location.
-     */
-	newUri: string;
+	 * The new location.
+	 */
+	newUri: DocumentUri;
 
 	/**
-     * Defines if existing files should be overwritten.
-     */
+	 * Defines if existing files should be overwritten.
+	 */
 	options: RenameFileOptions
 }
 
@@ -615,7 +617,7 @@ export interface RenameFileParams {
  */
 export interface RenameFileOptions {
 	/**
-     * If existing files should be overwritten.
-     */
+	 * If existing files should be overwritten.
+	 */
 	overwrite: boolean;
 }

--- a/protocol/src/common/proposed.fileSystemProvider.ts
+++ b/protocol/src/common/proposed.fileSystemProvider.ts
@@ -1,0 +1,621 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import { NotificationHandler, RequestHandler } from 'vscode-jsonrpc/src/common/connection';
+import { ProtocolNotificationType, ProtocolRequestType } from './messages';
+import {
+	StaticRegistrationOptions, TextDocumentRegistrationOptions
+} from './protocol';
+
+// -------------  Basic Structures  -------------
+
+/**
+ * Enumeration of file types. The types `File` and `Directory` can also be
+ * a symbolic links, in that case use `FileType.File | FileType.SymbolicLink` and
+ * `FileType.Directory | FileType.SymbolicLink`.
+ *
+ * @since 3.17.0 - proposed state
+ */
+export enum FileType {
+	/**
+     * The file type is unknown.
+     */
+	Unknown = 0,
+
+	/**
+     * A regular file.
+     */
+	File = 1,
+
+	/**
+     * A directory.
+     */
+	Directory = 2,
+
+	/**
+     * A symbolic link to a file or folder
+     */
+	Symbolic = 64,
+}
+
+
+/**
+ * Type of file system errors that can occur in file system based requests.
+ *
+ * @since 3.17.0 - proposed state
+ */
+export enum FileSystemErrorType {
+	/**
+     * An error to signal that a file or folder wasn't found.
+     */
+	FileNotFound = 0,
+
+	/**
+     * An error to signal that a file or folder already exists, e.g. when creating but not overwriting a file.
+     */
+	FileExists = 1,
+
+	/**
+     * An error to signal that a file is not a folder.
+     */
+	FileNotADirectory = 2,
+
+	/**
+     * An error to signal that a file is a folder.
+     */
+	FileIsADirectory = 3,
+
+	/**
+     * An error to signal that an operation lacks required permissions.
+     */
+	NoPermissions = 4,
+
+	/**
+     * An error to signal that the file system is unavailable or too busy to complete a request.
+     */
+	Unavailable = 5,
+
+	/**
+     * A custom error.
+     */
+	Other = 1000,
+}
+
+// -------------  Client & Server Capabilities  -------------
+
+/**
+ * Client capabilities specific to file system providers
+ *
+ * @since 3.17.0 - proposed state
+ */
+export interface FileSystemProviderClientCapabilities {
+	/**
+	 * Whether implementation supports dynamic registration. If this is set to `true`
+	 * the client supports the new `(TextDocumentRegistrationOptions & StaticRegistrationOptions)`
+	 * return value for the corresponding server capability as well.
+	 */
+	dynamicRegistration?: boolean;
+}
+
+export interface $FileSystemProviderClientCapabilities {
+	fileSystem?: FileSystemProviderClientCapabilities;
+}
+
+/**
+ * Server capabilities specific to file system providers
+ *
+ * @since 3.17.0 - proposed state
+ */
+export interface FileSystemProviderOptions {
+	/**
+     * The uri-scheme the provider registers for
+     */
+	scheme: string;
+
+	/**
+     * Whether or not the file system is case sensitive.
+     */
+	isCaseSensitive?: boolean;
+
+	/**
+     * Whether or not the file system is readonly.
+     */
+	isReadonly?: boolean
+}
+
+/**
+ * File system provider registration options.
+ *
+ * @since 3.17.0 - proposed state
+ */
+export interface FileSystemProviderRegistrationOptions extends TextDocumentRegistrationOptions, FileSystemProviderOptions, StaticRegistrationOptions {
+}
+
+export interface $FileSystemProviderServerCapabilities {
+	fileSystem?: FileSystemProviderOptions;
+}
+
+
+// -------------  Requests & Notifications  -------------
+
+
+// DidChangeFile Notification (server->client) fileSystem/didChangeFile
+
+/**
+ * The fileSystem did change file notification definition. Change file notifications are sent from the server to the client to
+ * signal the change of the registered file system provider.
+ *
+ * @since 3.17.0 - proposed state
+ */
+export namespace DidChangeFileNotification {
+	export const type = new ProtocolNotificationType<DidChangeFileParams, void>('fileSystem/didChangeFile');
+	export type HandlerSignature = NotificationHandler<DidChangeFileParams>;
+	export type MiddlewareSignature = (params: DidChangeFileParams, next: HandlerSignature) => void;
+}
+
+/**
+ * An event to signal that a resource has been created, changed, or deleted. This
+ * event should fire for resources that are being [watched](#FileSystemProvider.watch)
+ * by clients of this provider.
+ *
+ * *Note:* It is important that the metadata of the file that changed provides an
+ * updated `mtime` that advanced from the previous value in the [stat](#FileStat) and a
+ * correct `size` value. Otherwise there may be optimizations in place that will not show
+ * the change in an editor for example.
+ *
+ * @since 3.17.0 - proposed state
+ */
+export interface DidChangeFileParams {
+	/**
+     * The change events.'
+     */
+	changes: FileChangeEvent[];
+}
+
+/**
+ * The event filesystem providers must use to signal a file change.
+ *
+ * @since 3.17.0 - proposed state
+ */
+export interface FileChangeEvent {
+	/**
+     * The type of change.
+     */
+	uri: string;
+
+	/**
+     * The uri of the file that has changed.
+     */
+	type: FileChangeType
+}
+
+/**
+ * Enumeration of file change types.
+ *
+ * @since 3.17.0 - proposed state
+ */
+export enum FileChangeType {
+	/**
+     * The contents or metadata of a file have changed.
+     */
+	Changed = 1,
+
+	/**
+     * A file has been created.
+     */
+	Created = 2,
+
+	/**
+     * A file has been deleted.
+     */
+	Deleted = 3,
+}
+
+// Watch Notification (client->server) fileSystem/watch=
+
+/**
+ * The fileSystem watch notification definition. Watch notifications are sent from the client to the server to subscribe
+ * to DidChangeFile events in the file or folder denoted by uri.
+ *
+ * @since 3.17.0 - proposed state
+ */
+export namespace WatchNotification {
+	export const type = new ProtocolNotificationType<WatchParams, void>('fileSystem/watch');
+	export type HandlerSignature = NotificationHandler<WatchParams>;
+	export type MiddlewareSignature = (params: WatchParams, next: HandlerSignature) => void;
+}
+
+/**
+ * Parameters of the watch notification.
+ *
+ * @since 3.17.0 - proposed state
+ */
+export interface WatchParams {
+	/**
+     * The uri of the file or folder to be watched.
+     */
+	uri: string;
+
+	/**
+     * The subscription ID to be used in order to stop watching the provided file or folder uri via the fileSystem/stopWatching notification.
+     */
+	subscriptionId: string;
+
+	/**
+     * Configures the watch
+     */
+	options: WatchFileOptions
+}
+
+/**
+ * Options for the watch notification.
+ *
+ * @since 3.17.0 - proposed state
+ */
+export interface WatchFileOptions {
+	/**
+     * If a folder should be recursively subscribed to
+     */
+	recursive: boolean;
+
+	/**
+     * Folders or files to exclude from being watched.
+     */
+	excludes: string[];
+}
+
+// StopWatching Notification (client->server) fileSystem/watch
+
+/**
+ * The fileSystem stop watching notification definition. Stop watching notifications are sent from client to server to
+ * unsubscribe from a watched file or folder.
+ *
+ * @since 3.17.0 - proposed state
+ */
+export namespace StopWatchingNotification {
+	export const type = new ProtocolNotificationType<StopWatchingParams, void>('fileSystem/stopWatching');
+	export type HandlerSignature = NotificationHandler<StopWatchingParams>;
+	export type MiddlewareSignature = (params: StopWatchingParams, next: HandlerSignature) => void;
+}
+
+/**
+ * Parameters of the stop watching notification.
+ *
+ * @since 3.17.0 - proposed state
+ */
+export interface StopWatchingParams {
+	/**
+     * The subscription id.
+     */
+	subscriptionId: string;
+}
+
+// Stat Request (client->server) fileSystem/stat
+
+/**
+ * The fileSystem stat rquest definition. Stat requests are sent from the client to the server to request metadata about a URI.
+ *
+ * @since 3.17.0 - proposed state
+ */
+export namespace StatRequest {
+	export const method: 'fileSystem/stat' = 'fileSystem/stat';
+	export const type = new ProtocolRequestType<FileStatParams, FileStatResponse, void, FileSystemErrorType, FileSystemProviderRegistrationOptions>(method);
+	export type HandlerSignature = RequestHandler<FileStatParams, FileStatResponse, FileSystemErrorType>;
+}
+
+/**
+ * Parameters of the file stat request.
+ *
+ * @since 3.17.0 - proposed state
+ */
+export interface FileStatParams {
+	/**
+     * The uri to retrieve metadata about.
+     */
+	uri: string;
+}
+
+/**
+ * Response for the file stat request.
+ *
+ * @since 3.17.0 - proposed state
+ */
+export interface FileStatResponse {
+	/**
+     * The type of the file, e.g. is a regular file, a directory, or symbolic link
+     * to a file/directory.
+     *
+     * *Note:* This value might be a bitmask, e.g. `FileType.File | FileType.SymbolicLink`.
+     */
+	type: FileType;
+
+	/**
+     * The creation timestamp in milliseconds elapsed since January 1, 1970 00:00:00 UTC.
+     */
+	ctime: number;
+
+	/**
+     * The modification timestamp in milliseconds elapsed since January 1, 1970 00:00:00 UTC.
+     *
+     * *Note:* If the file changed, it is important to provide an updated `mtime` that advanced
+     * from the previous value. Otherwise there may be optimizations in place that will not show
+     * the updated file contents in an editor for example.
+     */
+	mtime: number;
+
+	/**
+     * The size in bytes.
+     *
+     * *Note:* If the file changed, it is important to provide an updated `size`. Otherwise there
+     * may be optimizations in place that will not show the updated file contents in an editor for
+     * example.
+     */
+	size: number;
+}
+
+// ReadDirectory Request (client->server) fileSystem/readDirectory
+
+/**
+ * The fileSystem read directory request definition. Read directory requests are sent from the client to the server
+ * to retrieve all entries of a directory.
+ *
+ * @since 3.17.0 - proposed state
+ */
+export namespace ReadDirectoryRequest {
+	export const method: 'fileSystem/readDirectory' = 'fileSystem/readDirectory';
+	export const type = new ProtocolRequestType<ReadDirectoryParams, ReadDirectoryResponse, void, void, FileSystemProviderRegistrationOptions>(method);
+	export type HandlerSignature = RequestHandler<ReadDirectoryParams, ReadDirectoryResponse, void>;
+}
+
+/**
+ * Parameters of the read directory request.
+ *
+ * @since 3.17.0 - proposed state
+ */
+export interface ReadDirectoryParams {
+	/**
+     * The uri of the folder.
+     */
+	uri: string;
+}
+
+/**
+ * Response for the read directory request.
+ *
+ * @since 3.17.0 - proposed state
+ */
+export interface ReadDirectoryResponse {
+	/**
+     * An array of nodes that represent the directories children.
+     */
+	children: DirectoryChild[]
+}
+
+/**
+ * A name/type item that represents a directory child node.
+ *
+ * @since 3.17.0 - proposed state
+ */
+export interface DirectoryChild {
+	/**
+     * The name of the node, e.g. a filename or directory name.
+     */
+	name: string;
+
+	/**
+     * The type of the file, e.g. is a regular file, a directory, or symbolic link to a file/directory.
+     *
+     * *Note:* This value might be a bitmask, e.g. `FileType.File | FileType.SymbolicLink`.
+     */
+	type: FileType;
+}
+
+// CreateDirectory Request (client->server) fileSystem/createDirectory
+
+/**
+ * The fileSystem create directory request definition. Create directory requests are sent from the client
+ * to the server to create a new directory.
+ *
+ * @since 3.17.0 - proposed state
+ */
+export namespace CreateDirectoryRequest {
+	export const method: 'fileSystem/createDirectory' = 'fileSystem/createDirectory';
+	export const type = new ProtocolRequestType<CreateDirectoryParams , void, void, FileSystemErrorType, FileSystemProviderRegistrationOptions>(method);
+	export type HandlerSignature = RequestHandler<CreateDirectoryParams, void, FileSystemErrorType>;
+}
+
+/**
+ * Parameters of the create directory request.
+ *
+ * @since 3.17.0 - proposed state
+ */
+export interface CreateDirectoryParams {
+	/**
+     * The uri of the folder
+     */
+	uri: string;
+}
+
+// readFile Request (client->server) fileSystem/readFile
+
+/**
+ * The fileSystem read file request definition. Read file requests are sent from the client
+ * to the server to retrieve the content of a file.
+ *
+ * @since 3.17.0 - proposed state
+ */
+export namespace ReadFileRequest {
+	export const method: 'fileSystem/readFile' = 'fileSystem/readFile';
+	export const type = new ProtocolRequestType<ReadFileParams , ReadFileResponse, void, FileSystemErrorType, FileSystemProviderRegistrationOptions>(method);
+	export type HandlerSignature = RequestHandler<ReadFileParams , ReadFileResponse, FileSystemErrorType>;
+}
+
+/**
+ * Parameters of the read file request.
+ *
+ * @since 3.17.0 - proposed state
+ */
+export interface ReadFileParams {
+	/**
+     * The uri of the folder
+     */
+	uri: string;
+}
+
+/**
+ * Response for the read file request.
+ *
+ * @since 3.17.0 - proposed state
+ */
+export interface ReadFileResponse {
+	/**
+     * The entire contents of the file `base64` encoded.
+     */
+	content: string;
+}
+
+// WriteFile Request (client->server) fileSystem/writeFile
+
+/**
+ * The fileSystem write file request definition. Write file requests are sent from the client
+ * to the server to write data to a file, replacing its entire contents.
+ *
+ * @since 3.17.0 - proposed state
+ */
+export namespace WriteFileRequest {
+	export const method: 'fileSystem/writeFile' = 'fileSystem/writeFile';
+	export const type = new ProtocolRequestType<WriteFileParams , void, void, FileSystemErrorType, FileSystemProviderRegistrationOptions>(method);
+	export type HandlerSignature = RequestHandler<WriteFileParams , void, FileSystemErrorType>;
+}
+
+/**
+ * Parameters of the write file request.
+ *
+ * @since 3.17.0 - proposed state
+ */
+export interface WriteFileParams {
+	/**
+     * The uri of the file to write
+     */
+	uri: string;
+
+	/**
+     * The new content of the file `base64` encoded.
+     */
+	content: string;
+
+	/**
+     * Options to define if missing files should or must be created.
+     */
+	options: WriteFileOptions
+}
+
+/**
+ * Options for the write file request.
+ *
+ * @since 3.17.0 - proposed state
+ */
+export interface WriteFileOptions {
+	/**
+     * If a new file should be created.
+     */
+	create: boolean;
+
+	/**
+     * If a pre-existing file should be overwritten.
+     */
+	overwrite: boolean;
+}
+
+// Delete Request (client->server) fileSystem/delete
+
+/**
+ * The fileSystem delete file request definition. Delete requests are sent from the client
+ * to the server to delete a file or folder.
+ *
+ * @since 3.17.0 - proposed state
+ */
+export namespace DeleteRequest {
+	export const method: 'fileSystem/delete' = 'fileSystem/delete';
+	export const type = new ProtocolRequestType<DeleteFileParams , void, void, FileSystemErrorType, FileSystemProviderRegistrationOptions>(method);
+	export type HandlerSignature = RequestHandler<DeleteFileParams , void, FileSystemErrorType>;
+}
+
+/**
+ * Parameters of the delete request.
+ *
+ * @since 3.17.0 - proposed state
+ */
+export interface DeleteFileParams {
+	/**
+     * The uri of the file or folder to delete
+     */
+	uri: string;
+
+	/**
+     * Defines if deletion of folders is recursive.
+     */
+	options: DeleteFileOptions
+}
+
+/**
+ * Options of the delete request.
+ *
+ * @since 3.17.0 - proposed state
+ */
+export interface DeleteFileOptions {
+	/**
+     * If a folder should be recursively deleted.
+     */
+	recursive: boolean;
+}
+
+// Rename Request (client->server) fileSystem/rename
+
+/**
+ * The fileSystem rename file request definition. Rename requests are sent from the client
+ * to the server to rename a file or folder.
+ *
+ * @since 3.17.0 - proposed state
+ */
+export namespace RenameRequest {
+	export const method: 'fileSystem/rename' = 'fileSystem/rename';
+	export const type = new ProtocolRequestType<RenameFileParams , void, void, FileSystemErrorType, FileSystemProviderRegistrationOptions>(method);
+	export type HandlerSignature = RequestHandler<RenameFileParams , void, FileSystemErrorType>;
+}
+
+/**
+ * Parameters of the rename file request.
+ *
+ * @since 3.17.0 - proposed state
+ */
+export interface RenameFileParams {
+	/**
+     * The existing file or folder.
+     */
+	oldUri: string;
+
+	/**
+     * The new location.
+     */
+	newUri: string;
+
+	/**
+     * Defines if existing files should be overwritten.
+     */
+	options: RenameFileOptions
+}
+
+/**
+ * Options of the rename file request.
+ *
+ * @since 3.17.0 - proposed state
+ */
+export interface RenameFileOptions {
+	/**
+     * If existing files should be overwritten.
+     */
+	overwrite: boolean;
+}


### PR DESCRIPTION
- Added the spec itself in addition to adding the protocol types, requests, notifications and expansions of that in the API.
- Prior to updating implementation figured this was a good first step to ensure I was setting things up correctly.