### PR TITLE
feat: optional targetSelectionRange property in LocationLink

### DIFF
--- a/types/src/main.ts
+++ b/types/src/main.ts
@@ -218,7 +218,7 @@ export interface LocationLink {
 	 * The range that should be selected and revealed when this link is being followed, e.g the name of a function.
 	 * Must be contained by the the `targetRange`. See also `DocumentSymbol#range`
 	 */
-	targetSelectionRange: Range;
+	targetSelectionRange?: Range;
 }
 
 /**
@@ -234,7 +234,7 @@ export namespace LocationLink {
 	 * @param targetSelectionRange The span of the symbol definition at the target.
 	 * @param originSelectionRange The span of the symbol being defined in the originating source file.
 	 */
-	export function create(targetUri: DocumentUri, targetRange: Range, targetSelectionRange: Range, originSelectionRange?: Range): LocationLink {
+	export function create(targetUri: DocumentUri, targetRange: Range, targetSelectionRange?: Range, originSelectionRange?: Range): LocationLink {
 		return { targetUri, targetRange, targetSelectionRange, originSelectionRange };
 	}
 


### PR DESCRIPTION
As the function [LocationLink::is](https://github.com/microsoft/vscode-languageserver-node/blob/main/types/src/main.ts#L244-L249) indicates, the property `targetSelectionRange` might be `undefined`.

So I think it might be acceptable to change the signature.

Please correct me if I'm wrong.