### PR TITLE
fix: fixed `computeSingleParam` judgement

### DIFF
--- a/jsonrpc/src/common/connection.ts
+++ b/jsonrpc/src/common/connection.ts
@@ -1063,19 +1063,19 @@ export function createMessageConnection(messageReader: MessageReader, messageWri
 	}
 
 	function computeSingleParam(parameterStructures: ParameterStructures, param: any): any | any[] {
-		switch(parameterStructures) {
-			case ParameterStructures.auto:
+		switch(parameterStructures.kind) {
+			case ParameterStructures.auto.kind:
 				if (isNamedParam(param)) {
 					return nullToUndefined(param);
 				} else {
 					return [undefinedToNull(param)];
 				}
-			case ParameterStructures.byName:
+			case ParameterStructures.byName.kind:
 				if (!isNamedParam(param)) {
 					throw new Error(`Received parameters by name but param is not an object literal.`);
 				}
 				return nullToUndefined(param);
-			case ParameterStructures.byPosition:
+			case ParameterStructures.byPosition.kind:
 				return [undefinedToNull(param)];
 			default:
 				throw new Error(`Unknown parameter structure ${parameterStructures.toString()}`);


### PR DESCRIPTION
If request type create by different `vscode-jsonrpc` module, `LanguageClient.sendRequest` always fails:

```log
Error: Unknown parameter structure auto
    at computeSingleParam (xxx/node_modules/vscode-jsonrpc/lib/common/connection.js:793:23)
    at computeMessageParams (xxx/node_modules/vscode-jsonrpc/lib/common/connection.js:804:26)
    at Object.sendRequest (xxx/node_modules/vscode-jsonrpc/lib/common/connection.js:946:33)
    at Object.sendRequest (xxx/node_modules/vscode-languageclient/lib/common/client.js:38:54)
    at LanguageClient.sendRequest (xxx/node_modules/vscode-languageclient/lib/common/client.js:1918:45)
```