### PR TITLE
Fix "A request has failed" dialog that can not be dismissed

### DIFF
--- a/client/src/common/client.ts
+++ b/client/src/common/client.ts
@@ -3061,8 +3061,10 @@ export abstract class BaseLanguageClient {
 	}
 
 	private showNotificationMessage() {
-		void Window.showInformationMessage('A request has failed. See the output for more information.', 'Go to output').then(() => {
-			this.outputChannel.show(true);
+		void Window.showInformationMessage('A request has failed. See the output for more information.', 'Go to output').then((selection) => {
+			if (selection !== undefined) {
+				this.outputChannel.show(true);
+			}
 		});
 	}
 


### PR DESCRIPTION
Take into account the user choice and only open the output channel if
user has clicked "Go to output".

Fixes #786