### PR TITLE
Location of SymbolInformation gets lost when range is not defined

### DIFF
--- a/client/src/common/protocolConverter.ts
+++ b/client/src/common/protocolConverter.ts
@@ -815,8 +815,8 @@ export function createConverter(uriConverter: URIConverter | undefined, trustMar
 		// Symbol kind is one based in the protocol and zero based in code.
 		let result = new code.SymbolInformation(
 			item.name, asSymbolKind(item.kind),
-			asRange(item.location.range),
-			item.location.uri ? _uriConverter(item.location.uri) : uri);
+			item.containerName!,
+			new code.Location(item.location.uri ? _uriConverter(item.location.uri) : uri!, asRange(item.location.range)));
 		fillTags(result, item);
 		if (item.containerName) { result.containerName = item.containerName; }
 		return result;


### PR DESCRIPTION
This is a follow-up of https://github.com/microsoft/vscode/issues/136618

`location` of `SymbolInformation` is lost in the deprecated `vscode.SymbolInformation` constructor that is used here:

https://github.com/microsoft/vscode-languageserver-node/blob/859a8ece3e14b130d531c6102b2d108196436bc4/client/src/common/protocolConverter.ts#L816-L819

This is only a problem if `range` is not defined in which case vscode will not display the symbol in the symbol picker. The `range` needs to be falsy in order to use [resolveWorkspaceSymbol](https://github.com/microsoft/vscode/blob/2c083a7bc92a86077f32a0d700c3821b76372e62/src/vs/vscode.d.ts#L3151)

To override `resolveWorkspaceSymbol`, I used the following code:
```
const feature = this.languageClient.getFeature('workspace/symbol');
const provider: WorkspaceSymbolProvider = feature.getProviders()[0];
provider.resolveWorkspaceSymbol = (symbol, token) => {
	return new SymbolInformation(symbol.name, symbol.kind, "foo", new Location(Uri.parse("/foo"), new Position(120, 20)))
}
```

The updated constructor invocation should create exactly the same object as before: https://github.com/microsoft/vscode/blob/042a6e36a495db9830029d87c12dd9b65c7e3b47/src/vs/workbench/api/common/extHostTypes.ts#L1094-L1110