### PR TITLE
make sure to unsubscribe from file events

### DIFF
--- a/client/src/common/fileSystemWatcher.ts
+++ b/client/src/common/fileSystemWatcher.ts
@@ -62,7 +62,7 @@ export class FileSystemWatcherFeature implements DynamicFeature<DidChangeWatched
 				watchDelete = (watcher.kind & WatchKind.Delete) !== 0;
 			}
 			const fileSystemWatcher: VFileSystemWatcher = Workspace.createFileSystemWatcher(globPattern, !watchCreate, !watchChange, !watchDelete);
-			this.hookListeners(fileSystemWatcher, watchCreate, watchChange, watchDelete);
+			this.hookListeners(fileSystemWatcher, watchCreate, watchChange, watchDelete, disposables);
 			disposables.push(fileSystemWatcher);
 		}
 		this._watchers.set(data.id, disposables);


### PR DESCRIPTION
I looked through vscode's code base and It doesn't look like ```fileSystemWatcher.dispose()``` through ```disposables.push(fileSystemWatcher);``` will unsubscribe each file watch subscription. 

each must be disposed individually by ```this.hookListeners(fileSystemWatcher, watchCreate, watchChange, watchDelete, **disposables**);``` like how ```registerRaw``` does.

here are relevant code in vscode

https://github.com/microsoft/vscode/blob/main/src/vs/workbench/api/common/extHostFileSystemEventService.ts#L22
https://github.com/microsoft/vscode/blob/main/src/vs/workbench/api/common/extHostFileSystemEventService.ts#L91
https://github.com/microsoft/vscode/blob/main/src/vs/base/common/event.ts#L617
https://github.com/microsoft/vscode/blob/main/src/vs/base/common/event.ts#L681
https://github.com/microsoft/vscode/blob/main/src/vs/base/common/lifecycle.ts#L356

basically, no one is calling dispose on listener.subscription which is disposable returned by fileWatcher.onXXX call.