### PR TITLE
Mention dependency of codeDescription on code

### DIFF
--- a/types/src/main.ts
+++ b/types/src/main.ts
@@ -620,6 +620,7 @@ export interface Diagnostic {
 
 	/**
 	 * An optional property to describe the error code.
+	 * Requires the code field (above) to be present/not null.
 	 *
 	 * @since 3.16.0
 	 */


### PR DESCRIPTION
This was, in retrospect, obvious, but took me a while to figure out.
https://github.com/microsoft/vscode-languageserver-node/blob/d5b8fbe2b164bfb093734ba54d481da353bb1060/client/src/common/protocolConverter.ts#L269-L272