### PR TITLE
Map LSPAny to any

### DIFF
--- a/client/src/common/notebook.ts
+++ b/client/src/common/notebook.ts
@@ -9,7 +9,7 @@ import * as minimatch from 'minimatch';
 
 import * as proto from 'vscode-languageserver-protocol';
 import {
-	StaticRegistrationOptions, NotebookDocumentFilter, LSPObject, LSPArray, TextDocumentItem, NotebookCellTextDocumentFilter
+	StaticRegistrationOptions, NotebookDocumentFilter, TextDocumentItem, NotebookCellTextDocumentFilter, LSPAny
 } from 'vscode-languageserver-protocol';
 
 import * as UUID from './utils/uuid';
@@ -26,6 +26,9 @@ function ensure<T, K extends keyof T>(target: T, key: K): T[K] {
 	}
 	return target[key];
 }
+
+type LSPObject = { [key: string]: LSPAny };
+type LSPArray = LSPAny[];
 
 namespace Converter {
 	export namespace c2p {

--- a/protocol/src/common/protocol.notebook.ts
+++ b/protocol/src/common/protocol.notebook.ts
@@ -4,7 +4,7 @@
  * ------------------------------------------------------------------------------------------ */
 
 import {
-	URI, integer, DocumentUri, uinteger, LSPAny, LSPObject, TextDocumentItem, TextDocumentIdentifier,
+	URI, integer, DocumentUri, uinteger, LSPAny, TextDocumentItem, TextDocumentIdentifier,
 	VersionedTextDocumentIdentifier
 } from 'vscode-languageserver-types';
 
@@ -123,8 +123,10 @@ export type NotebookCell = {
 
 	/**
 	 * Additional metadata stored with the cell.
+	 *
+	 * Note: should always be an object literal (e.g. LSPObject)
 	 */
-	metadata?: LSPObject;
+	metadata?: LSPAny;
 
 	/**
 	 * Additional execution summary information
@@ -165,6 +167,7 @@ export namespace NotebookCell {
 	}
 
 	function equalsMetadata(one: LSPAny | undefined, other: LSPAny | undefined): boolean {
+		type LSPObject = { [key: string]: LSPAny };
 		if (one === other) {
 			return true;
 		}
@@ -244,8 +247,10 @@ export type NotebookDocument = {
 	/**
 	 * Additional metadata stored with the notebook
 	 * document.
+	 *
+	 * Note: should always be an object literal (e.g. LSPObject)
 	 */
-	metadata?: LSPObject;
+	metadata?: LSPAny;
 
 	/**
 	 * The cells of a notebook.
@@ -440,8 +445,10 @@ export namespace NotebookCellArrayChange {
 export type NotebookDocumentChangeEvent = {
 	/**
 	 * The changed meta data if any.
+	 *
+	 * Note: should always be an object literal (e.g. LSPObject)
 	 */
-	metadata?: LSPObject;
+	metadata?: LSPAny;
 
 	/**
 	 * Changes to cells

--- a/server/src/common/notebook.ts
+++ b/server/src/common/notebook.ts
@@ -5,10 +5,10 @@
 'use strict';
 
 import {
-	NotificationHandler1, Emitter, Event, LSPObject, DidChangeTextDocumentParams, DidCloseTextDocumentParams, DidOpenTextDocumentParams,
+	NotificationHandler1, Emitter, Event, DidChangeTextDocumentParams, DidCloseTextDocumentParams, DidOpenTextDocumentParams,
 	NotificationHandler, DocumentUri, URI, Disposable, DidOpenNotebookDocumentParams, DidChangeNotebookDocumentParams, DidSaveNotebookDocumentParams,
 	DidCloseNotebookDocumentParams, DidOpenNotebookDocumentNotification, DidChangeNotebookDocumentNotification, DidSaveNotebookDocumentNotification,
-	DidCloseNotebookDocumentNotification, NotebookDocument, NotebookCell
+	DidCloseNotebookDocumentNotification, NotebookDocument, NotebookCell, LSPAny
 } from 'vscode-languageserver-protocol';
 
 import type { Feature, _Notebooks, Connection, } from './server';
@@ -67,8 +67,10 @@ export type NotebookDocumentChangeEvent = {
 
 	/**
 	 * The meta data change if any.
+	 *
+	 * Note: old and new should always be an object literal (e.g. LSPObject)
 	 */
-	metadata?: { old: LSPObject | undefined; new: LSPObject | undefined };
+	metadata?: { old: LSPAny | undefined; new: LSPAny | undefined };
 
 	/**
 	 * The cell changes if any.

--- a/types/src/main.ts
+++ b/types/src/main.ts
@@ -67,6 +67,19 @@ export type decimal = number;
 /**
  * The LSP any type.
  *
+ * In the current implementation we map LSPAny to any. This is due to the fact
+ * that the TypeScript compilers can't infer string access signatures for
+ * interface correctly (it can though for types). See the following issue for
+ * details: https://github.com/microsoft/TypeScript/issues/15300.
+ *
+ * When the issue is addressed LSPAny can be defined as follows:
+ *
+ * ```ts
+ * export type LSPAny = LSPObject | LSPArray | string | integer | uinteger | decimal | boolean | null | undefined;
+ * export type LSPObject = { [key: string]: LSPAny };
+ * export type LSPArray = LSPAny[];
+ * ```
+ *
  * Please note that strictly speaking a property with the value `undefined`
  * can't be converted into JSON preserving the property name. However for
  * convenience it is allowed and assumed that all these properties are
@@ -74,21 +87,7 @@ export type decimal = number;
  *
  * @since 3.17.0
  */
-export type LSPAny = LSPObject | LSPArray | string | integer | uinteger | decimal | boolean | null | undefined;
-
-/**
- * LSP object definition.
- *
- * @since 3.17.0
- */
-export type LSPObject = { [key: string]: LSPAny };
-
-/**
- * LSP arrays.
- *
- * @since 3.17.0
- */
-export type LSPArray = LSPAny[];
+export type LSPAny = any;
 
 /**
  * Position in a text document expressed as zero-based line and character


### PR DESCRIPTION
Maps LSPAny to any again to avoid TS compiler problems with access signature inferrence for interfaces.