### PR TITLE
Provides a way to register a file watcher relative to a given uri.

### DIFF
--- a/client/src/common/client.ts
+++ b/client/src/common/client.ts
@@ -1411,6 +1411,7 @@ class FileSystemWatcherFeature implements DynamicFeature<DidChangeWatchedFilesRe
 
 	public fillClientCapabilities(capabilities: ClientCapabilities): void {
 		ensure(ensure(capabilities, 'workspace')!, 'didChangeWatchedFiles')!.dynamicRegistration = true;
+		ensure(ensure(capabilities, 'workspace')!, 'didChangeWatchedFiles')!.relativePatternSupport = true;
 	}
 
 	public initialize(_capabilities: ServerCapabilities, _documentSelector: DocumentSelector): void {

--- a/client/src/common/client.ts
+++ b/client/src/common/client.ts
@@ -20,7 +20,7 @@ import {
 	DocumentRangeFormattingEditProvider, OnTypeFormattingEditProvider, RenameProvider, DocumentLinkProvider, DocumentColorProvider, DeclarationProvider,
 	FoldingRangeProvider, ImplementationProvider, SelectionRangeProvider, TypeDefinitionProvider, WorkspaceSymbolProvider, CallHierarchyProvider,
 	DocumentSymbolProviderMetadata, EventEmitter, env as Env, TextDocumentShowOptions, FileWillCreateEvent, FileWillRenameEvent, FileWillDeleteEvent, FileCreateEvent, FileDeleteEvent, FileRenameEvent,
-	LinkedEditingRangeProvider, Event as VEvent, CancellationError, TypeHierarchyProvider as VTypeHierarchyProvider, CancellationTokenSource, NotebookDocument, NotebookCell,
+	LinkedEditingRangeProvider, Event as VEvent, CancellationError, TypeHierarchyProvider as VTypeHierarchyProvider, CancellationTokenSource, NotebookDocument, NotebookCell, RelativePattern,
 } from 'vscode';
 
 import {
@@ -53,7 +53,7 @@ import {
 	FileOperationRegistrationOptions, WillCreateFilesRequest, WillRenameFilesRequest, WillDeleteFilesRequest, DidCreateFilesNotification, DidDeleteFilesNotification,
 	DidRenameFilesNotification, ShowDocumentParams, ShowDocumentResult, LinkedEditingRangeRequest, WorkDoneProgress, WorkDoneProgressBegin, WorkDoneProgressEnd,
 	WorkDoneProgressReport, PrepareSupportDefaultBehavior, SemanticTokensRequest, SemanticTokensRangeRequest, SemanticTokensDeltaRequest, Proposed, WorkspaceSymbolResolveRequest,
-	Diagnostic, ApplyWorkspaceEditResult, InlayHintRequest, InlineValueRequest, TypeHierarchyPrepareRequest
+	Diagnostic, ApplyWorkspaceEditResult, InlayHintRequest, InlineValueRequest, TypeHierarchyPrepareRequest, GlobPattern
 } from 'vscode-languageserver-protocol';
 
 import { toJSONObject } from './configuration';
@@ -1422,7 +1422,7 @@ class FileSystemWatcherFeature implements DynamicFeature<DidChangeWatchedFilesRe
 		}
 		let disposables: Disposable[] = [];
 		for (let watcher of data.registerOptions.watchers) {
-			if (!Is.string(watcher.globPattern)) {
+			if (!Is.string(watcher.globPattern) && !GlobPattern.is(watcher.globPattern)) {
 				continue;
 			}
 			let watchCreate: boolean = true, watchChange: boolean = true, watchDelete: boolean = true;
@@ -1431,7 +1431,10 @@ class FileSystemWatcherFeature implements DynamicFeature<DidChangeWatchedFilesRe
 				watchChange = (watcher.kind & WatchKind.Change) !== 0;
 				watchDelete = (watcher.kind & WatchKind.Delete) !== 0;
 			}
-			let fileSystemWatcher: VFileSystemWatcher = Workspace.createFileSystemWatcher(watcher.globPattern, !watchCreate, !watchChange, !watchDelete);
+			const globPattern =
+				Is.string(watcher.globPattern) ? watcher.globPattern :
+					new RelativePattern(watcher.globPattern.baseUri, watcher.globPattern.pattern);
+			let fileSystemWatcher: VFileSystemWatcher = Workspace.createFileSystemWatcher(globPattern, !watchCreate, !watchChange, !watchDelete);
 			this.hookListeners(fileSystemWatcher, watchCreate, watchChange, watchDelete);
 			disposables.push(fileSystemWatcher);
 		}

--- a/client/src/common/client.ts
+++ b/client/src/common/client.ts
@@ -20,7 +20,7 @@ import {
 	DocumentRangeFormattingEditProvider, OnTypeFormattingEditProvider, RenameProvider, DocumentLinkProvider, DocumentColorProvider, DeclarationProvider,
 	FoldingRangeProvider, ImplementationProvider, SelectionRangeProvider, TypeDefinitionProvider, WorkspaceSymbolProvider, CallHierarchyProvider,
 	DocumentSymbolProviderMetadata, EventEmitter, env as Env, TextDocumentShowOptions, FileWillCreateEvent, FileWillRenameEvent, FileWillDeleteEvent, FileCreateEvent, FileDeleteEvent, FileRenameEvent,
-	LinkedEditingRangeProvider, Event as VEvent, CancellationError, TypeHierarchyProvider as VTypeHierarchyProvider, CancellationTokenSource, NotebookDocument, NotebookCell, RelativePattern,
+	LinkedEditingRangeProvider, Event as VEvent, CancellationError, TypeHierarchyProvider as VTypeHierarchyProvider, CancellationTokenSource, NotebookDocument, NotebookCell, RelativePattern as VRelativePattern,
 } from 'vscode';
 
 import {
@@ -53,7 +53,7 @@ import {
 	FileOperationRegistrationOptions, WillCreateFilesRequest, WillRenameFilesRequest, WillDeleteFilesRequest, DidCreateFilesNotification, DidDeleteFilesNotification,
 	DidRenameFilesNotification, ShowDocumentParams, ShowDocumentResult, LinkedEditingRangeRequest, WorkDoneProgress, WorkDoneProgressBegin, WorkDoneProgressEnd,
 	WorkDoneProgressReport, PrepareSupportDefaultBehavior, SemanticTokensRequest, SemanticTokensRangeRequest, SemanticTokensDeltaRequest, Proposed, WorkspaceSymbolResolveRequest,
-	Diagnostic, ApplyWorkspaceEditResult, InlayHintRequest, InlineValueRequest, TypeHierarchyPrepareRequest, GlobPattern
+	Diagnostic, ApplyWorkspaceEditResult, InlayHintRequest, InlineValueRequest, TypeHierarchyPrepareRequest, RelativePattern
 } from 'vscode-languageserver-protocol';
 
 import { toJSONObject } from './configuration';
@@ -1422,7 +1422,7 @@ class FileSystemWatcherFeature implements DynamicFeature<DidChangeWatchedFilesRe
 		}
 		let disposables: Disposable[] = [];
 		for (let watcher of data.registerOptions.watchers) {
-			if (!Is.string(watcher.globPattern) && !GlobPattern.is(watcher.globPattern)) {
+			if (!Is.string(watcher.globPattern) && !RelativePattern.is(watcher.globPattern)) {
 				continue;
 			}
 			let watchCreate: boolean = true, watchChange: boolean = true, watchDelete: boolean = true;
@@ -1433,7 +1433,7 @@ class FileSystemWatcherFeature implements DynamicFeature<DidChangeWatchedFilesRe
 			}
 			const globPattern =
 				Is.string(watcher.globPattern) ? watcher.globPattern :
-					new RelativePattern(watcher.globPattern.baseUri, watcher.globPattern.pattern);
+					new VRelativePattern(watcher.globPattern.baseUri, watcher.globPattern.pattern);
 			let fileSystemWatcher: VFileSystemWatcher = Workspace.createFileSystemWatcher(globPattern, !watchCreate, !watchChange, !watchDelete);
 			this.hookListeners(fileSystemWatcher, watchCreate, watchChange, watchDelete);
 			disposables.push(fileSystemWatcher);

--- a/protocol/metaModel.json
+++ b/protocol/metaModel.json
@@ -7788,9 +7788,9 @@
 					"name": "globPattern",
 					"type": {
 						"kind": "base",
-						"name": "string"
+						"name": "GlobPattern"
 					},
-					"documentation": "The  glob pattern to watch. Glob patterns can have the following syntax:\n- `*` to match one or more characters in a path segment\n- `?` to match on one character in a path segment\n- `**` to match any number of path segments, including none\n- `{}` to group conditions (e.g. `**​/*.{ts,js}` matches all TypeScript and JavaScript files)\n- `[]` to declare a range of characters to match in a path segment (e.g., `example.[0-9]` to match on `example.0`, `example.1`, …)\n- `[!...]` to negate a range of characters to match in a path segment (e.g., `example.[!0-9]` to match on `example.a`, `example.b`, but not `example.0`)"
+					"documentation": "The glob pattern to watch. See {@link GlobPattern glob pattern} for more detail."
 				},
 				{
 					"name": "kind",
@@ -7800,6 +7800,44 @@
 					},
 					"optional": true,
 					"documentation": "The kind of events of interest. If omitted it defaults\nto WatchKind.Create | WatchKind.Change | WatchKind.Delete\nwhich is 7."
+				}
+			]
+		},
+		{
+			"name": "GlobPattern",
+			"type": {
+				"kind": "or",
+				"items": [
+					{
+						"kind": "reference",
+						"name": "string"
+					},
+					{
+						"kind": "reference",
+						"name": "RelativePattern"
+					}
+				]
+			},
+			"documentation": "The glob pattern to match file paths against. This can either be a glob pattern string\n(like `**​/*.{ts,js}` or `*.{ts,js}`) or a {@link RelativePattern relative pattern}.\n\nGlob patterns can have the following syntax:\n - `*` to match one or more characters in a path segment\n - `?` to match on one character in a path segment\n - `**` to match any number of path segments, including none\n - `{}` to group conditions (e.g. `**​/*.{ts,js}` matches all TypeScript and JavaScript files)\n - `[]` to declare a range of characters to match in a path segment (e.g., `example.[0-9]` to match on `example.0`, `example.1`, …)\n - `[!...]` to negate a range of characters to match in a path segment (e.g., `example.[!0-9]` to match on `example.a`, `example.b`, but not `example.0`)"
+		},
+		{
+			"name": "RelativePattern",
+			"properties": [
+				{
+					"name": "baseUri",
+					"type": {
+						"kind": "base",
+						"name": "DocumentUri"
+					},
+					"documentation": "A base file path to which this pattern will be matched against relatively."
+				},
+				{
+					"name": "pattern",
+					"type": {
+						"kind": "base",
+						"name": "string"
+					},
+					"documentation": "The  glob pattern to watch. Glob patterns can have the following syntax:\n- `*` to match one or more characters in a path segment\n- `?` to match on one character in a path segment\n- `**` to match any number of path segments, including none\n- `{}` to group conditions (e.g. `**​/*.{ts,js}` matches all TypeScript and JavaScript files)\n- `[]` to declare a range of characters to match in a path segment (e.g., `example.[0-9]` to match on `example.0`, `example.1`, …)\n- `[!...]` to negate a range of characters to match in a path segment (e.g., `example.[!0-9]` to match on `example.a`, `example.b`, but not `example.0`)"
 				}
 			]
 		},
@@ -10362,6 +10400,15 @@
 					},
 					"optional": true,
 					"documentation": "Did change watched files notification supports dynamic registration. Please note\nthat the current protocol doesn't support static configuration for file changes\nfrom the server side."
+				},
+				{
+					"name": "relativePatternSupport",
+					"type": {
+						"kind": "base",
+						"name": "boolean"
+					},
+					"optional": true,
+					"documentation": "Did change watched files notification supports relative pattern."
 				}
 			]
 		},

--- a/protocol/src/common/protocol.ts
+++ b/protocol/src/common/protocol.ts
@@ -1807,6 +1807,12 @@ export interface DidChangeWatchedFilesClientCapabilities {
 	 * from the server side.
 	 */
 	dynamicRegistration?: boolean;
+	/**
+	 * A relative pattern is a helper to construct glob patterns that are matched
+	 * relatively to a base file path. The base path can either be an absolute file
+	 * path as string or uri.
+	 */
+	relativePatternSupport?: boolean;
 }
 
 /**
@@ -1871,7 +1877,12 @@ export interface DidChangeWatchedFilesRegistrationOptions {
 	watchers: FileSystemWatcher[];
 }
 
-export interface GlobPattern {
+/**
+ * A relative pattern is a helper to construct glob patterns that are matched
+ * relatively to a base file path. The base path can either be an absolute file
+ * path as string or uri.
+ */
+export interface RelativePattern {
 	/**
 	 * A base file path to which this pattern will be matched against relatively.
 	 */
@@ -1889,24 +1900,32 @@ export interface GlobPattern {
 	 pattern: string;
 }
 
-export namespace GlobPattern {
-	export function is(value: any): value is GlobPattern {
-		const candidate: GlobPattern = value;
+export namespace RelativePattern {
+	export function is(value: any): value is RelativePattern {
+		const candidate: RelativePattern = value;
 		return DocumentUri.is(candidate.baseUri) && Is.string(candidate.pattern);
 	}
 }
 
+/**
+ * The glob pattern to match file paths against. This can either be a glob pattern string
+ * (like `**​/*.{ts,js}` or `*.{ts,js}`) or a {@link RelativePattern relative pattern}.
+ *
+ * Glob patterns can have the following syntax:
+ * - `*` to match one or more characters in a path segment
+ * - `?` to match on one character in a path segment
+ * - `**` to match any number of path segments, including none
+ * - `{}` to group conditions (e.g. `**​/*.{ts,js}` matches all TypeScript and JavaScript files)
+ * - `[]` to declare a range of characters to match in a path segment (e.g., `example.[0-9]` to match on `example.0`, `example.1`, …)
+ * - `[!...]` to negate a range of characters to match in a path segment (e.g., `example.[!0-9]` to match on `example.a`, `example.b`, but not `example.0`)
+ */
+export type GlobPattern = string | RelativePattern;
+
 export interface FileSystemWatcher {
 	/**
-	 * The glob pattern to watch. Glob patterns can have the following syntax:
-	 * - `*` to match one or more characters in a path segment
-	 * - `?` to match on one character in a path segment
-	 * - `**` to match any number of path segments, including none
-	 * - `{}` to group conditions (e.g. `**​/*.{ts,js}` matches all TypeScript and JavaScript files)
-	 * - `[]` to declare a range of characters to match in a path segment (e.g., `example.[0-9]` to match on `example.0`, `example.1`, …)
-	 * - `[!...]` to negate a range of characters to match in a path segment (e.g., `example.[!0-9]` to match on `example.a`, `example.b`, but not `example.0`)
+	 * The glob pattern to watch. See {@link GlobPattern glob pattern} for more detail.
 	 */
-	globPattern: string | GlobPattern;
+	globPattern: GlobPattern;
 
 	/**
 	 * The kind of events of interest. If omitted it defaults

--- a/protocol/src/common/protocol.ts
+++ b/protocol/src/common/protocol.ts
@@ -1871,9 +1871,14 @@ export interface DidChangeWatchedFilesRegistrationOptions {
 	watchers: FileSystemWatcher[];
 }
 
-export interface FileSystemWatcher {
+export interface GlobPattern {
 	/**
-	 * The  glob pattern to watch. Glob patterns can have the following syntax:
+	 * A base file path to which this pattern will be matched against relatively.
+	 */
+	baseUri: DocumentUri;
+
+	/**
+	 * The glob pattern to watch relative to the base path. Glob patterns can have the following syntax:
 	 * - `*` to match one or more characters in a path segment
 	 * - `?` to match on one character in a path segment
 	 * - `**` to match any number of path segments, including none
@@ -1881,7 +1886,27 @@ export interface FileSystemWatcher {
 	 * - `[]` to declare a range of characters to match in a path segment (e.g., `example.[0-9]` to match on `example.0`, `example.1`, …)
 	 * - `[!...]` to negate a range of characters to match in a path segment (e.g., `example.[!0-9]` to match on `example.a`, `example.b`, but not `example.0`)
 	 */
-	globPattern: string;
+	 pattern: string;
+}
+
+export namespace GlobPattern {
+	export function is(value: any): value is GlobPattern {
+		const candidate: GlobPattern = value;
+		return DocumentUri.is(candidate.baseUri) && Is.string(candidate.pattern);
+	}
+}
+
+export interface FileSystemWatcher {
+	/**
+	 * The glob pattern to watch. Glob patterns can have the following syntax:
+	 * - `*` to match one or more characters in a path segment
+	 * - `?` to match on one character in a path segment
+	 * - `**` to match any number of path segments, including none
+	 * - `{}` to group conditions (e.g. `**​/*.{ts,js}` matches all TypeScript and JavaScript files)
+	 * - `[]` to declare a range of characters to match in a path segment (e.g., `example.[0-9]` to match on `example.0`, `example.1`, …)
+	 * - `[!...]` to negate a range of characters to match in a path segment (e.g., `example.[!0-9]` to match on `example.a`, `example.b`, but not `example.0`)
+	 */
+	globPattern: string | GlobPattern;
 
 	/**
 	 * The kind of events of interest. If omitted it defaults


### PR DESCRIPTION
Visual studio code added an ability to watch file/folders outside of workspace folder but LSP didn't expose the ability to server yet. This PR adds that support to LSP.

here are link to spec - https://github.com/microsoft/language-server-protocol/pull/1433

and here are link to vscode API - vscode.workspace.createFileSystemWatcher - https://github.com/microsoft/vscode/blob/main/src/vscode-dts/vscode.d.ts#L11516