### PR TITLE
correct engines field node 14+

### DIFF
--- a/jsonrpc/package.json
+++ b/jsonrpc/package.json
@@ -13,7 +13,7 @@
 		"url": "https://github.com/Microsoft/vscode-languageserver-node/issues"
 	},
 	"engines": {
-		"node": ">=8.0.0 || >=10.0.0"
+		"node": ">=14.0.0"
 	},
 	"main": "./lib/node/main.js",
 	"browser": {


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining

Optional chaining is supported by Node 14+.