### PR TITLE
fix: return `false` when `showDocument` fails

### DIFF
--- a/client/src/common/client.ts
+++ b/client/src/common/client.ts
@@ -1043,7 +1043,7 @@ export abstract class BaseLanguageClient implements FeatureClient<Middleware, La
 							return { success: true };
 						}
 					} catch (error) {
-						return { success: true };
+						return { success: false };
 					}
 				};
 				const middleware = this._clientOptions.middleware.window?.showDocument;


### PR DESCRIPTION
If there is an error during `showDocument` execution, it sounds like the request should return `success: false`. On the other hand if this is intentional, feel free to close.