### PR TITLE
Avoid circular dependencies in SemVer

### DIFF
--- a/client/src/node/main.ts
+++ b/client/src/node/main.ts
@@ -8,8 +8,6 @@ import ChildProcess = cp.ChildProcess;
 import * as fs from 'fs';
 import * as path from 'path';
 
-import * as SemVer from 'semver';
-
 import { workspace as Workspace, Disposable, version as VSCodeVersion } from 'vscode';
 
 import * as Is from '../common/utils/is';
@@ -17,6 +15,10 @@ import { BaseLanguageClient, LanguageClientOptions, MessageTransports } from '..
 
 import { terminate } from './processes';
 import { StreamMessageReader, StreamMessageWriter, IPCMessageReader, IPCMessageWriter, createClientPipeTransport, generateRandomPipeName, createClientSocketTransport, InitializeParams} from 'vscode-languageserver-protocol/node';
+
+// Import SemVer functions individually to avoid circular dependencies in SemVer
+import semverParse = require('semver/functions/parse');
+import semverSatisfies = require('semver/functions/satisfies');
 
 export * from 'vscode-languageserver-protocol/node';
 export * from '../common/api';
@@ -168,7 +170,7 @@ export class LanguageClient extends BaseLanguageClient {
 	}
 
 	private checkVersion() {
-		const codeVersion = SemVer.parse(VSCodeVersion);
+		const codeVersion = semverParse(VSCodeVersion);
 		if (!codeVersion) {
 			throw new Error(`No valid VS Code version detected. Version string is: ${VSCodeVersion}`);
 		}
@@ -176,7 +178,7 @@ export class LanguageClient extends BaseLanguageClient {
 		if (codeVersion.prerelease && codeVersion.prerelease.length > 0) {
 			codeVersion.prerelease = [];
 		}
-		if (!SemVer.satisfies(codeVersion, REQUIRED_VSCODE_VERSION)) {
+		if (!semverSatisfies(codeVersion, REQUIRED_VSCODE_VERSION)) {
 			throw new Error(`The language client requires VS Code version ${REQUIRED_VSCODE_VERSION} but received version ${VSCodeVersion}`);
 		}
 	}


### PR DESCRIPTION
## Problem

Consumers using bundlers like Rollup or Webpack are hitting a circular dependency error coming from [npm/node-semver](https://github.com/npm/node-semver). This is causing the `SemVer,satisfies` function to always return `false` when bundled, resulting in the following error:

<img width="1174" alt="semver-satisfies-error" src="https://user-images.githubusercontent.com/11774595/169929458-982fde23-cf70-4732-8fa3-322b4f8825dd.png">

## What this PR is doing

A circular dependency between the Range and Comparator classes can cause issues for consumers who are trying to bundle extensions with `vscode-languageclient` as a dependency.

See related GitHub issue from [npm/node-semver](https://github.com/npm/node-semver)

- [[BUG] the package isn't compatible with Rollup due to require cycle #381](https://github.com/npm/node-semver/issues/381)

### Using Rollup to bundle VS Code extension

| When importing all of SemVer | When only importing individual functions |
| --- | --- |
| <img width="963" alt="Screen Shot 2022-05-23 at 7 15 24 PM" src="https://user-images.githubusercontent.com/11774595/169929581-03f58ccc-7d88-42d3-8297-876b394ccae1.png"> | No circular deps and the extension works! ✨  Tested in external project using `yalc` |

Verified the build output of `client/lib/node/main.js` is correctly importing only the needed functions, avoiding the circular dependency:

```js
// client/lib/node/main.js

const semverParse = require("semver/functions/parse");
const semverSatisfies = require("semver/functions/satisfies");
```