### PR TITLE
convert tabs to spaces to fix improper indentation

### DIFF
--- a/types/src/main.ts
+++ b/types/src/main.ts
@@ -1886,13 +1886,13 @@ export type MarkupKind = 'plaintext' | 'markdown';
  * ```ts
  * let markdown: MarkdownContent = {
  *  kind: MarkupKind.Markdown,
- *	value: [
- *		'# Header',
- *		'Some text',
- *		'```typescript',
- *		'someCode();',
- *		'```'
- *	].join('\n')
+ *  value: [
+ *    '# Header',
+ *    'Some text',
+ *    '```typescript',
+ *    'someCode();',
+ *    '```'
+ *  ].join('\n')
  * };
  * ```
  *


### PR DESCRIPTION
The hover documentation for `interface MarkupContent` isn't aligned; converting tabs to spaces appears to fix its formatting.

### Without this change
![image](https://user-images.githubusercontent.com/43425812/166168451-417e166b-6350-4aca-9039-4f2f1c3bd7b5.png)

### With this change
![image](https://user-images.githubusercontent.com/43425812/166168437-15f7a461-4c07-4d77-bade-9db3fc29f7aa.png)