### PR TITLE
Don't ignore sourcemap files in .npmignore

### DIFF
--- a/client/.npmignore
+++ b/client/.npmignore
@@ -1,7 +1,6 @@
 .vscode/
 lib/**/test/
 .vscode-test/
-lib/**/*.map
 lib/**/*.tsbuildInfo
 src/
 test/

--- a/jsonrpc/.npmignore
+++ b/jsonrpc/.npmignore
@@ -1,7 +1,6 @@
 .vscode/
 dist/
 lib/**/test/
-lib/**/*.map
 lib/**/*.tsbuildInfo
 src/
 test/

--- a/protocol/.npmignore
+++ b/protocol/.npmignore
@@ -1,7 +1,6 @@
 .vscode/
 dist/
 lib/**/test/
-lib/**/*.map
 lib/**/*.tsbuildInfo
 src/
 test/

--- a/server/.npmignore
+++ b/server/.npmignore
@@ -1,6 +1,5 @@
 .vscode/
 lib/**/test/
-lib/**/*.map
 lib/**/*.tsbuildInfo
 src/
 test/


### PR DESCRIPTION
# Fixes https://github.com/microsoft/vscode-languageserver-node/issues/879

_This PR should be considered mutually exclusive with https://github.com/microsoft/vscode-languageserver-node/pull/899 - i.e. only one of the two should be merged._

## The problem 
The packages in this repo are configured to produce source maps at compile-time, which includes:
1. a reference to a source map at the bottom of each generated JS file, e.g. 
    ```js
    // lib/browser/main.js
    ...

        return browser_1.createMessageConnection(reader, writer, logger, options);
    }
    exports.createProtocolConnection = createProtocolConnection;
    //# sourceMappingURL=main.js.map
    ```
1. a source map, e.g. `lib/browser/main.js.map`

However, when the packages are published, the source maps are not uploaded because they are explicitly ignored by npm: https://github.com/microsoft/vscode-languageserver-node/blob/f72faa0975cb2aaa85ce84da819944f84e1aac52/protocol/.npmignore#L4

Therefore, the published package:
1. does include the references at the bottom of each generated JS file
1. does **not** include the actual source maps

These dangling references are causing build errors:
```
Failed to parse source map from '/home/char0n/Documents/GitHub/test/node_modules/vscode-languageserver-protocol/lib/common/utils/is.js.map' file: Error: ENOENT: no such file or directory, open '/home/char0n/Documents/GitHub/test/node_modules/vscode-languageserver-protocol/lib/common/utils/is.js.map'
``` 

## The solution

There are two solutions that I can think of:
1. Don't produce source maps. This effectively maintains the current functionality, but removes the dangling references in the generated JS files.
1. Produce and publish source maps - i.e. don't ignore `lib/\*\*/\*.map` in `.npmignore`

While I think Option 2 is a better devx, I'd understand if you'd like to maintain the current functionality. To that end, I've created two PRs:
1. https://github.com/microsoft/vscode-languageserver-node/pull/899 does Option 1.
1. This PR does Option 2.

Let me know which is your preference and I'll close the other one.

Thanks!