### PR TITLE
[Bug Repro] Race bug repro 

### DIFF
--- a/client/src/common/semanticTokens.ts
+++ b/client/src/common/semanticTokens.ts
@@ -117,6 +117,8 @@ export class SemanticTokensFeature extends TextDocumentLanguageFeature<boolean |
 	}
 
 	protected registerLanguageProvider(options: SemanticTokensRegistrationOptions): [vscode.Disposable, SemanticTokensProviderShape] {
+		this._client.info('***** semantic registered');
+
 		const selector = options.documentSelector!;
 		const fullProvider = Is.boolean(options.full) ? options.full : options.full !== undefined;
 		const hasEditProvider = options.full !== undefined && typeof options.full !== 'boolean' && options.full.delta === true;
@@ -212,6 +214,9 @@ export class SemanticTokensFeature extends TextDocumentLanguageFeature<boolean |
 			disposables.push(vscode.languages.registerDocumentRangeSemanticTokensProvider(documentSelector, rangeProvider, legend));
 		}
 
-		return [new vscode.Disposable(() => disposables.forEach(item => item.dispose())), { range: rangeProvider, full: documentProvider, onDidChangeSemanticTokensEmitter: eventEmitter }];
+		return [new vscode.Disposable(() => {
+			this._client.info('***** disposed');
+			disposables.forEach(item => item.dispose());
+		}), { range: rangeProvider, full: documentProvider, onDidChangeSemanticTokensEmitter: eventEmitter }];
 	}
 }

--- a/testbed/client/package-lock.json
+++ b/testbed/client/package-lock.json
@@ -7,10 +7,26 @@
 		"": {
 			"name": "testbed-client",
 			"version": "0.1.0",
-			"devDependencies": {},
+			"devDependencies": {
+				"@types/vscode": "1.67.0"
+			},
 			"engines": {
-				"vscode": "^1.40.0"
+				"vscode": "^1.67.0"
 			}
+		},
+		"node_modules/@types/vscode": {
+			"version": "1.67.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.67.0.tgz",
+			"integrity": "sha512-GH8BDf8cw9AC9080uneJfulhSa7KHSMI2s/CyKePXoGNos9J486w2V4YKoeNUqIEkW4hKoEAWp6/cXTwyGj47g==",
+			"dev": true
+		}
+	},
+	"dependencies": {
+		"@types/vscode": {
+			"version": "1.67.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.67.0.tgz",
+			"integrity": "sha512-GH8BDf8cw9AC9080uneJfulhSa7KHSMI2s/CyKePXoGNos9J486w2V4YKoeNUqIEkW4hKoEAWp6/cXTwyGj47g==",
+			"dev": true
 		}
 	}
 }

--- a/testbed/client/package.json
+++ b/testbed/client/package.json
@@ -5,11 +5,13 @@
 	"private": true,
 	"publisher": "vscode",
 	"engines": {
-		"vscode": "^1.40.0"
+		"vscode": "^1.67.0"
 	},
 	"scripts": {
 		"watch": "tsc -watch -b ./tsconfig.json",
 		"compile": "tsc -b ./tsconfig.json"
 	},
-	"devDependencies": {}
+	"devDependencies": {
+		"@types/vscode": "1.67.0"
+	}
 }

--- a/testbed/client/src/extension.ts
+++ b/testbed/client/src/extension.ts
@@ -9,8 +9,9 @@ import { commands, ExtensionContext, Uri } from 'vscode';
 import { LanguageClient, LanguageClientOptions, ServerOptions, TransportKind, NotificationType, SuspendMode, DidOpenTextDocumentNotification } from 'vscode-languageclient/node';
 
 let client: LanguageClient;
+let id = 0;
 
-export function activate(context: ExtensionContext) {
+export async function activate(context: ExtensionContext) {
 	// We need to go one level up since an extension compile the js code into
 	// the output folder.
 	let module = path.join(__dirname, '..', '..', 'server', 'out', 'server.js');
@@ -57,20 +58,36 @@ export function activate(context: ExtensionContext) {
 		}
 	};
 
-	client = new LanguageClient('testbed', 'Testbed', serverOptions, clientOptions);
+	await runServer();
+	await runServer();
+	await runServer();
+	await runServer();
+	await runServer();
+	await runServer();
+	await runServer();
+	await runServer();
+	await runServer();
+	await runServer();
+	await runServer();
+	await runServer();
+
+	client = new LanguageClient('testbed' + id, 'Testbed' + id, serverOptions, clientOptions);
 	client.registerProposedFeatures();
-	client.onTelemetry((data: any) => {
-		console.log(`Telemetry event received: ${JSON.stringify(data)}`);
-	});
-	const not: NotificationType<string[]> = new NotificationType<string[]>('testbed/notification');
-	client.start().catch((error)=> client.error(`Start failed`, error, 'force'));
-	client.sendNotification(not, ['dirk', 'baeumer']).catch((error) => client.error(`Sending test notification failed`, error, 'force'));
-	commands.registerCommand('testbed.myCommand.invoked', () => {
-		void commands.executeCommand('testbed.myCommand').then(value => {
-			console.log(value);
-		});
-	});
+
+	await client.start();
+
+	async function runServer() {
+		client = new LanguageClient('testbed' + id, 'Testbed' + id, serverOptions, clientOptions);
+		client.registerProposedFeatures();
+
+		await client.start();
+		await client.stop();
+
+		id++;
+
+	}
 }
+
 
 export function deactivate() {
 	return client.stop();


### PR DESCRIPTION
I think LSP has a **race bug**.

**here are repro steps.**
1. sync the raceRepro branch
2. open extension.ts in testbed/client/src
3. set breakpoints at the code I added (shown below)
```
if (!allowRestart) {
	this.outputChannel.appendLine(`***** already stopped. client ${this.name}`);
	**throw new LSPCancellationError({ retriggerRequest: false });**
}
````
4. run "Launch TestBed Client"

Expectation - the breakpoint never hit since client is already stopped.

Actual - some requests such as semantic tokens, pulling diagnostics, dynamic registration requests and etc sometimes **run after client is explicitly stopped**. and those requests **automatically/implicitly/silently re-start client** that is already explicitly stopped. 

in our scenario, that implicit restart causes **crashes** due to conflict with another client already running.

here are examples of crash

it says, "Canceled" since I made the code above to throw cancellation error.

```
***** already stopped. client Testbed10
[Error - 11:10:46 PM] Sending request textDocument/semanticTokens/full failed.
Canceled: Canceled
	at LanguageClient.startInternal (d:\dd\vscode-languageserver-node\testbed\client\node_modules\vscode-languageclient\lib\common\client.js:581:19)
	at LanguageClient.$start (d:\dd\vscode-languageserver-node\testbed\client\node_modules\vscode-languageclient\lib\common\client.js:1020:20)
	at LanguageClient.sendRequest (d:\dd\vscode-languageserver-node\testbed\client\node_modules\vscode-languageclient\lib\common\client.js:319:43)
	at provideDocumentSemanticTokens (d:\dd\vscode-languageserver-node\testbed\client\node_modules\vscode-languageclient\lib\common\semanticTokens.js:98:39)
	at Object.provideDocumentSemanticTokens (d:\dd\vscode-languageserver-node\testbed\client\node_modules\vscode-languageclient\lib\common\semanticTokens.js:109:27)
	at V.provideDocumentSemanticTokens (c:\Users\hechang\AppData\Local\Programs\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:83:108386)
	at c:\Users\hechang\AppData\Local\Programs\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:83:134912
	at we._withAdapter (c:\Users\hechang\AppData\Local\Programs\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:83:126001)
	at we.$provideDocumentSemanticTokens (c:\Users\hechang\AppData\Local\Programs\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:83:134890)
	at s._doInvokeHandler (c:\Users\hechang\AppData\Local\Programs\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:86:13828)
	at s._invokeHandler (c:\Users\hechang\AppData\Local\Programs\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:86:13512)
	at s._receiveRequest (c:\Users\hechang\AppData\Local\Programs\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:86:12121)
	at s._receiveOneMessage (c:\Users\hechang\AppData\Local\Programs\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:86:10843)
	at c:\Users\hechang\AppData\Local\Programs\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:86:8949
	at m.invoke (c:\Users\hechang\AppData\Local\Programs\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:58:145)
	at b.deliver (c:\Users\hechang\AppData\Local\Programs\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:58:2265)
	at v.fire (c:\Users\hechang\AppData\Local\Programs\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:58:1843)
	at l.fire (c:\Users\hechang\AppData\Local\Programs\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:66:19001)
	at c:\Users\hechang\AppData\Local\Programs\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:102:34426
	at m.invoke (c:\Users\hechang\AppData\Local\Programs\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:58:145)
	at b.deliver (c:\Users\hechang\AppData\Local\Programs\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:58:2265)
	at v.fire (c:\Users\hechang\AppData\Local\Programs\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:58:1843)
	at l.fire (c:\Users\hechang\AppData\Local\Programs\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:66:19001)
	at r._receiveMessage (c:\Users\hechang\AppData\Local\Programs\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:66:23582)
	at c:\Users\hechang\AppData\Local\Programs\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:66:21116
	at m.invoke (c:\Users\hechang\AppData\Local\Programs\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:58:145)
	at b.deliver (c:\Users\hechang\AppData\Local\Programs\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:58:2265)
	at v.fire (c:\Users\hechang\AppData\Local\Programs\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:58:1843)
	at v.acceptChunk (c:\Users\hechang\AppData\Local\Programs\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:66:15832)
	at c:\Users\hechang\AppData\Local\Programs\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:66:14962
	at Socket.R (c:\Users\hechang\AppData\Local\Programs\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:102:13798)
	at Socket.emit (node:events:390:28)
	at addChunk (node:internal/streams/readable:315:12)
	at readableAddChunk (node:internal/streams/readable:289:9)
	at Socket.push (node:internal/streams/readable:228:10)
	at Pipe.onStreamRead (node:internal/stream_base_commons:199:23)
	at Pipe.callbackTrampoline (node:internal/async_hooks:130:17)
[Error - 11:10:46 PM] Request textDocument/semanticTokens/full failed.
Canceled: Canceled
	at LanguageClient.startInternal (d:\dd\vscode-languageserver-node\testbed\client\node_modules\vscode-languageclient\lib\common\client.js:581:19)
	at LanguageClient.$start (d:\dd\vscode-languageserver-node\testbed\client\node_modules\vscode-languageclient\lib\common\client.js:1020:20)
	at LanguageClient.sendRequest (d:\dd\vscode-languageserver-node\testbed\client\node_modules\vscode-languageclient\lib\common\client.js:319:43)
	at provideDocumentSemanticTokens (d:\dd\vscode-languageserver-node\testbed\client\node_modules\vscode-languageclient\lib\common\semanticTokens.js:98:39)
	at Object.provideDocumentSemanticTokens (d:\dd\vscode-languageserver-node\testbed\client\node_modules\vscode-languageclient\lib\common\semanticTokens.js:109:27)
	at V.provideDocumentSemanticTokens (c:\Users\hechang\AppData\Local\Programs\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:83:108386)
	at c:\Users\hechang\AppData\Local\Programs\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:83:134912
	at we._withAdapter (c:\Users\hechang\AppData\Local\Programs\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:83:126001)
	at we.$provideDocumentSemanticTokens (c:\Users\hechang\AppData\Local\Programs\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:83:134890)
	at s._doInvokeHandler (c:\Users\hechang\AppData\Local\Programs\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:86:13828)
	at s._invokeHandler (c:\Users\hechang\AppData\Local\Programs\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:86:13512)
	at s._receiveRequest (c:\Users\hechang\AppData\Local\Programs\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:86:12121)
	at s._receiveOneMessage (c:\Users\hechang\AppData\Local\Programs\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:86:10843)
	at c:\Users\hechang\AppData\Local\Programs\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:86:8949
	at m.invoke (c:\Users\hechang\AppData\Local\Programs\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:58:145)
	at b.deliver (c:\Users\hechang\AppData\Local\Programs\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:58:2265)
	at v.fire (c:\Users\hechang\AppData\Local\Programs\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:58:1843)
	at l.fire (c:\Users\hechang\AppData\Local\Programs\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:66:19001)
	at c:\Users\hechang\AppData\Local\Programs\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:102:34426
	at m.invoke (c:\Users\hechang\AppData\Local\Programs\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:58:145)
	at b.deliver (c:\Users\hechang\AppData\Local\Programs\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:58:2265)
	at v.fire (c:\Users\hechang\AppData\Local\Programs\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:58:1843)
	at l.fire (c:\Users\hechang\AppData\Local\Programs\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:66:19001)
	at r._receiveMessage (c:\Users\hechang\AppData\Local\Programs\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:66:23582)
	at c:\Users\hechang\AppData\Local\Programs\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:66:21116
	at m.invoke (c:\Users\hechang\AppData\Local\Programs\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:58:145)
	at b.deliver (c:\Users\hechang\AppData\Local\Programs\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:58:2265)
	at v.fire (c:\Users\hechang\AppData\Local\Programs\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:58:1843)
	at v.acceptChunk (c:\Users\hechang\AppData\Local\Programs\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:66:15832)
	at c:\Users\hechang\AppData\Local\Programs\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:66:14962
	at Socket.R (c:\Users\hechang\AppData\Local\Programs\Microsoft VS Code\resources\app\out\vs\workbench\api\node\extensionHostProcess.js:102:13798)
	at Socket.emit (node:events:390:28)
	at addChunk (node:internal/streams/readable:315:12)
	at readableAddChunk (node:internal/streams/readable:289:9)
	at Socket.push (node:internal/streams/readable:228:10)
	at Pipe.onStreamRead (node:internal/stream_base_commons:199:23)
	at Pipe.callbackTrampoline (node:internal/async_hooks:130:17)
***** already stopped. client Testbed10
[Error - 11:11:08 PM] Sending request textDocument/diagnostic failed.
Canceled: Canceled
	at LanguageClient.startInternal (d:\dd\vscode-languageserver-node\testbed\client\node_modules\vscode-languageclient\lib\common\client.js:581:19)
	at LanguageClient.$start (d:\dd\vscode-languageserver-node\testbed\client\node_modules\vscode-languageclient\lib\common\client.js:1020:20)
	at LanguageClient.sendRequest (d:\dd\vscode-languageserver-node\testbed\client\node_modules\vscode-languageclient\lib\common\client.js:319:43)
	at provideDiagnostics (d:\dd\vscode-languageserver-node\testbed\client\node_modules\vscode-languageclient\lib\common\diagnostic.js:328:40)
	at Object.provideDiagnostics (d:\dd\vscode-languageserver-node\testbed\client\node_modules\vscode-languageclient\lib\common\diagnostic.js:345:23)
	at DiagnosticRequestor.pullAsync (d:\dd\vscode-languageserver-node\testbed\client\node_modules\vscode-languageclient\lib\common\diagnostic.js:197:46)
	at DiagnosticRequestor.pull (d:\dd\vscode-languageserver-node\testbed\client\node_modules\vscode-languageclient\lib\common\diagnostic.js:174:14)
	at Timeout.<anonymous> (d:\dd\vscode-languageserver-node\testbed\client\node_modules\vscode-languageclient\lib\common\diagnostic.js:482:42)
	at listOnTimeout (node:internal/timers:557:17)
	at processTimers (node:internal/timers:500:7)
[Error - 11:11:08 PM] Request textDocument/diagnostic failed.
Canceled: Canceled
	at LanguageClient.startInternal (d:\dd\vscode-languageserver-node\testbed\client\node_modules\vscode-languageclient\lib\common\client.js:581:19)
	at LanguageClient.$start (d:\dd\vscode-languageserver-node\testbed\client\node_modules\vscode-languageclient\lib\common\client.js:1020:20)
	at LanguageClient.sendRequest (d:\dd\vscode-languageserver-node\testbed\client\node_modules\vscode-languageclient\lib\common\client.js:319:43)
	at provideDiagnostics (d:\dd\vscode-languageserver-node\testbed\client\node_modules\vscode-languageclient\lib\common\diagnostic.js:328:40)
	at Object.provideDiagnostics (d:\dd\vscode-languageserver-node\testbed\client\node_modules\vscode-languageclient\lib\common\diagnostic.js:345:23)
	at DiagnosticRequestor.pullAsync (d:\dd\vscode-languageserver-node\testbed\client\node_modules\vscode-languageclient\lib\common\diagnostic.js:197:46)
	at DiagnosticRequestor.pull (d:\dd\vscode-languageserver-node\testbed\client\node_modules\vscode-languageclient\lib\common\diagnostic.js:174:14)
	at Timeout.<anonymous> (d:\dd\vscode-languageserver-node\testbed\client\node_modules\vscode-languageclient\lib\common\diagnostic.js:482:42)
	at listOnTimeout (node:internal/timers:557:17)
	at processTimers (node:internal/timers:500:7)
[Error - 11:11:08 PM] Document pull failed for text document file:///d%3A/pytest/requestTest/test.bat
Canceled: Canceled
	at LanguageClient.startInternal (d:\dd\vscode-languageserver-node\testbed\client\node_modules\vscode-languageclient\lib\common\client.js:581:19)
	at LanguageClient.$start (d:\dd\vscode-languageserver-node\testbed\client\node_modules\vscode-languageclient\lib\common\client.js:1020:20)
	at LanguageClient.sendRequest (d:\dd\vscode-languageserver-node\testbed\client\node_modules\vscode-languageclient\lib\common\client.js:319:43)
	at provideDiagnostics (d:\dd\vscode-languageserver-node\testbed\client\node_modules\vscode-languageclient\lib\common\diagnostic.js:328:40)
	at Object.provideDiagnostics (d:\dd\vscode-languageserver-node\testbed\client\node_modules\vscode-languageclient\lib\common\diagnostic.js:345:23)
	at DiagnosticRequestor.pullAsync (d:\dd\vscode-languageserver-node\testbed\client\node_modules\vscode-languageclient\lib\common\diagnostic.js:197:46)
	at DiagnosticRequestor.pull (d:\dd\vscode-languageserver-node\testbed\client\node_modules\vscode-languageclient\lib\common\diagnostic.js:174:14)
	at Timeout.<anonymous> (d:\dd\vscode-languageserver-node\testbed\client\node_modules\vscode-languageclient\lib\common\diagnostic.js:482:42)
	at listOnTimeout (node:internal/timers:557:17)
	at processTimers (node:internal/timers:500:7)
```

this doesn't repro every time, but often enough for us to get thousands of crash reports