### PR TITLE
Mark WorkspaceFoldersInitializeParams.workspaceFolders as optional

### DIFF
--- a/protocol/metaModel.json
+++ b/protocol/metaModel.json
@@ -7699,6 +7699,7 @@
 							}
 						]
 					},
+					"optional": true,
 					"documentation": "The actual configured workspace folders."
 				}
 			]

--- a/protocol/src/common/protocol.workspaceFolder.ts
+++ b/protocol/src/common/protocol.workspaceFolder.ts
@@ -12,7 +12,7 @@ export interface WorkspaceFoldersInitializeParams {
 	/**
 	 * The actual configured workspace folders.
 	 */
-	workspaceFolders: WorkspaceFolder[] | null;
+	workspaceFolders?: WorkspaceFolder[] | null;
 }
 
 export interface WorkspaceFoldersServerCapabilities {


### PR DESCRIPTION
The LSP spec defines these as optional:

https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#initializeParams

Fixes one of the issues in https://github.com/microsoft/vscode-languageserver-node/issues/946.