### PR TITLE
Fix typos + minor doc tweaks

### DIFF
--- a/protocol/src/common/protocol.callHierarchy.ts
+++ b/protocol/src/common/protocol.callHierarchy.ts
@@ -50,7 +50,7 @@ export interface CallHierarchyPrepareParams extends TextDocumentPositionParams, 
 
 /**
  * A request to result a `CallHierarchyItem` in a document at a given position.
- * Can be used as an input to a incoming or outgoing call hierarchy.
+ * Can be used as an input to an incoming or outgoing call hierarchy.
  *
  * @since 3.16.0
  */

--- a/protocol/src/common/protocol.diagnostic.ts
+++ b/protocol/src/common/protocol.diagnostic.ts
@@ -111,7 +111,7 @@ export namespace DiagnosticServerCancellationData {
  *
  * @since 3.17.0
  */
-export type DocumentDiagnosticParams =  WorkDoneProgressParams & PartialResultParams & {
+export type DocumentDiagnosticParams = WorkDoneProgressParams & PartialResultParams & {
 	/**
 	 * The text document.
 	 */
@@ -231,14 +231,14 @@ export type RelatedUnchangedDocumentDiagnosticReport = UnchangedDocumentDiagnost
 	 * @since 3.17.0
 	 */
 	relatedDocuments?: {
-		[uri: DocumentUri ]: FullDocumentDiagnosticReport | UnchangedDocumentDiagnosticReport;
+		[uri: DocumentUri]: FullDocumentDiagnosticReport | UnchangedDocumentDiagnosticReport;
 	};
 };
 
 /**
  * The result of a document diagnostic pull request. A report can
  * either be a full report containing all diagnostics for the
- * requested document or a unchanged report indicating that nothing
+ * requested document or an unchanged report indicating that nothing
  * has changed in terms of diagnostics in comparison to the last
  * pull request.
  *

--- a/protocol/src/common/protocol.fileOperations.ts
+++ b/protocol/src/common/protocol.fileOperations.ts
@@ -15,32 +15,32 @@ import { ProtocolNotificationType, ProtocolRequestType } from './messages';
 export interface FileOperationOptions {
 
 	/**
-	* The server is interested in didCreateFiles notifications.
+	* The server is interested in receiving didCreateFiles notifications.
 	*/
 	didCreate?: FileOperationRegistrationOptions;
 
 	/**
-	* The server is interested in willCreateFiles requests.
+	* The server is interested in receiving willCreateFiles requests.
 	*/
 	willCreate?: FileOperationRegistrationOptions;
 
 	/**
-	* The server is interested in didRenameFiles notifications.
+	* The server is interested in receiving didRenameFiles notifications.
 	*/
 	didRename?: FileOperationRegistrationOptions;
 
 	/**
-	* The server is interested in willRenameFiles requests.
+	* The server is interested in receiving willRenameFiles requests.
 	*/
 	willRename?: FileOperationRegistrationOptions;
 
 	/**
-	* The server is interested in didDeleteFiles file notifications.
+	* The server is interested in receiving didDeleteFiles file notifications.
 	*/
 	didDelete?: FileOperationRegistrationOptions;
 
 	/**
-	* The server is interested in willDeleteFiles file requests.
+	* The server is interested in receiving willDeleteFiles file requests.
 	*/
 	willDelete?: FileOperationRegistrationOptions;
 }
@@ -94,7 +94,7 @@ export interface FileOperationPatternOptions {
 
 /**
  * A pattern to describe in which file operation requests or notifications
- * the server is interested in.
+ * the server is interested in receiving.
  *
  * @since 3.16.0
  */
@@ -126,14 +126,14 @@ interface FileOperationPattern {
 
 /**
  * A filter to describe in which file operation requests or notifications
- * the server is interested in.
+ * the server is interested in receiving.
  *
  * @since 3.16.0
  */
 export interface FileOperationFilter {
 
 	/**
-	 * A Uri like `file` or `untitled`.
+	 * A Uri scheme like `file` or `untitled`.
 	 */
 	scheme?: string;
 
@@ -164,7 +164,7 @@ export interface FileOperationClientCapabilities {
 	didCreate?: boolean;
 
 	/**
-	 * The client has support for willCreateFiles requests.
+	 * The client has support for sending willCreateFiles requests.
 	 */
 	willCreate?: boolean;
 
@@ -174,7 +174,7 @@ export interface FileOperationClientCapabilities {
 	didRename?: boolean;
 
 	/**
-	 * The client has support for willRenameFiles requests.
+	 * The client has support for sending willRenameFiles requests.
 	 */
 	willRename?: boolean;
 
@@ -184,13 +184,14 @@ export interface FileOperationClientCapabilities {
 	didDelete?: boolean;
 
 	/**
-	 * The client has support for willDeleteFiles requests.
+	 * The client has support for sending willDeleteFiles requests.
 	 */
 	willDelete?: boolean;
 }
 
 /**
- * The parameters sent in file create requests/notifications.
+ * The parameters sent in notifications/requests for user-initiated creation of
+ * files.
  *
  * @since 3.16.0
  */
@@ -216,7 +217,8 @@ export interface FileCreate {
 }
 
 /**
- * The parameters sent in file rename requests/notifications.
+ * The parameters sent in notifications/requests for user-initiated renames of
+ * files.
  *
  * @since 3.16.0
  */
@@ -248,7 +250,8 @@ export interface FileRename {
 }
 
 /**
- * The parameters sent in file delete requests/notifications.
+ * The parameters sent in notifications/requests for user-initiated deletes of
+ * files.
  *
  * @since 3.16.0
  */

--- a/protocol/src/common/protocol.foldingRange.ts
+++ b/protocol/src/common/protocol.foldingRange.ts
@@ -42,7 +42,7 @@ export interface FoldingRangeClientCapabilities {
 	 *
 	 * @since 3.17.0
 	 */
-	foldingRangeKind? : {
+	foldingRangeKind?: {
 		/**
 		 * The folding range kind values the client supports. When this
 		 * property exists the client also guarantees that it will
@@ -54,6 +54,7 @@ export interface FoldingRangeClientCapabilities {
 
 	/**
 	 * Specific options for the folding range.
+	 *
 	 * @since 3.17.0
 	 */
 	foldingRange?: {

--- a/protocol/src/common/protocol.inlayHint.ts
+++ b/protocol/src/common/protocol.inlayHint.ts
@@ -10,7 +10,7 @@ import { ProtocolRequestType, ProtocolRequestType0 } from './messages';
 import type { StaticRegistrationOptions, TextDocumentRegistrationOptions, WorkDoneProgressOptions, WorkDoneProgressParams } from './protocol';
 
 /**
- * Inlay hint client capabilities
+ * Inlay hint client capabilities.
  *
  * @since 3.17.0
  */
@@ -22,7 +22,7 @@ export type InlayHintClientCapabilities = {
 	dynamicRegistration?: boolean;
 
 	/**
-	 * Indicates which properties a client can resolve lazily on a inlay
+	 * Indicates which properties a client can resolve lazily on an inlay
 	 * hint.
 	 */
 	resolveSupport?: {
@@ -74,7 +74,7 @@ export type InlayHintOptions = WorkDoneProgressOptions & {
 export type InlayHintRegistrationOptions = InlayHintOptions & TextDocumentRegistrationOptions & StaticRegistrationOptions;
 
 /**
- * A parameter literal used in inlay hints requests.
+ * A parameter literal used in inlay hint requests.
  *
  * @since 3.17.0
  */
@@ -104,7 +104,7 @@ export namespace InlayHintRequest {
 }
 
 /**
- * A request to resolve additional properties for a inlay hint.
+ * A request to resolve additional properties for an inlay hint.
  * The request's parameter is of type [InlayHint](#InlayHint), the response is
  * of type [InlayHint](#InlayHint) or a Thenable that resolves to such.
  *

--- a/protocol/src/common/protocol.notebook.ts
+++ b/protocol/src/common/protocol.notebook.ts
@@ -41,13 +41,13 @@ export type NotebookDocumentSyncClientCapabilities = {
 export namespace NotebookCellKind {
 
 	/**
-     * A markup-cell is formatted source that is used for display.
-     */
+	 * A markup-cell is formatted source that is used for display.
+	 */
 	export const Markup: 1 = 1;
 
 	/**
-     * A code-cell is source code.
-     */
+	 * A code-cell is source code.
+	 */
 	export const Code: 2 = 2;
 
 	export function is(value: any): value is NotebookCellKind {
@@ -298,7 +298,7 @@ export type VersionedNotebookDocumentIdentifier = {
  * Options specific to a notebook plus its cells
  * to be synced to the server.
  *
- * If a selector provide a notebook document
+ * If a selector provides a notebook document
  * filter but no cell selector all cells of a
  * matching notebook document will be synced.
  *
@@ -316,8 +316,8 @@ export type NotebookDocumentSyncOptions = {
 	notebookSelector: ({
 		/**
 		 * The notebook to be synced If a string
-	 	 * value is provided it matches against the
-	     * notebook type. '*' matches every notebook.
+		 * value is provided it matches against the
+		 * notebook type. '*' matches every notebook.
 		 */
 		notebook: string | NotebookDocumentFilter;
 
@@ -328,8 +328,8 @@ export type NotebookDocumentSyncOptions = {
 	} | {
 		/**
 		 * The notebook to be synced If a string
-	 	 * value is provided it matches against the
-	     * notebook type. '*' matches every notebook.
+		 * value is provided it matches against the
+		 * notebook type. '*' matches every notebook.
 		 */
 		notebook?: string | NotebookDocumentFilter;
 
@@ -359,7 +359,7 @@ export namespace NotebookDocumentSyncRegistrationType {
 }
 
 /**
- * The params sent in a open notebook document notification.
+ * The params sent in an open notebook document notification.
  *
  * @since 3.17.0
  */
@@ -470,8 +470,8 @@ export type NotebookDocumentChangeEvent = {
 		data?: NotebookCell[];
 
 		/**
-    	 * Changes to the text content of notebook cells.
-     	 */
+		 * Changes to the text content of notebook cells.
+		 */
 		textContent?: {
 			document: VersionedTextDocumentIdentifier;
 			changes: TextDocumentContentChangeEvent[];

--- a/protocol/src/common/protocol.showDocument.ts
+++ b/protocol/src/common/protocol.showDocument.ts
@@ -8,13 +8,13 @@ import { Range, URI } from 'vscode-languageserver-types';
 import { ProtocolRequestType } from './messages';
 
 /**
- * Client capabilities for the show document request.
+ * Client capabilities for the showDocument request.
  *
  * @since 3.16.0
  */
 export interface ShowDocumentClientCapabilities {
 	/**
-	 * The client has support for the show document
+	 * The client has support for the showDocument
 	 * request.
 	 */
 	support: boolean;
@@ -42,7 +42,7 @@ export interface ShowDocumentParams {
 	 * An optional property to indicate whether the editor
 	 * showing the document should take focus or not.
 	 * Clients might ignore this property if an external
-	 * program in started.
+	 * program is started.
 	 */
 	takeFocus?: boolean;
 
@@ -56,7 +56,7 @@ export interface ShowDocumentParams {
 }
 
 /**
- * The result of an show document request.
+ * The result of a showDocument request.
  *
  * @since 3.16.0
  */

--- a/protocol/src/common/protocol.ts
+++ b/protocol/src/common/protocol.ts
@@ -313,7 +313,7 @@ export interface Registration {
 	id: string;
 
 	/**
-	 * The method to register for.
+	 * The method / capability to register for.
 	 */
 	method: string;
 
@@ -465,7 +465,7 @@ export interface WorkspaceClientCapabilities {
 	applyEdit?: boolean;
 
 	/**
-	 * Capabilities specific to `WorkspaceEdit`s
+	 * Capabilities specific to `WorkspaceEdit`s.
 	 */
 	workspaceEdit?: WorkspaceEditClientCapabilities;
 
@@ -490,7 +490,7 @@ export interface WorkspaceClientCapabilities {
 	executeCommand?: ExecuteCommandClientCapabilities;
 
 	/**
-	 * The client has support for workspace folders
+	 * The client has support for workspace folders.
 	 *
 	 * @since 3.6.0
 	 */
@@ -535,7 +535,7 @@ export interface WorkspaceClientCapabilities {
 	inlineValue?: InlineValueWorkspaceClientCapabilities;
 
 	/**
-	 * Capabilities specific to the inlay hints requests scoped to the
+	 * Capabilities specific to the inlay hint requests scoped to the
 	 * workspace.
 	 *
 	 * @since 3.17.0.
@@ -562,122 +562,125 @@ export interface TextDocumentClientCapabilities {
 	synchronization?: TextDocumentSyncClientCapabilities;
 
 	/**
-	 * Capabilities specific to the `textDocument/completion`
+	 * Capabilities specific to the `textDocument/completion` request.
 	 */
 	completion?: CompletionClientCapabilities;
 
 	/**
-	 * Capabilities specific to the `textDocument/hover`
+	 * Capabilities specific to the `textDocument/hover` request.
 	 */
 	hover?: HoverClientCapabilities;
 
 	/**
-	 * Capabilities specific to the `textDocument/signatureHelp`
+	 * Capabilities specific to the `textDocument/signatureHelp` request.
 	 */
 	signatureHelp?: SignatureHelpClientCapabilities;
 
 	/**
-	 * Capabilities specific to the `textDocument/declaration`
+	 * Capabilities specific to the `textDocument/declaration` request.
 	 *
 	 * @since 3.14.0
 	 */
 	declaration?: DeclarationClientCapabilities;
 
 	/**
-	 * Capabilities specific to the `textDocument/definition`
+	 * Capabilities specific to the `textDocument/definition` request.
 	 */
 	definition?: DefinitionClientCapabilities;
 
 	/**
-	 * Capabilities specific to the `textDocument/typeDefinition`
+	 * Capabilities specific to the `textDocument/typeDefinition` request.
 	 *
 	 * @since 3.6.0
 	 */
 	typeDefinition?: TypeDefinitionClientCapabilities;
 
 	/**
-	 * Capabilities specific to the `textDocument/implementation`
+	 * Capabilities specific to the `textDocument/implementation` request.
 	 *
 	 * @since 3.6.0
 	 */
 	implementation?: ImplementationClientCapabilities;
 
 	/**
-	 * Capabilities specific to the `textDocument/references`
+	 * Capabilities specific to the `textDocument/references` request.
 	 */
 	references?: ReferenceClientCapabilities;
 
 	/**
-	 * Capabilities specific to the `textDocument/documentHighlight`
+	 * Capabilities specific to the `textDocument/documentHighlight` request.
 	 */
 	documentHighlight?: DocumentHighlightClientCapabilities;
 
 	/**
-	 * Capabilities specific to the `textDocument/documentSymbol`
+	 * Capabilities specific to the `textDocument/documentSymbol` request.
 	 */
 	documentSymbol?: DocumentSymbolClientCapabilities;
 
 	/**
-	 * Capabilities specific to the `textDocument/codeAction`
+	 * Capabilities specific to the `textDocument/codeAction` request.
 	 */
 	codeAction?: CodeActionClientCapabilities;
 
 	/**
-	 * Capabilities specific to the `textDocument/codeLens`
+	 * Capabilities specific to the `textDocument/codeLens` request.
 	 */
 	codeLens?: CodeLensClientCapabilities;
 
 	/**
-	 * Capabilities specific to the `textDocument/documentLink`
+	 * Capabilities specific to the `textDocument/documentLink` request.
 	 */
 	documentLink?: DocumentLinkClientCapabilities;
 
 	/**
-	 * Capabilities specific to the `textDocument/documentColor`
+	 * Capabilities specific to the `textDocument/documentColor` and the
+	 * `textDocument/colorPresentation` request.
+	 *
+	 * @since 3.6.0
 	 */
 	colorProvider?: DocumentColorClientCapabilities;
 
 	/**
-	 * Capabilities specific to the `textDocument/formatting`
+	 * Capabilities specific to the `textDocument/formatting` request.
 	 */
 	formatting?: DocumentFormattingClientCapabilities;
 
 	/**
-	 * Capabilities specific to the `textDocument/rangeFormatting`
+	 * Capabilities specific to the `textDocument/rangeFormatting` request.
 	 */
 	rangeFormatting?: DocumentRangeFormattingClientCapabilities;
 
 	/**
-	 * Capabilities specific to the `textDocument/onTypeFormatting`
+	 * Capabilities specific to the `textDocument/onTypeFormatting` request.
 	 */
 	onTypeFormatting?: DocumentOnTypeFormattingClientCapabilities;
 
 	/**
-	 * Capabilities specific to the `textDocument/rename`
+	 * Capabilities specific to the `textDocument/rename` request.
 	 */
 	rename?: RenameClientCapabilities;
 
 	/**
-	 * Capabilities specific to `textDocument/foldingRange` request.
+	 * Capabilities specific to the `textDocument/foldingRange` request.
 	 *
 	 * @since 3.10.0
 	 */
 	foldingRange?: FoldingRangeClientCapabilities;
 
 	/**
-	 * Capabilities specific to `textDocument/selectionRange` request.
+	 * Capabilities specific to the `textDocument/selectionRange` request.
 	 *
 	 * @since 3.15.0
 	 */
 	selectionRange?: SelectionRangeClientCapabilities;
 
 	/**
-	 * Capabilities specific to `textDocument/publishDiagnostics` notification.
+	 * Capabilities specific to the `textDocument/publishDiagnostics` notification.
 	 */
 	publishDiagnostics?: PublishDiagnosticsClientCapabilities;
 
 	/**
-	 * Capabilities specific to the various call hierarchy request.
+	 * Capabilities specific to the various call hierarchy requests.
 	 *
 	 * @since 3.16.0
 	 */
@@ -691,14 +694,14 @@ export interface TextDocumentClientCapabilities {
 	semanticTokens?: SemanticTokensClientCapabilities;
 
 	/**
-	 * Capabilities specific to the linked editing range request.
+	 * Capabilities specific to the `textDocument/linkedEditingRange` request.
 	 *
 	 * @since 3.16.0
 	 */
 	linkedEditingRange?: LinkedEditingRangeClientCapabilities;
 
 	/**
-	 * Client capabilities specific to the moniker request.
+	 * Client capabilities specific to the `textDocument/moniker` request.
 	 *
 	 * @since 3.16.0
 	 */
@@ -889,7 +892,7 @@ export interface GeneralClientCapabilities {
 	 * The position encodings supported by the client. Client and server
 	 * have to agree on the same position encoding to ensure that offsets
 	 * (e.g. character position in a line) are interpreted the same on both
-	 * side.
+	 * sides.
 	 *
 	 * To keep the protocol backwards compatible the following applies: if
 	 * the value 'utf-16' is missing from the array of position encodings
@@ -1049,8 +1052,6 @@ export interface ServerCapabilities<T = any> {
 	 * value that a server can return is 'utf-16'.
 	 *
 	 * If omitted it defaults to 'utf-16'.
-	 *
-	 * If for some reason
 	 *
 	 * @since 3.17.0
 	 */
@@ -1283,6 +1284,9 @@ export interface _InitializeParams extends WorkDoneProgressParams {
 	/**
 	 * The process Id of the parent process that started
 	 * the server.
+	 *
+	 * Is `null` if the process has not been started by another process.
+	 * If the parent process is not alive then the server should exit.
 	 */
 	processId: integer | null;
 
@@ -1514,7 +1518,7 @@ export interface ShowMessageParams {
 	type: MessageType;
 
 	/**
-	 * The actual message
+	 * The actual message.
 	 */
 	message: string;
 }
@@ -1565,7 +1569,7 @@ export interface ShowMessageRequestParams {
 	type: MessageType;
 
 	/**
-	 * The actual message
+	 * The actual message.
 	 */
 	message: string;
 
@@ -1601,7 +1605,7 @@ export interface LogMessageParams {
 	type: MessageType;
 
 	/**
-	 * The actual message
+	 * The actual message.
 	 */
 	message: string;
 }
@@ -1697,7 +1701,7 @@ export interface TextDocumentSyncOptions {
 }
 
 /**
- * The parameters send in a open text document notification
+ * The parameters sent in an open text document notification
  */
 export interface DidOpenTextDocumentParams {
 	/**
@@ -1818,7 +1822,7 @@ export namespace DidChangeTextDocumentNotification {
 }
 
 /**
- * The parameters send in a close text document notification
+ * The parameters sent in a close text document notification
  */
 export interface DidCloseTextDocumentParams {
 	/**
@@ -1842,11 +1846,11 @@ export namespace DidCloseTextDocumentNotification {
 }
 
 /**
- * The parameters send in a save text document notification
+ * The parameters sent in a save text document notification
  */
 export interface DidSaveTextDocumentParams {
 	/**
-	 * The document that was closed.
+	 * The document that was saved.
 	 */
 	textDocument: TextDocumentIdentifier;
 
@@ -1897,7 +1901,7 @@ export namespace TextDocumentSaveReason {
 export type TextDocumentSaveReason = 1 | 2 | 3;
 
 /**
- * The parameters send in a will save text document notification.
+ * The parameters sent in a will save text document notification.
  */
 export interface WillSaveTextDocumentParams {
 	/**
@@ -2065,7 +2069,7 @@ export interface FileSystemWatcher {
 	/**
 	 * The glob pattern to watch. See {@link GlobPattern glob pattern} for more detail.
 	 *
- 	 * @since 3.17.0 support for relative patterns.
+	 * @since 3.17.0 support for relative patterns.
 	 */
 	globPattern: GlobPattern;
 
@@ -2121,7 +2125,7 @@ export interface PublishDiagnosticsClientCapabilities {
 
 	/**
 	 * Whether the client interprets the version property of the
-	 * `textDocument/publishDiagnostics` notification`s parameter.
+	 * `textDocument/publishDiagnostics` notification's parameter.
 	 *
 	 * @since 3.15.0
 	 */
@@ -2206,7 +2210,7 @@ export interface CompletionClientCapabilities {
 		commitCharactersSupport?: boolean;
 
 		/**
-		 * Client supports the follow content formats for the documentation
+		 * Client supports the following content formats for the documentation
 		 * property. The order describes the preferred format of the client.
 		 */
 		documentationFormat?: MarkupKind[];
@@ -2315,7 +2319,7 @@ export interface CompletionClientCapabilities {
 	 */
 	completionList?: {
 		/**
-		 * The client supports the the following itemDefaults on
+		 * The client supports the following itemDefaults on
 		 * a completion list.
 		 *
 		 * The value lists the supported property names of the
@@ -2474,7 +2478,7 @@ export interface HoverClientCapabilities {
 	dynamicRegistration?: boolean;
 
 	/**
-	 * Client supports the follow content formats for the content
+	 * Client supports the following content formats for the content
 	 * property. The order describes the preferred format of the client.
 	 */
 	contentFormat?: MarkupKind[];
@@ -2525,7 +2529,7 @@ export interface SignatureHelpClientCapabilities {
 	 */
 	signatureInformation?: {
 		/**
-		 * Client supports the follow content formats for the documentation
+		 * Client supports the following content formats for the documentation
 		 * property. The order describes the preferred format of the client.
 		 */
 		documentationFormat?: MarkupKind[];
@@ -2544,7 +2548,7 @@ export interface SignatureHelpClientCapabilities {
 		};
 
 		/**
-		 * The client support the `activeParameter` property on `SignatureInformation`
+		 * The client supports the `activeParameter` property on `SignatureInformation`
 		 * literal.
 		 *
 		 * @since 3.16.0
@@ -2568,7 +2572,7 @@ export interface SignatureHelpClientCapabilities {
  */
 export interface SignatureHelpOptions extends WorkDoneProgressOptions {
 	/**
-	 * List of characters that trigger signature help.
+	 * List of characters that trigger signature help automatically.
 	 */
 	triggerCharacters?: string[];
 
@@ -2625,7 +2629,7 @@ export interface SignatureHelpContext {
 	/**
 	 * `true` if signature help was already showing when it was triggered.
 	 *
-	 * Retrigger occurs when the signature help is already active and can be caused by actions such as
+	 * Retriggers occurs when the signature help is already active and can be caused by actions such as
 	 * typing a trigger character, a cursor move, or document content changes.
 	 */
 	isRetrigger: boolean;
@@ -2807,7 +2811,8 @@ export interface DocumentSymbolClientCapabilities {
 	dynamicRegistration?: boolean;
 
 	/**
-	 * Specific capabilities for the `SymbolKind`.
+	 * Specific capabilities for the `SymbolKind` in the
+	 * `textDocument/documentSymbol` request.
 	 */
 	symbolKind?: {
 		/**
@@ -2824,7 +2829,7 @@ export interface DocumentSymbolClientCapabilities {
 	};
 
 	/**
-	 * The client support hierarchical document symbols.
+	 * The client supports hierarchical document symbols.
 	 */
 	hierarchicalDocumentSymbolSupport?: boolean;
 
@@ -2950,7 +2955,7 @@ export interface CodeActionClientCapabilities {
 	dataSupport?: boolean;
 
 	/**
-	 * Whether the client support resolving additional code action
+	 * Whether the client supports resolving additional code action
 	 * properties via a separate `codeAction/resolve` request.
 	 *
 	 * @since 3.16.0
@@ -2963,7 +2968,7 @@ export interface CodeActionClientCapabilities {
 	};
 
 	/**
-	 * Whether th client honors the change annotations in
+	 * Whether the client honors the change annotations in
 	 * text edits and resource operations returned via the
 	 * `CodeAction#edit` property by for example presenting
 	 * the workspace edit in the user interface and asking
@@ -3245,7 +3250,7 @@ export interface DocumentLinkClientCapabilities {
 	dynamicRegistration?: boolean;
 
 	/**
-	 * Whether the client support the `tooltip` property on `DocumentLink`.
+	 * Whether the client supports the `tooltip` property on `DocumentLink`.
 	 *
 	 * @since 3.15.0
 	 */
@@ -3318,7 +3323,7 @@ export interface DocumentFormattingParams extends WorkDoneProgressParams {
 	textDocument: TextDocumentIdentifier;
 
 	/**
-	 * The format options
+	 * The format options.
 	 */
 	options: FormattingOptions;
 }
@@ -3429,7 +3434,7 @@ export interface DocumentOnTypeFormattingParams {
 	ch: string;
 
 	/**
-	 * The format options.
+	 * The formatting options.
 	 */
 	options: FormattingOptions;
 }
@@ -3439,7 +3444,7 @@ export interface DocumentOnTypeFormattingParams {
  */
 export interface DocumentOnTypeFormattingOptions {
 	/**
-	 * A character on which formatting should be triggered, like `{}`.
+	 * A character on which formatting should be triggered, like `{`.
 	 */
 	firstTriggerCharacter: string;
 
@@ -3500,7 +3505,7 @@ export interface RenameClientCapabilities {
 	prepareSupportDefaultBehavior?: PrepareSupportDefaultBehavior;
 
 	/**
-	 * Whether th client honors the change annotations in
+	 * Whether the client honors the change annotations in
 	 * text edits and resource operations returned via the
 	 * rename request's workspace edit by for example presenting
 	 * the workspace edit in the user interface and asking
@@ -3653,7 +3658,7 @@ export interface WorkspaceEditClientCapabilities {
 	 * Whether the client normalizes line endings to the client specific
 	 * setting.
 	 * If set to `true` the client will normalize line ending characters
-	 * in a workspace edit containing to the client specific new line
+	 * in a workspace edit to the client-specified new line
 	 * character.
 	 *
 	 * @since 3.16.0

--- a/protocol/src/common/protocol.workspaceFolder.ts
+++ b/protocol/src/common/protocol.workspaceFolder.ts
@@ -10,7 +10,13 @@ import { ProtocolRequestType0, ProtocolNotificationType } from './messages';
 
 export interface WorkspaceFoldersInitializeParams {
 	/**
-	 * The actual configured workspace folders.
+	 * The workspace folders configured in the client when the server starts.
+	 *
+	 * This property is only available if the client supports workspace folders.
+	 * It can be `null` if the client supports workspace folders but none are
+	 * configured.
+	 *
+	 * @since 3.6.0
 	 */
 	workspaceFolders: WorkspaceFolder[] | null;
 }
@@ -18,7 +24,7 @@ export interface WorkspaceFoldersInitializeParams {
 export interface WorkspaceFoldersServerCapabilities {
 
 	/**
-	 * The Server has support for workspace folders
+	 * The server has support for workspace folders
 	 */
 	supported?: boolean;
 
@@ -26,7 +32,7 @@ export interface WorkspaceFoldersServerCapabilities {
 	 * Whether the server wants to receive workspace folder
 	 * change notifications.
 	 *
-	 * If a strings is provided the string is treated as a ID
+	 * If a string is provided the string is treated as an ID
 	 * under which the notification is registered on the client
 	 * side. The ID can be used to unregister for these events
 	 * using the `client/unregisterCapability` request.

--- a/server/src/common/notebook.ts
+++ b/server/src/common/notebook.ts
@@ -108,7 +108,7 @@ export type NotebookDocumentChangeEvent = {
 
 class CellTextDocumentConnection implements TextDocumentConnection {
 
-	private static readonly NULL_DISPOSE = Object.freeze({ dispose: () => { }});
+	private static readonly NULL_DISPOSE = Object.freeze({ dispose: () => { } });
 
 	private openHandler: NotificationHandler<DidOpenTextDocumentParams> | undefined;
 	private changeHandler: NotificationHandler<DidChangeTextDocumentParams> | undefined;
@@ -154,7 +154,7 @@ class CellTextDocumentConnection implements TextDocumentConnection {
 	}
 }
 
-export class NotebookDocuments<T extends {  uri: DocumentUri }> {
+export class NotebookDocuments<T extends { uri: DocumentUri }> {
 
 	private readonly notebookDocuments: Map<URI, NotebookDocument>;
 	private readonly notebookCellMap: Map<DocumentUri, [NotebookCell, NotebookDocument]>;
@@ -172,7 +172,7 @@ export class NotebookDocuments<T extends {  uri: DocumentUri }> {
 		} else {
 			this._cellTextDocuments = new TextDocuments<T>(configurationOrTextDocuments);
 		}
-		this.notebookDocuments= new Map();
+		this.notebookDocuments = new Map();
 		this.notebookCellMap = new Map();
 		this._onDidOpen = new Emitter();
 		this._onDidChange = new Emitter();
@@ -222,7 +222,7 @@ export class NotebookDocuments<T extends {  uri: DocumentUri }> {
 	/**
 	 * Listens for `low level` notification on the given connection to
 	 * update the notebook documents managed by this instance.
-     *
+	 *
 	 * Please note that the connection only provides handlers not an event model. Therefore
 	 * listening on a connection will overwrite the following handlers on a connection:
 	 * `onDidOpenNotebookDocument`, `onDidChangeNotebookDocument`, `onDidSaveNotebookDocument`,

--- a/server/src/common/textDocuments.ts
+++ b/server/src/common/textDocuments.ts
@@ -36,8 +36,8 @@ export interface TextDocumentsConfiguration<T extends { uri: DocumentUri }> {
  */
 export interface TextDocumentChangeEvent<T> {
 	/**
-     * The document that has changed.
-     */
+	 * The document that has changed.
+	 */
 	document: T;
 }
 
@@ -46,12 +46,12 @@ export interface TextDocumentChangeEvent<T> {
  */
 export interface TextDocumentWillSaveEvent<T> {
 	/**
-     * The document that will be saved
-     */
+	 * The document that will be saved
+	 */
 	document: T;
 	/**
-     * The reason why save was triggered.
-     */
+	 * The reason why save was triggered.
+	 */
 	reason: TextDocumentSaveReason;
 }
 
@@ -172,7 +172,7 @@ export class TextDocuments<T extends { uri: DocumentUri }> {
 	/**
 	 * Listens for `low level` notification on the given connection to
 	 * update the text documents managed by this instance.
-     *
+	 *
 	 * Please note that the connection only provides handlers not an event model. Therefore
 	 * listening on a connection will overwrite the following handlers on a connection:
 	 * `onDidOpenTextDocument`, `onDidChangeTextDocument`, `onDidCloseTextDocument`,

--- a/textDocument/src/main.ts
+++ b/textDocument/src/main.ts
@@ -28,13 +28,13 @@ export interface Position {
 	line: number;
 
 	/**
-	 * Character offset on a line in a document (zero-based). Assuming that the line is
-	 * represented as a string, the `character` value represents the gap between the
-	 * `character` and `character + 1`.
+	 * Character offset on a line in a document (zero-based).
+	 *
+	 * The meaning of this offset is determined by the negotiated
+	 * `PositionEncodingKind`.
 	 *
 	 * If the character value is greater than the line length it defaults back to the
 	 * line length.
-	 * If a line number is negative, it defaults to 0.
 	 */
 	character: number;
 }
@@ -54,7 +54,7 @@ export interface Position {
  */
 export interface Range {
 	/**
-	 * The range's start position
+	 * The range's start position.
 	 */
 	start: Position;
 
@@ -338,7 +338,7 @@ export namespace TextDocument {
 	 *
 	 * @param document the document to update. Only documents created by TextDocument.create are valid inputs.
 	 * @param changes the changes to apply to the document.
-     * @param version the changes version for the document.
+	 * @param version the changes version for the document.
 	 * @returns The updated TextDocument. Note: That's the same document instance passed in as first parameter.
 	 *
 	 */

--- a/types/src/main.ts
+++ b/types/src/main.ts
@@ -123,13 +123,17 @@ export type LSPArray = any[];
 export interface Position {
 	/**
 	 * Line position in a document (zero-based).
+	 *
+	 * If a line number is greater than the number of lines in a document, it defaults back to the number of lines in the document.
+	 * If a line number is negative, it defaults to 0.
 	 */
 	line: uinteger;
 
 	/**
-	 * Character offset on a line in a document (zero-based). Assuming that the line is
-	 * represented as a string, the `character` value represents the gap between the
-	 * `character` and `character + 1`.
+	 * Character offset on a line in a document (zero-based).
+	 *
+	 * The meaning of this offset is determined by the negotiated
+	 * `PositionEncodingKind`.
 	 *
 	 * If the character value is greater than the line length it defaults back to the
 	 * line length.
@@ -176,7 +180,7 @@ export namespace Position {
  */
 export interface Range {
 	/**
-	 * The range's start position
+	 * The range's start position.
 	 */
 	start: Position;
 
@@ -262,7 +266,7 @@ export interface LocationLink {
 	/**
 	 * Span of the origin of this link.
 	 *
-	 * Used as the underlined span for mouse definition hover. Defaults to the word range at
+	 * Used as the underlined span for mouse interaction. Defaults to the word range at
 	 * the definition position.
 	 */
 	originSelectionRange?: Range;
@@ -281,7 +285,7 @@ export interface LocationLink {
 
 	/**
 	 * The range that should be selected and revealed when this link is being followed, e.g the name of a function.
-	 * Must be contained by the the `targetRange`. See also `DocumentSymbol#range`
+	 * Must be contained by the `targetRange`. See also `DocumentSymbol#range`
 	 */
 	targetSelectionRange: Range;
 }
@@ -466,7 +470,7 @@ export namespace FoldingRangeKind {
 	export const Comment = 'comment';
 
 	/**
-	 * Folding range for a imports or includes
+	 * Folding range for an import or include
 	 */
 	export const Imports = 'imports';
 
@@ -477,6 +481,8 @@ export namespace FoldingRangeKind {
 }
 
 /**
+ * A predefined folding range kind.
+ *
  * The type is a string since the value set is extensible
  */
 export type FoldingRangeKind = string;
@@ -511,8 +517,8 @@ export interface FoldingRange {
 
 	/**
 	 * Describes the kind of the folding range such as `comment' or 'region'. The kind
-	 * is used to categorize folding ranges. See [FoldingRangeKind](#FoldingRangeKind)
-	 * for an enumeration of standardized kinds.
+	 * is used to categorize folding ranges and used by commands like 'Fold all comments'.
+	 * See [FoldingRangeKind](#FoldingRangeKind) for an enumeration of standardized kinds.
 	 */
 	kind?: FoldingRangeKind;
 
@@ -864,7 +870,7 @@ export namespace TextEdit {
 		return { range, newText };
 	}
 	/**
-	 * Creates a insert text edit.
+	 * Creates an insert text edit.
 	 * @param position The position to insert the text at.
 	 * @param newText The text to be inserted.
 	 */
@@ -894,15 +900,15 @@ export namespace TextEdit {
  */
 export interface ChangeAnnotation {
 	/**
-     * A human-readable string describing the actual change. The string
+	 * A human-readable string describing the actual change. The string
 	 * is rendered prominent in the user interface.
-     */
+	 */
 	label: string;
 
 	/**
-     * A flag which indicates that user confirmation is needed
+	 * A flag which indicates that user confirmation is needed
 	 * before applying the change.
-     */
+	 */
 	needsConfirmation?: boolean;
 
 	/**
@@ -1108,8 +1114,8 @@ export namespace CreateFile {
 			candidate.options === undefined ||
 			((candidate.options.overwrite === undefined || Is.boolean(candidate.options.overwrite)) && (candidate.options.ignoreIfExists === undefined || Is.boolean(candidate.options.ignoreIfExists)))
 		) && (
-			candidate.annotationId === undefined || ChangeAnnotationIdentifier.is(candidate.annotationId)
-		);
+				candidate.annotationId === undefined || ChangeAnnotationIdentifier.is(candidate.annotationId)
+			);
 	}
 }
 
@@ -1175,8 +1181,8 @@ export namespace RenameFile {
 			candidate.options === undefined ||
 			((candidate.options.overwrite === undefined || Is.boolean(candidate.options.overwrite)) && (candidate.options.ignoreIfExists === undefined || Is.boolean(candidate.options.ignoreIfExists)))
 		) && (
-			candidate.annotationId === undefined || ChangeAnnotationIdentifier.is(candidate.annotationId)
-		);
+				candidate.annotationId === undefined || ChangeAnnotationIdentifier.is(candidate.annotationId)
+			);
 	}
 }
 
@@ -1236,8 +1242,8 @@ export namespace DeleteFile {
 			candidate.options === undefined ||
 			((candidate.options.recursive === undefined || Is.boolean(candidate.options.recursive)) && (candidate.options.ignoreIfNotExists === undefined || Is.boolean(candidate.options.ignoreIfNotExists)))
 		) && (
-			candidate.annotationId === undefined || ChangeAnnotationIdentifier.is(candidate.annotationId)
-		);
+				candidate.annotationId === undefined || ChangeAnnotationIdentifier.is(candidate.annotationId)
+			);
 	}
 }
 
@@ -1806,7 +1812,7 @@ export interface TextDocumentItem {
 	uri: DocumentUri;
 
 	/**
-	 * The text document's language identifier
+	 * The text document's language identifier.
 	 */
 	languageId: string;
 
@@ -2079,13 +2085,13 @@ export type InsertTextMode = 1 | 2;
 export interface CompletionItemLabelDetails {
 	/**
 	 * An optional string which is rendered less prominently directly after {@link CompletionItem.label label},
-	 * without any spacing. Should be used for function signatures or type annotations.
+	 * without any spacing. Should be used for function signatures and type annotations.
 	 */
 	detail?: string;
 
 	/**
 	 * An optional string which is rendered less prominently after {@link CompletionItem.detail}. Should be used
-	 * for fully qualified names or file path.
+	 * for fully qualified names and file paths.
 	 */
 	description?: string;
 }
@@ -2202,7 +2208,7 @@ export interface CompletionItem {
 
 	/**
 	 * How whitespace and indentation is handled during completion
-	 * item insertion. If ignored the clients default value depends on
+	 * item insertion. If not provided the clients default value depends on
 	 * the `textDocument.completion.insertTextMode` client capability.
 	 *
 	 * @since 3.16.0
@@ -2214,15 +2220,15 @@ export interface CompletionItem {
 	 * this completion. When an edit is provided the value of
 	 * [insertText](#CompletionItem.insertText) is ignored.
 	 *
-	 * Most editors support two different operation when accepting a completion
+	 * Most editors support two different operations when accepting a completion
 	 * item. One is to insert a completion text and the other is to replace an
-	 * existing text with a completion text. Since this can usually not
+	 * existing text with a completion text. Since this can usually not be
 	 * predetermined by a server it can report both ranges. Clients need to
 	 * signal support for `InsertReplaceEdits` via the
 	 * `textDocument.completion.insertReplaceSupport` client capability
 	 * property.
 	 *
-	 * *Note 1:* The text edit's range as well as both ranges from a insert
+	 * *Note 1:* The text edit's range as well as both ranges from an insert
 	 * replace edit must be a [single line] and they must contain the position
 	 * at which completion has been requested.
 	 * *Note 2:* If an `InsertReplaceEdit` is returned the edit's insert range
@@ -2300,6 +2306,9 @@ export namespace CompletionItem {
 export interface CompletionList {
 	/**
 	 * This list it not complete. Further typing results in recomputing this list.
+	 *
+	 * Recomputed lists have all their items replaced (not appended) in the
+	 * incomplete completion sessions.
 	 */
 	isIncomplete: boolean;
 
@@ -2425,7 +2434,8 @@ export interface Hover {
 	contents: MarkupContent | MarkedString | MarkedString[];
 
 	/**
-	 * An optional range
+	 * An optional range inside the text document that is used to
+	 * visualize the hover, e.g. by changing the background color.
 	 */
 	range?: Range;
 }
@@ -2441,8 +2451,8 @@ export namespace Hover {
 			MarkedString.is(candidate.contents) ||
 			Is.typedArray(candidate.contents, MarkedString.is)
 		) && (
-			value.range === undefined || Range.is(value.range)
-		);
+				value.range === undefined || Range.is(value.range)
+			);
 	}
 }
 
@@ -2465,7 +2475,7 @@ export interface ParameterInformation {
 	label: string | [uinteger, uinteger];
 
 	/**
-	 * The human-readable doc-comment of this signature. Will be shown
+	 * The human-readable doc-comment of this parameter. Will be shown
 	 * in the UI but can be omitted.
 	 */
 	documentation?: string | MarkupContent;
@@ -2572,7 +2582,7 @@ export interface SignatureHelp {
 	 * mandatory to better express the active parameter if the
 	 * active signature does have any.
 	 */
-	 activeParameter?: uinteger;
+	activeParameter?: uinteger;
 }
 
 /**
@@ -2714,6 +2724,7 @@ export type SymbolKind = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 |
 
 /**
  * Symbol tags are extra annotations that tweak the rendering of a symbol.
+ *
  * @since 3.16
  */
 export namespace SymbolTag {
@@ -2742,7 +2753,7 @@ export interface BaseSymbolInformation {
 	kind: SymbolKind;
 
 	/**
-	 * Tags for this completion item.
+	 * Tags for this symbol.
 	 *
 	 * @since 3.16.0
 	 */
@@ -2774,9 +2785,9 @@ export interface SymbolInformation extends BaseSymbolInformation {
 	 * to reveal the location in the editor. If the symbol is selected in the
 	 * tool the range's start information is used to position the cursor. So
 	 * the range usually spans more than the actual symbol's name and does
-	 * normally include thinks like visibility modifiers.
+	 * normally include things like visibility modifiers.
 	 *
-	 * The range doesn't have to denote a node range in the sense of a abstract
+	 * The range doesn't have to denote a node range in the sense of an abstract
 	 * syntax tree. It can therefore not be used to re-construct a hierarchy of
 	 * the symbols.
 	 */
@@ -2888,14 +2899,14 @@ export interface DocumentSymbol {
 
 	/**
 	 * The range enclosing this symbol not including leading/trailing whitespace but everything else
-	 * like comments. This information is typically used to determine if the the clients cursor is
+	 * like comments. This information is typically used to determine if the clients cursor is
 	 * inside the symbol to reveal in the symbol in the UI.
 	 */
 	range: Range;
 
 	/**
 	 * The range that should be selected and revealed when this symbol is being picked, e.g the name of a function.
-	 * Must be contained by the the `range`.
+	 * Must be contained by the `range`.
 	 */
 	selectionRange: Range;
 
@@ -3159,14 +3170,14 @@ export interface CodeAction {
 	 *
 	 * Clients should follow the following guidelines regarding disabled code actions:
 	 *
-	 *   - Disabled code actions are not shown in automatic [lightbulb](https://code.visualstudio.com/docs/editor/editingevolved#_code-action)
-	 *     code action menu.
+	 *   - Disabled code actions are not shown in automatic [lightbulbs](https://code.visualstudio.com/docs/editor/editingevolved#_code-action)
+	 *     code action menus.
 	 *
-	 *   - Disabled actions are shown as faded out in the code action menu when the user request a more specific type
+	 *   - Disabled actions are shown as faded out in the code action menu when the user requests a more specific type
 	 *     of code action, such as refactorings.
 	 *
 	 *   - If the user has a [keybinding](https://code.visualstudio.com/docs/editor/refactoring#_keybindings-for-code-actions)
-	 *     that auto applies a code action and only a disabled code actions are returned, the client should show the user an
+	 *     that auto applies a code action and only disabled code actions are returned, the client should show the user an
 	 *     error message with `reason` in the editor.
 	 *
 	 * @since 3.16.0
@@ -3188,7 +3199,7 @@ export interface CodeAction {
 
 	/**
 	 * A command this code action executes. If a code action
-	 * provides a edit and a command, first the edit is
+	 * provides an edit and a command, first the edit is
 	 * executed and then the command.
 	 */
 	command?: Command;
@@ -3262,7 +3273,7 @@ export namespace CodeAction {
  * source text, like the number of references, a way to run tests, etc.
  *
  * A code lens is _unresolved_ when no command is associated to it. For performance
- * reasons the creation of a code lens and resolving should be done to two stages.
+ * reasons the creation of a code lens and resolving should be done in two stages.
  */
 export interface CodeLens {
 	/**
@@ -3320,7 +3331,7 @@ export interface FormattingOptions {
 	insertSpaces: boolean;
 
 	/**
-	 * Trim trailing whitespaces on a line.
+	 * Trim trailing whitespace on a line.
 	 *
 	 * @since 3.15.0
 	 */
@@ -3378,7 +3389,7 @@ export interface DocumentLink {
 	range: Range;
 
 	/**
-	 * The uri this link points to.
+	 * The uri this link points to. If missing a resolve request is sent later.
 	 */
 	target?: string;
 
@@ -4048,7 +4059,7 @@ export type InlayHint = {
 	paddingRight?: boolean;
 
 	/**
-	 * A data entry field that is preserved on a inlay hint between
+	 * A data entry field that is preserved on an inlay hint between
 	 * a `textDocument/inlayHint` and a `inlayHint/resolve` request.
 	 */
 	data?: LSPAny;


### PR DESCRIPTION
This is mostly typos and tweaks I noticed when diffing code generated from parsing the TypeScript spec to the new meta model, but also some additional things I spotted along the way.

Some of the changes are quite trivial like trailing full stops.. I mostly added these where they existed in the LSP spec (in an attempt to reduce the size of my diff to help me review the TS -> meta model migration), I didn't try to fix these in all places.

@dbaeumer 