### PR TITLE
Add information about message direction to metamodel

### DIFF
--- a/protocol/src/common/messages.ts
+++ b/protocol/src/common/messages.ts
@@ -5,6 +5,12 @@
 
 import { RequestType, RequestType0, NotificationType, NotificationType0, ProgressType, _EM, ParameterStructures } from 'vscode-jsonrpc';
 
+export enum MessageDirection {
+  clientToServer = 'clientToServer',
+  serverToClient = 'serverToClient',
+  both = 'both'
+}
+
 export class RegistrationType<RO> {
 	/**
 	 * Clients must not use this property. It is here to ensure correct typing.

--- a/protocol/src/common/messages.ts
+++ b/protocol/src/common/messages.ts
@@ -6,9 +6,9 @@
 import { RequestType, RequestType0, NotificationType, NotificationType0, ProgressType, _EM, ParameterStructures } from 'vscode-jsonrpc';
 
 export enum MessageDirection {
-  clientToServer = 'clientToServer',
-  serverToClient = 'serverToClient',
-  both = 'both'
+	clientToServer = 'clientToServer',
+	serverToClient = 'serverToClient',
+	both = 'both'
 }
 
 export class RegistrationType<RO> {

--- a/protocol/src/common/protocol.$.ts
+++ b/protocol/src/common/protocol.$.ts
@@ -6,7 +6,7 @@
 import { LogTraceParams, SetTraceParams, ProgressToken, ErrorCodes } from 'vscode-jsonrpc';
 import { SemanticTokenTypes, SemanticTokenModifiers, LSPAny } from 'vscode-languageserver-types';
 
-import { ProtocolNotificationType } from './messages';
+import { MessageDirection, ProtocolNotificationType } from './messages';
 import { LSPErrorCodes } from './api';
 import { WorkDoneProgressBegin, WorkDoneProgressEnd, WorkDoneProgressReport } from './protocol.progress';
 
@@ -15,12 +15,16 @@ import { WorkDoneProgressBegin, WorkDoneProgressEnd, WorkDoneProgressReport } fr
 
 // @ts-ignore 6196
 namespace SetTraceNotification {
-	export const type = new ProtocolNotificationType<SetTraceParams, void>('$/setTrace');
+  export const method: '$/setTrace' = '$/setTrace';
+	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
+	export const type = new ProtocolNotificationType<SetTraceParams, void>(method);
 }
 
 // @ts-ignore 6196
 namespace LogTraceNotification {
-	export const type = new ProtocolNotificationType<LogTraceParams, void>('$/logTrace');
+  export const method: '$/logTrace' = '$/logTrace';
+	export const messageDirection: MessageDirection = MessageDirection.serverToClient;
+	export const type = new ProtocolNotificationType<LogTraceParams, void>(method);
 }
 
 // @ts-ignore 6196
@@ -44,7 +48,9 @@ interface CancelParams {
 
 // @ts-ignore 6196
 namespace CancelNotification {
-	export const type = new ProtocolNotificationType<CancelParams, void>('$/cancelRequest');
+  export const method: '$/cancelRequest' = '$/cancelRequest';
+	export const messageDirection: MessageDirection = MessageDirection.both;
+	export const type = new ProtocolNotificationType<CancelParams, void>(method);
 }
 
 interface ProgressParams {
@@ -61,7 +67,9 @@ interface ProgressParams {
 
 // @ts-ignore 6196
 namespace ProgressNotification {
-	export const type = new ProtocolNotificationType<ProgressParams, void>('$/progress');
+  export const method: '$/progress' = '$/progress';
+	export const messageDirection: MessageDirection = MessageDirection.both;
+	export const type = new ProtocolNotificationType<ProgressParams, void>(method);
 }
 
 // @ts-ignore 6196

--- a/protocol/src/common/protocol.$.ts
+++ b/protocol/src/common/protocol.$.ts
@@ -15,14 +15,14 @@ import { WorkDoneProgressBegin, WorkDoneProgressEnd, WorkDoneProgressReport } fr
 
 // @ts-ignore 6196
 namespace SetTraceNotification {
-  export const method: '$/setTrace' = '$/setTrace';
+	export const method: '$/setTrace' = '$/setTrace';
 	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
 	export const type = new ProtocolNotificationType<SetTraceParams, void>(method);
 }
 
 // @ts-ignore 6196
 namespace LogTraceNotification {
-  export const method: '$/logTrace' = '$/logTrace';
+	export const method: '$/logTrace' = '$/logTrace';
 	export const messageDirection: MessageDirection = MessageDirection.serverToClient;
 	export const type = new ProtocolNotificationType<LogTraceParams, void>(method);
 }
@@ -48,7 +48,7 @@ interface CancelParams {
 
 // @ts-ignore 6196
 namespace CancelNotification {
-  export const method: '$/cancelRequest' = '$/cancelRequest';
+	export const method: '$/cancelRequest' = '$/cancelRequest';
 	export const messageDirection: MessageDirection = MessageDirection.both;
 	export const type = new ProtocolNotificationType<CancelParams, void>(method);
 }
@@ -67,7 +67,7 @@ interface ProgressParams {
 
 // @ts-ignore 6196
 namespace ProgressNotification {
-  export const method: '$/progress' = '$/progress';
+	export const method: '$/progress' = '$/progress';
 	export const messageDirection: MessageDirection = MessageDirection.both;
 	export const type = new ProtocolNotificationType<ProgressParams, void>(method);
 }

--- a/protocol/src/common/protocol.callHierarchy.ts
+++ b/protocol/src/common/protocol.callHierarchy.ts
@@ -6,7 +6,7 @@
 import { RequestHandler } from 'vscode-jsonrpc';
 import { CallHierarchyItem, CallHierarchyIncomingCall, CallHierarchyOutgoingCall } from 'vscode-languageserver-types';
 
-import { ProtocolRequestType } from './messages';
+import { MessageDirection, ProtocolRequestType } from './messages';
 import type {
 	TextDocumentRegistrationOptions, StaticRegistrationOptions, TextDocumentPositionParams, PartialResultParams,
 	WorkDoneProgressParams, WorkDoneProgressOptions
@@ -56,6 +56,7 @@ export interface CallHierarchyPrepareParams extends TextDocumentPositionParams, 
  */
 export namespace CallHierarchyPrepareRequest {
 	export const method: 'textDocument/prepareCallHierarchy' = 'textDocument/prepareCallHierarchy';
+	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
 	export const type = new ProtocolRequestType<CallHierarchyPrepareParams, CallHierarchyItem[] | null, never, void, CallHierarchyRegistrationOptions>(method);
 	export type HandlerSignature = RequestHandler<CallHierarchyPrepareParams, CallHierarchyItem[] | null, void>;
 }
@@ -76,6 +77,7 @@ export interface CallHierarchyIncomingCallsParams extends WorkDoneProgressParams
  */
 export namespace CallHierarchyIncomingCallsRequest {
 	export const method: 'callHierarchy/incomingCalls' = 'callHierarchy/incomingCalls';
+	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
 	export const type = new ProtocolRequestType<CallHierarchyIncomingCallsParams, CallHierarchyIncomingCall[] | null, CallHierarchyIncomingCall[], void, void>(method);
 	export type HandlerSignature = RequestHandler<CallHierarchyIncomingCallsParams, CallHierarchyIncomingCall[] | null, void>;
 }
@@ -96,6 +98,7 @@ export interface CallHierarchyOutgoingCallsParams extends WorkDoneProgressParams
  */
 export namespace CallHierarchyOutgoingCallsRequest {
 	export const method: 'callHierarchy/outgoingCalls' = 'callHierarchy/outgoingCalls';
+	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
 	export const type = new ProtocolRequestType<CallHierarchyOutgoingCallsParams, CallHierarchyOutgoingCall[] | null, CallHierarchyOutgoingCall[], void, void>(method);
 	export type HandlerSignature = RequestHandler<CallHierarchyOutgoingCallsParams, CallHierarchyOutgoingCall[] | null, void>;
 }

--- a/protocol/src/common/protocol.colorProvider.ts
+++ b/protocol/src/common/protocol.colorProvider.ts
@@ -6,7 +6,7 @@
 import { RequestHandler } from 'vscode-jsonrpc';
 import { TextDocumentIdentifier, Range, Color, ColorInformation, ColorPresentation } from 'vscode-languageserver-types';
 
-import { ProtocolRequestType } from './messages';
+import { MessageDirection, ProtocolRequestType } from './messages';
 import type {
 	TextDocumentRegistrationOptions, StaticRegistrationOptions, PartialResultParams, WorkDoneProgressParams, WorkDoneProgressOptions
 } from './protocol';
@@ -48,6 +48,7 @@ export interface DocumentColorParams extends WorkDoneProgressParams, PartialResu
  */
 export namespace DocumentColorRequest {
 	export const method: 'textDocument/documentColor' = 'textDocument/documentColor';
+	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
 	export const type = new ProtocolRequestType<DocumentColorParams, ColorInformation[], ColorInformation[], void, DocumentColorRegistrationOptions>(method);
 	export type HandlerSignature = RequestHandler<DocumentColorParams, ColorInformation[], void>;
 }
@@ -79,6 +80,8 @@ export interface ColorPresentationParams extends WorkDoneProgressParams, Partial
  * that resolves to such.
  */
 export namespace ColorPresentationRequest {
-	export const type = new ProtocolRequestType<ColorPresentationParams, ColorPresentation[], ColorPresentation[], void, WorkDoneProgressOptions & TextDocumentRegistrationOptions>('textDocument/colorPresentation');
+	export const method: 'textDocument/colorPresentation' = 'textDocument/colorPresentation';
+	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
+	export const type = new ProtocolRequestType<ColorPresentationParams, ColorPresentation[], ColorPresentation[], void, WorkDoneProgressOptions & TextDocumentRegistrationOptions>(method);
 	export type HandlerSignature = RequestHandler<ColorPresentationParams, ColorPresentation[], void>;
 }

--- a/protocol/src/common/protocol.configuration.ts
+++ b/protocol/src/common/protocol.configuration.ts
@@ -6,7 +6,7 @@
 import { RequestHandler, HandlerResult, CancellationToken } from 'vscode-jsonrpc';
 import { LSPAny } from 'vscode-languageserver-types';
 
-import { ProtocolRequestType } from './messages';
+import { MessageDirection, ProtocolRequestType } from './messages';
 import type { PartialResultParams } from './protocol';
 
 //---- Get Configuration request ----
@@ -21,7 +21,9 @@ import type { PartialResultParams } from './protocol';
  * change event and empty the cache if such an event is received.
  */
 export namespace ConfigurationRequest {
-	export const type = new ProtocolRequestType<ConfigurationParams & PartialResultParams, LSPAny[], never, void, void>('workspace/configuration');
+	export const method: 'workspace/configuration' = 'workspace/configuration';
+	export const messageDirection: MessageDirection = MessageDirection.serverToClient;
+	export const type = new ProtocolRequestType<ConfigurationParams & PartialResultParams, LSPAny[], never, void, void>(method);
 	export type HandlerSignature = RequestHandler<ConfigurationParams, LSPAny[], void>;
 	export type MiddlewareSignature = (params: ConfigurationParams, token: CancellationToken, next: HandlerSignature) => HandlerResult<LSPAny[], void>;
 }

--- a/protocol/src/common/protocol.declaration.ts
+++ b/protocol/src/common/protocol.declaration.ts
@@ -6,7 +6,7 @@
 import { RequestHandler } from 'vscode-jsonrpc';
 import { Declaration, DeclarationLink, Location, LocationLink } from 'vscode-languageserver-types';
 
-import { ProtocolRequestType } from './messages';
+import { MessageDirection, ProtocolRequestType } from './messages';
 import type {
 	TextDocumentRegistrationOptions, StaticRegistrationOptions, TextDocumentPositionParams, PartialResultParams, WorkDoneProgressParams,
 	WorkDoneProgressOptions
@@ -50,6 +50,7 @@ export interface DeclarationParams extends TextDocumentPositionParams, WorkDoneP
  */
 export namespace DeclarationRequest {
 	export const method: 'textDocument/declaration' = 'textDocument/declaration';
+	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
 	export const type = new ProtocolRequestType<DeclarationParams, Declaration | DeclarationLink[] | null, Location[] | DeclarationLink[], void, DeclarationRegistrationOptions>(method);
 	export type HandlerSignature = RequestHandler<DeclarationParams, Declaration | DeclarationLink[] | null, void>;
 }

--- a/protocol/src/common/protocol.diagnostic.ts
+++ b/protocol/src/common/protocol.diagnostic.ts
@@ -7,7 +7,7 @@ import { RequestHandler0, RequestHandler, ProgressType } from 'vscode-jsonrpc';
 import { TextDocumentIdentifier, Diagnostic, DocumentUri, integer } from 'vscode-languageserver-types';
 
 import * as Is from './utils/is';
-import { ProtocolRequestType0, ProtocolRequestType } from './messages';
+import { MessageDirection, ProtocolRequestType0, ProtocolRequestType } from './messages';
 import type {
 	PartialResultParams, StaticRegistrationOptions, WorkDoneProgressParams, TextDocumentRegistrationOptions, WorkDoneProgressOptions
 } from './protocol';
@@ -264,6 +264,7 @@ export type DocumentDiagnosticReportPartialResult = {
  */
 export namespace DocumentDiagnosticRequest {
 	export const method: 'textDocument/diagnostic' = 'textDocument/diagnostic';
+	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
 	export const type = new ProtocolRequestType<DocumentDiagnosticParams, DocumentDiagnosticReport, DocumentDiagnosticReportPartialResult, DiagnosticServerCancellationData, DiagnosticRegistrationOptions>(method);
 	export const partialResult = new ProgressType<DocumentDiagnosticReportPartialResult>();
 	export type HandlerSignature = RequestHandler<DocumentDiagnosticParams, DocumentDiagnosticReport, void>;
@@ -376,6 +377,7 @@ export type WorkspaceDiagnosticReportPartialResult = {
  */
 export namespace WorkspaceDiagnosticRequest {
 	export const method: 'workspace/diagnostic' = 'workspace/diagnostic';
+	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
 	export const type = new ProtocolRequestType<WorkspaceDiagnosticParams, WorkspaceDiagnosticReport, WorkspaceDiagnosticReportPartialResult, DiagnosticServerCancellationData, void>(method);
 	export const partialResult = new ProgressType<WorkspaceDiagnosticReportPartialResult>();
 	export type HandlerSignature = RequestHandler<WorkspaceDiagnosticParams, WorkspaceDiagnosticReport | null, void>;
@@ -388,6 +390,7 @@ export namespace WorkspaceDiagnosticRequest {
  */
 export namespace DiagnosticRefreshRequest {
 	export const method: `workspace/diagnostic/refresh` = `workspace/diagnostic/refresh`;
+	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
 	export const type = new ProtocolRequestType0<void, void, void, void>(method);
 	export type HandlerSignature = RequestHandler0<void, void>;
 }

--- a/protocol/src/common/protocol.fileOperations.ts
+++ b/protocol/src/common/protocol.fileOperations.ts
@@ -5,7 +5,7 @@
 
 import { NotificationHandler, RequestHandler } from 'vscode-jsonrpc';
 import { WorkspaceEdit } from 'vscode-languageserver-types';
-import { ProtocolNotificationType, ProtocolRequestType } from './messages';
+import { MessageDirection, ProtocolNotificationType, ProtocolRequestType } from './messages';
 
 /**
  * Options for notifications/requests for user operations on files.
@@ -285,6 +285,7 @@ export interface FileDelete {
  */
 export namespace WillCreateFilesRequest {
 	export const method: 'workspace/willCreateFiles' = 'workspace/willCreateFiles';
+	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
 	export const type = new ProtocolRequestType<CreateFilesParams, WorkspaceEdit | null, never, void, FileOperationRegistrationOptions>(method);
 	export type HandlerSignature = RequestHandler<CreateFilesParams, WorkspaceEdit | undefined | null, void>;
 }
@@ -297,6 +298,7 @@ export namespace WillCreateFilesRequest {
  */
 export namespace DidCreateFilesNotification {
 	export const method: 'workspace/didCreateFiles' = 'workspace/didCreateFiles';
+	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
 	export const type = new ProtocolNotificationType<CreateFilesParams, FileOperationRegistrationOptions>(method);
 	export type HandlerSignature = NotificationHandler<CreateFilesParams>;
 }
@@ -309,6 +311,7 @@ export namespace DidCreateFilesNotification {
  */
 export namespace WillRenameFilesRequest {
 	export const method: 'workspace/willRenameFiles' = 'workspace/willRenameFiles';
+	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
 	export const type = new ProtocolRequestType<RenameFilesParams, WorkspaceEdit | null, never, void, FileOperationRegistrationOptions>(method);
 	export type HandlerSignature = RequestHandler<RenameFilesParams, WorkspaceEdit | undefined | null, void>;
 }
@@ -321,6 +324,7 @@ export namespace WillRenameFilesRequest {
  */
 export namespace DidRenameFilesNotification {
 	export const method: 'workspace/didRenameFiles' = 'workspace/didRenameFiles';
+	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
 	export const type = new ProtocolNotificationType<RenameFilesParams, FileOperationRegistrationOptions>(method);
 	export type HandlerSignature = NotificationHandler<RenameFilesParams>;
 }
@@ -333,6 +337,7 @@ export namespace DidRenameFilesNotification {
  */
 export namespace DidDeleteFilesNotification {
 	export const method: 'workspace/didDeleteFiles' = 'workspace/didDeleteFiles';
+	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
 	export const type = new ProtocolNotificationType<DeleteFilesParams, FileOperationRegistrationOptions>(method);
 	export type HandlerSignature = NotificationHandler<DeleteFilesParams>;
 }
@@ -345,6 +350,7 @@ export namespace DidDeleteFilesNotification {
  */
 export namespace WillDeleteFilesRequest {
 	export const method: 'workspace/willDeleteFiles' = 'workspace/willDeleteFiles';
+	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
 	export const type = new ProtocolRequestType<DeleteFilesParams, WorkspaceEdit | null, never, void, FileOperationRegistrationOptions>(method);
 	export type HandlerSignature = RequestHandler<DeleteFilesParams, WorkspaceEdit | undefined | null, void>;
 }

--- a/protocol/src/common/protocol.foldingRange.ts
+++ b/protocol/src/common/protocol.foldingRange.ts
@@ -6,7 +6,7 @@
 import { RequestHandler } from 'vscode-jsonrpc';
 import { TextDocumentIdentifier, uinteger, FoldingRange, FoldingRangeKind } from 'vscode-languageserver-types';
 
-import { ProtocolRequestType } from './messages';
+import { MessageDirection, ProtocolRequestType } from './messages';
 import type {
 	TextDocumentRegistrationOptions, StaticRegistrationOptions, PartialResultParams, WorkDoneProgressParams, WorkDoneProgressOptions
 } from './protocol';
@@ -92,6 +92,7 @@ export interface FoldingRangeParams extends WorkDoneProgressParams, PartialResul
  */
 export namespace FoldingRangeRequest {
 	export const method: 'textDocument/foldingRange' = 'textDocument/foldingRange';
+	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
 	export const type = new ProtocolRequestType<FoldingRangeParams, FoldingRange[] | null, FoldingRange[], void, FoldingRangeRegistrationOptions>(method);
 	export type HandlerSignature = RequestHandler<FoldingRangeParams, FoldingRange[] | null, void>;
 }

--- a/protocol/src/common/protocol.implementation.ts
+++ b/protocol/src/common/protocol.implementation.ts
@@ -6,7 +6,7 @@
 import { RequestHandler } from 'vscode-jsonrpc';
 import { Definition, DefinitionLink, Location, LocationLink } from 'vscode-languageserver-types';
 
-import { ProtocolRequestType } from './messages';
+import { MessageDirection, ProtocolRequestType } from './messages';
 import type {
 	TextDocumentRegistrationOptions, StaticRegistrationOptions, TextDocumentPositionParams, PartialResultParams, WorkDoneProgressParams,
 	WorkDoneProgressOptions
@@ -51,6 +51,7 @@ export interface ImplementationParams extends TextDocumentPositionParams, WorkDo
  */
 export namespace ImplementationRequest {
 	export const method: 'textDocument/implementation' = 'textDocument/implementation';
+	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
 	export const type = new ProtocolRequestType<ImplementationParams, Definition | DefinitionLink[] | null, Location[] | DefinitionLink[], void, ImplementationRegistrationOptions>(method);
 	export type HandlerSignature = RequestHandler<ImplementationParams, Definition | DefinitionLink[] | null, void>;
 }

--- a/protocol/src/common/protocol.inlayHint.ts
+++ b/protocol/src/common/protocol.inlayHint.ts
@@ -5,7 +5,7 @@
 
 import { RequestHandler, RequestHandler0 } from 'vscode-jsonrpc';
 import { Range, TextDocumentIdentifier, InlayHint } from 'vscode-languageserver-types';
-import { ProtocolRequestType, ProtocolRequestType0 } from './messages';
+import { MessageDirection, ProtocolRequestType, ProtocolRequestType0 } from './messages';
 
 import type { StaticRegistrationOptions, TextDocumentRegistrationOptions, WorkDoneProgressOptions, WorkDoneProgressParams } from './protocol';
 
@@ -99,6 +99,7 @@ export type InlayHintParams = WorkDoneProgressParams & {
  */
 export namespace InlayHintRequest {
 	export const method: 'textDocument/inlayHint' = 'textDocument/inlayHint';
+	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
 	export const type = new ProtocolRequestType<InlayHintParams, InlayHint[] | null, InlayHint[], void, InlayHintRegistrationOptions>(method);
 	export type HandlerSignature = RequestHandler<InlayHintParams, InlayHint[] | null, void>;
 }
@@ -112,6 +113,7 @@ export namespace InlayHintRequest {
  */
 export namespace InlayHintResolveRequest {
 	export const method: 'inlayHint/resolve' = 'inlayHint/resolve';
+	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
 	export const type = new ProtocolRequestType<InlayHint, InlayHint, never, void, void>(method);
 	export type HandlerSignature = RequestHandler<InlayHint, InlayHint, void>;
 }
@@ -121,6 +123,7 @@ export namespace InlayHintResolveRequest {
  */
 export namespace InlayHintRefreshRequest {
 	export const method: `workspace/inlayHint/refresh` = `workspace/inlayHint/refresh`;
+	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
 	export const type = new ProtocolRequestType0<void, void, void, void>(method);
 	export type HandlerSignature = RequestHandler0<void, void>;
 }

--- a/protocol/src/common/protocol.inlineValue.ts
+++ b/protocol/src/common/protocol.inlineValue.ts
@@ -6,7 +6,7 @@
 import { TextDocumentIdentifier, Range, InlineValue, InlineValueContext } from 'vscode-languageserver-types';
 import { RequestHandler, RequestHandler0 } from 'vscode-jsonrpc';
 
-import { ProtocolRequestType, ProtocolRequestType0 } from './messages';
+import { MessageDirection, ProtocolRequestType, ProtocolRequestType0 } from './messages';
 import type { TextDocumentRegistrationOptions, WorkDoneProgressOptions, StaticRegistrationOptions, WorkDoneProgressParams } from './protocol';
 
 // ---- capabilities
@@ -87,6 +87,7 @@ export type InlineValueParams = WorkDoneProgressParams & {
  */
 export namespace InlineValueRequest {
 	export const method: 'textDocument/inlineValue' = 'textDocument/inlineValue';
+	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
 	export const type = new ProtocolRequestType<InlineValueParams, InlineValue[] | null, InlineValue[], void, InlineValueRegistrationOptions>(method);
 	export type HandlerSignature = RequestHandler<InlineValueParams, InlineValue[] | null, void>;
 }
@@ -96,6 +97,7 @@ export namespace InlineValueRequest {
  */
 export namespace InlineValueRefreshRequest {
 	export const method: `workspace/inlineValue/refresh` = `workspace/inlineValue/refresh`;
+	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
 	export const type = new ProtocolRequestType0<void, void, void, void>(method);
 	export type HandlerSignature = RequestHandler0<void, void>;
 }

--- a/protocol/src/common/protocol.linkedEditingRange.ts
+++ b/protocol/src/common/protocol.linkedEditingRange.ts
@@ -6,7 +6,7 @@
 import { RequestHandler } from 'vscode-jsonrpc';
 import { Range } from 'vscode-languageserver-types';
 
-import { ProtocolRequestType } from './messages';
+import { MessageDirection, ProtocolRequestType } from './messages';
 import type {
 	StaticRegistrationOptions, TextDocumentPositionParams, TextDocumentRegistrationOptions, WorkDoneProgressOptions,
 	WorkDoneProgressParams
@@ -62,6 +62,7 @@ export interface LinkedEditingRanges {
  */
 export namespace LinkedEditingRangeRequest {
 	export const method: 'textDocument/linkedEditingRange' = 'textDocument/linkedEditingRange';
+	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
 	export const type = new ProtocolRequestType<LinkedEditingRangeParams, LinkedEditingRanges | null, void, void, LinkedEditingRangeRegistrationOptions>(method);
 	export type HandlerSignature = RequestHandler<LinkedEditingRangeParams, LinkedEditingRanges | null, void>;
 }

--- a/protocol/src/common/protocol.moniker.ts
+++ b/protocol/src/common/protocol.moniker.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 
-import { ProtocolRequestType } from './messages';
+import { MessageDirection, ProtocolRequestType } from './messages';
 import type {
 	WorkDoneProgressOptions, WorkDoneProgressParams, PartialResultParams, TextDocumentRegistrationOptions, TextDocumentPositionParams
 } from './protocol';
@@ -128,5 +128,6 @@ export interface MonikerParams extends TextDocumentPositionParams, WorkDoneProgr
  */
 export namespace MonikerRequest {
 	export const method: 'textDocument/moniker' = 'textDocument/moniker';
+	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
 	export const type = new ProtocolRequestType<MonikerParams, Moniker[] | null, Moniker[], void, MonikerRegistrationOptions>(method);
 }

--- a/protocol/src/common/protocol.notebook.ts
+++ b/protocol/src/common/protocol.notebook.ts
@@ -9,7 +9,7 @@ import {
 } from 'vscode-languageserver-types';
 
 import * as Is from './utils/is';
-import { ProtocolNotificationType, RegistrationType } from './messages';
+import { MessageDirection, ProtocolNotificationType, RegistrationType } from './messages';
 import type { StaticRegistrationOptions, NotebookDocumentFilter, TextDocumentContentChangeEvent } from './protocol';
 
 /**
@@ -355,6 +355,7 @@ export type NotebookDocumentSyncRegistrationOptions = NotebookDocumentSyncOption
 
 export namespace NotebookDocumentSyncRegistrationType {
 	export const method: 'notebookDocument/sync' = 'notebookDocument/sync';
+	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
 	export const type = new RegistrationType<NotebookDocumentSyncRegistrationOptions>(method);
 }
 
@@ -384,6 +385,7 @@ export type DidOpenNotebookDocumentParams = {
  */
 export namespace DidOpenNotebookDocumentNotification {
 	export const method: 'notebookDocument/didOpen' = 'notebookDocument/didOpen';
+	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
 	export const type = new ProtocolNotificationType<DidOpenNotebookDocumentParams, void>(method);
 	export const registrationMethod: typeof NotebookDocumentSyncRegistrationType.method = NotebookDocumentSyncRegistrationType.method;
 }
@@ -515,6 +517,7 @@ export type DidChangeNotebookDocumentParams = {
 
 export namespace DidChangeNotebookDocumentNotification {
 	export const method: 'notebookDocument/didChange' = 'notebookDocument/didChange';
+	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
 	export const type = new ProtocolNotificationType<DidChangeNotebookDocumentParams, void>(method);
 	export const registrationMethod: typeof NotebookDocumentSyncRegistrationType.method = NotebookDocumentSyncRegistrationType.method;
 }
@@ -538,6 +541,7 @@ export type DidSaveNotebookDocumentParams = {
  */
 export namespace DidSaveNotebookDocumentNotification {
 	export const method: 'notebookDocument/didSave' = 'notebookDocument/didSave';
+	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
 	export const type = new ProtocolNotificationType<DidSaveNotebookDocumentParams, void>(method);
 	export const registrationMethod: typeof NotebookDocumentSyncRegistrationType.method = NotebookDocumentSyncRegistrationType.method;
 }
@@ -568,6 +572,7 @@ export type DidCloseNotebookDocumentParams = {
  */
 export namespace DidCloseNotebookDocumentNotification {
 	export const method: 'notebookDocument/didClose' = 'notebookDocument/didClose';
+	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
 	export const type = new ProtocolNotificationType<DidCloseNotebookDocumentParams, void>(method);
 	export const registrationMethod: typeof NotebookDocumentSyncRegistrationType.method = NotebookDocumentSyncRegistrationType.method;
 }

--- a/protocol/src/common/protocol.progress.ts
+++ b/protocol/src/common/protocol.progress.ts
@@ -6,7 +6,7 @@
 import { NotificationHandler, RequestHandler, ProgressType, ProgressToken } from 'vscode-jsonrpc';
 import { uinteger } from 'vscode-languageserver-types';
 
-import { ProtocolRequestType, ProtocolNotificationType } from './messages';
+import { MessageDirection, ProtocolRequestType, ProtocolNotificationType } from './messages';
 
 export interface WorkDoneProgressBegin {
 
@@ -111,6 +111,7 @@ export interface WorkDoneProgressCreateParams  {
  */
 export namespace WorkDoneProgressCreateRequest {
 	export const method: 'window/workDoneProgress/create' = 'window/workDoneProgress/create';
+	export const messageDirection: MessageDirection = MessageDirection.serverToClient;
 	export const type = new ProtocolRequestType<WorkDoneProgressCreateParams, void, never, void, void>(method);
 	export type HandlerSignature = RequestHandler<WorkDoneProgressCreateParams, void, void>;
 }
@@ -128,6 +129,7 @@ export interface WorkDoneProgressCancelParams {
  */
 export namespace WorkDoneProgressCancelNotification {
 	export const method: 'window/workDoneProgress/cancel' = 'window/workDoneProgress/cancel';
+	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
 	export const type = new ProtocolNotificationType<WorkDoneProgressCancelParams, void>(method);
 	export type HandlerSignature = NotificationHandler<WorkDoneProgressCancelParams>;
 }

--- a/protocol/src/common/protocol.selectionRange.ts
+++ b/protocol/src/common/protocol.selectionRange.ts
@@ -6,7 +6,7 @@
 import { RequestHandler } from 'vscode-jsonrpc';
 import { TextDocumentIdentifier, Position, SelectionRange } from 'vscode-languageserver-types';
 
-import { ProtocolRequestType } from './messages';
+import { MessageDirection, ProtocolRequestType } from './messages';
 import type {
 	TextDocumentRegistrationOptions, WorkDoneProgressOptions, StaticRegistrationOptions, WorkDoneProgressParams, PartialResultParams
 } from './protocol';
@@ -51,6 +51,7 @@ export interface SelectionRangeParams extends WorkDoneProgressParams, PartialRes
  */
 export namespace SelectionRangeRequest {
 	export const method: 'textDocument/selectionRange' = 'textDocument/selectionRange';
+	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
 	export const type = new ProtocolRequestType<SelectionRangeParams, SelectionRange[] | null, SelectionRange[], void, SelectionRangeRegistrationOptions>(method);
 	export type HandlerSignature = RequestHandler<SelectionRangeParams, SelectionRange[] | null, void>;
 }

--- a/protocol/src/common/protocol.semanticTokens.ts
+++ b/protocol/src/common/protocol.semanticTokens.ts
@@ -6,7 +6,7 @@
 import { TextDocumentIdentifier, Range, uinteger, SemanticTokensEdit, SemanticTokensLegend, SemanticTokens, SemanticTokensDelta } from 'vscode-languageserver-types';
 import { RequestHandler0, RequestHandler } from 'vscode-jsonrpc';
 
-import { ProtocolRequestType, ProtocolRequestType0, RegistrationType } from './messages';
+import { MessageDirection, ProtocolRequestType, ProtocolRequestType0, RegistrationType } from './messages';
 import type {
 	PartialResultParams, WorkDoneProgressParams, WorkDoneProgressOptions, TextDocumentRegistrationOptions, StaticRegistrationOptions
 } from './protocol';
@@ -182,6 +182,7 @@ export interface SemanticTokensParams extends WorkDoneProgressParams, PartialRes
  */
 export namespace SemanticTokensRequest {
 	export const method: 'textDocument/semanticTokens/full' = 'textDocument/semanticTokens/full';
+	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
 	export const type = new ProtocolRequestType<SemanticTokensParams, SemanticTokens | null, SemanticTokensPartialResult, void, SemanticTokensRegistrationOptions>(method);
 	export const registrationMethod: typeof SemanticTokensRegistrationType.method  = SemanticTokensRegistrationType.method;
 	export type HandlerSignature = RequestHandler<SemanticTokensDeltaParams, SemanticTokens | null, void>;
@@ -210,6 +211,7 @@ export interface SemanticTokensDeltaParams extends WorkDoneProgressParams, Parti
  */
 export namespace SemanticTokensDeltaRequest {
 	export const method: 'textDocument/semanticTokens/full/delta' = 'textDocument/semanticTokens/full/delta';
+	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
 	export const type = new ProtocolRequestType<SemanticTokensDeltaParams, SemanticTokens | SemanticTokensDelta | null, SemanticTokensPartialResult | SemanticTokensDeltaPartialResult, void, SemanticTokensRegistrationOptions>(method);
 	export const registrationMethod: typeof SemanticTokensRegistrationType.method  = SemanticTokensRegistrationType.method;
 	export type HandlerSignature = RequestHandler<SemanticTokensDeltaParams, SemanticTokens | SemanticTokensDelta | null, void>;
@@ -237,6 +239,7 @@ export interface SemanticTokensRangeParams extends WorkDoneProgressParams, Parti
  */
 export namespace SemanticTokensRangeRequest {
 	export const method: 'textDocument/semanticTokens/range' = 'textDocument/semanticTokens/range';
+	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
 	export const type = new ProtocolRequestType<SemanticTokensRangeParams, SemanticTokens | null, SemanticTokensPartialResult, void, void>(method);
 	export const registrationMethod: typeof SemanticTokensRegistrationType.method  = SemanticTokensRegistrationType.method;
 	export type HandlerSignature = RequestHandler<SemanticTokensRangeParams, SemanticTokens | null, void>;
@@ -265,6 +268,7 @@ export interface SemanticTokensWorkspaceClientCapabilities {
  */
 export namespace SemanticTokensRefreshRequest {
 	export const method: `workspace/semanticTokens/refresh` = `workspace/semanticTokens/refresh`;
+	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
 	export const type = new ProtocolRequestType0<void, void, void, void>(method);
 	export type HandlerSignature = RequestHandler0<void, void>;
 }

--- a/protocol/src/common/protocol.showDocument.ts
+++ b/protocol/src/common/protocol.showDocument.ts
@@ -5,7 +5,7 @@
 
 import { HandlerResult, RequestHandler } from 'vscode-jsonrpc';
 import { Range, URI } from 'vscode-languageserver-types';
-import { ProtocolRequestType } from './messages';
+import { MessageDirection, ProtocolRequestType } from './messages';
 
 /**
  * Client capabilities for the showDocument request.
@@ -77,6 +77,7 @@ export interface ShowDocumentResult {
 */
 export namespace ShowDocumentRequest {
 	export const method: 'window/showDocument' = 'window/showDocument';
+	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
 	export const type = new ProtocolRequestType<ShowDocumentParams, ShowDocumentResult, void, void, void>(method);
 	export type HandlerSignature = RequestHandler<ShowDocumentParams, ShowDocumentResult, void>;
 	export type MiddlewareSignature = (params: ShowDocumentParams, next: HandlerSignature) => HandlerResult<ShowDocumentResult, void>;

--- a/protocol/src/common/protocol.showDocument.ts
+++ b/protocol/src/common/protocol.showDocument.ts
@@ -77,7 +77,7 @@ export interface ShowDocumentResult {
 */
 export namespace ShowDocumentRequest {
 	export const method: 'window/showDocument' = 'window/showDocument';
-	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
+	export const messageDirection: MessageDirection = MessageDirection.serverToClient;
 	export const type = new ProtocolRequestType<ShowDocumentParams, ShowDocumentResult, void, void, void>(method);
 	export type HandlerSignature = RequestHandler<ShowDocumentParams, ShowDocumentResult, void>;
 	export type MiddlewareSignature = (params: ShowDocumentParams, next: HandlerSignature) => HandlerResult<ShowDocumentResult, void>;

--- a/protocol/src/common/protocol.ts
+++ b/protocol/src/common/protocol.ts
@@ -5,7 +5,7 @@
 
 import { ProgressToken } from 'vscode-jsonrpc';
 
-import { ProtocolRequestType, ProtocolRequestType0, ProtocolNotificationType, ProtocolNotificationType0 } from './messages';
+import { MessageDirection, ProtocolRequestType, ProtocolRequestType0, ProtocolNotificationType, ProtocolNotificationType0 } from './messages';
 
 import {
 	Position, Range, Location, LocationLink, Diagnostic, Command, TextEdit, WorkspaceEdit, DocumentUri,
@@ -332,7 +332,9 @@ export interface RegistrationParams {
  * handler on the client side.
  */
 export namespace RegistrationRequest {
-	export const type = new ProtocolRequestType<RegistrationParams, void, never, void, void>('client/registerCapability');
+  export const method: 'client/registerCapability' = 'client/registerCapability';
+	export const messageDirection: MessageDirection = MessageDirection.serverToClient;
+	export const type = new ProtocolRequestType<RegistrationParams, void, never, void, void>(method);
 }
 
 /**
@@ -363,7 +365,9 @@ export interface UnregistrationParams {
  * handler on the client side.
  */
 export namespace UnregistrationRequest {
-	export const type = new ProtocolRequestType<UnregistrationParams, void, never, void, void>('client/unregisterCapability');
+  export const method: 'client/unregisterCapability' = 'client/unregisterCapability';
+	export const messageDirection: MessageDirection = MessageDirection.serverToClient;
+	export const type = new ProtocolRequestType<UnregistrationParams, void, never, void, void>(method);
 }
 
 export interface WorkDoneProgressParams {
@@ -1274,7 +1278,9 @@ export interface ServerCapabilities<T = LSPAny> {
  * resolves to such.
  */
 export namespace InitializeRequest {
-	export const type = new ProtocolRequestType<InitializeParams, InitializeResult, never, InitializeError, void>('initialize');
+  export const method: 'initialize' = 'initialize';
+	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
+	export const type = new ProtocolRequestType<InitializeParams, InitializeResult, never, InitializeError, void>(method);
 }
 
 /**
@@ -1425,7 +1431,9 @@ export interface InitializedParams {
  * is allowed to send requests from the server to the client.
  */
 export namespace InitializedNotification {
-	export const type = new ProtocolNotificationType<InitializedParams, void>('initialized');
+  export const method: 'initialized' = 'initialized';
+	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
+	export const type = new ProtocolNotificationType<InitializedParams, void>(method);
 }
 
 //---- Shutdown Method ----
@@ -1437,7 +1445,9 @@ export namespace InitializedNotification {
  * is the exit event.
  */
 export namespace ShutdownRequest {
-	export const type = new ProtocolRequestType0<void, never, void, void>('shutdown');
+  export const method: 'shutdown' = 'shutdown';
+	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
+	export const type = new ProtocolRequestType0<void, never, void, void>(method);
 }
 
 //---- Exit Notification ----
@@ -1447,7 +1457,9 @@ export namespace ShutdownRequest {
  * ask the server to exit its process.
  */
 export namespace ExitNotification {
-	export const type = new ProtocolNotificationType0<void>('exit');
+  export const method: 'exit' = 'exit';
+	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
+	export const type = new ProtocolNotificationType0<void>(method);
 }
 
 //---- Configuration notification ----
@@ -1465,7 +1477,9 @@ export interface DidChangeConfigurationClientCapabilities {
  * the changed configuration as defined by the language client.
  */
 export namespace DidChangeConfigurationNotification {
-	export const type = new ProtocolNotificationType<DidChangeConfigurationParams, DidChangeConfigurationRegistrationOptions>('workspace/didChangeConfiguration');
+  export const method: 'workspace/didChangeConfiguration' = 'workspace/didChangeConfiguration';
+	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
+	export const type = new ProtocolNotificationType<DidChangeConfigurationParams, DidChangeConfigurationRegistrationOptions>(method);
 }
 
 export interface DidChangeConfigurationRegistrationOptions {
@@ -1528,7 +1542,9 @@ export interface ShowMessageParams {
  * the client to display a particular message in the user interface.
  */
 export namespace ShowMessageNotification {
-	export const type = new ProtocolNotificationType<ShowMessageParams, void>('window/showMessage');
+  export const method: 'window/showMessage' = 'window/showMessage';
+	export const messageDirection: MessageDirection = MessageDirection.serverToClient;
+	export const type = new ProtocolNotificationType<ShowMessageParams, void>(method);
 }
 
 /**
@@ -1584,7 +1600,9 @@ export interface ShowMessageRequestParams {
  * and a set of options actions to the user.
  */
 export namespace ShowMessageRequest {
-	export const type = new ProtocolRequestType<ShowMessageRequestParams, MessageActionItem | null, never, void, void>('window/showMessageRequest');
+  export const method: 'window/showMessageRequest' = 'window/showMessageRequest';
+	export const messageDirection: MessageDirection = MessageDirection.serverToClient;
+	export const type = new ProtocolRequestType<ShowMessageRequestParams, MessageActionItem | null, never, void, void>(method);
 }
 
 /**
@@ -1592,7 +1610,9 @@ export namespace ShowMessageRequest {
  * the client to log a particular message.
  */
 export namespace LogMessageNotification {
-	export const type = new ProtocolNotificationType<LogMessageParams, void>('window/logMessage');
+  export const method: 'window/logMessage' = 'window/logMessage';
+	export const messageDirection: MessageDirection = MessageDirection.serverToClient;
+	export const type = new ProtocolNotificationType<LogMessageParams, void>(method);
 }
 
 /**
@@ -1617,7 +1637,9 @@ export interface LogMessageParams {
  * the client to log telemetry data.
  */
 export namespace TelemetryEventNotification {
-	export const type = new ProtocolNotificationType<LSPAny, void>('telemetry/event');
+  export const method: 'telemetry/event' = 'telemetry/event';
+	export const messageDirection: MessageDirection = MessageDirection.serverToClient;
+	export const type = new ProtocolNotificationType<LSPAny, void>(method);
 }
 
 //---- Text document notifications ----
@@ -1722,6 +1744,7 @@ export interface DidOpenTextDocumentParams {
  */
 export namespace DidOpenTextDocumentNotification {
 	export const method: 'textDocument/didOpen' = 'textDocument/didOpen';
+	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
 	export const type = new ProtocolNotificationType<DidOpenTextDocumentParams, TextDocumentRegistrationOptions>(method);
 }
 
@@ -1818,6 +1841,7 @@ export interface TextDocumentChangeRegistrationOptions extends TextDocumentRegis
  */
 export namespace DidChangeTextDocumentNotification {
 	export const method: 'textDocument/didChange' = 'textDocument/didChange';
+	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
 	export const type = new ProtocolNotificationType<DidChangeTextDocumentParams, TextDocumentChangeRegistrationOptions>(method);
 }
 
@@ -1842,6 +1866,7 @@ export interface DidCloseTextDocumentParams {
  */
 export namespace DidCloseTextDocumentNotification {
 	export const method: 'textDocument/didClose' = 'textDocument/didClose';
+	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
 	export const type = new ProtocolNotificationType<DidCloseTextDocumentParams, TextDocumentRegistrationOptions>(method);
 }
 
@@ -1873,6 +1898,7 @@ export interface TextDocumentSaveRegistrationOptions extends TextDocumentRegistr
  */
 export namespace DidSaveTextDocumentNotification {
 	export const method: 'textDocument/didSave' = 'textDocument/didSave';
+	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
 	export const type = new ProtocolNotificationType<DidSaveTextDocumentParams, TextDocumentSaveRegistrationOptions>(method);
 }
 
@@ -1921,6 +1947,7 @@ export interface WillSaveTextDocumentParams {
  */
 export namespace WillSaveTextDocumentNotification {
 	export const method: 'textDocument/willSave' = 'textDocument/willSave';
+	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
 	export const type = new ProtocolNotificationType<WillSaveTextDocumentParams, TextDocumentRegistrationOptions>(method);
 }
 
@@ -1934,6 +1961,7 @@ export namespace WillSaveTextDocumentNotification {
  */
 export namespace WillSaveTextDocumentWaitUntilRequest {
 	export const method: 'textDocument/willSaveWaitUntil' = 'textDocument/willSaveWaitUntil';
+	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
 	export const type = new ProtocolRequestType<WillSaveTextDocumentParams, TextEdit[] | null, never, void, TextDocumentRegistrationOptions>(method);
 }
 
@@ -1961,7 +1989,9 @@ export interface DidChangeWatchedFilesClientCapabilities {
  * the client detects changes to file watched by the language client.
  */
 export namespace DidChangeWatchedFilesNotification {
-	export const type = new ProtocolNotificationType<DidChangeWatchedFilesParams, DidChangeWatchedFilesRegistrationOptions>('workspace/didChangeWatchedFiles');
+  export const method: 'workspace/didChangeWatchedFiles' = 'workspace/didChangeWatchedFiles';
+	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
+	export const type = new ProtocolNotificationType<DidChangeWatchedFilesParams, DidChangeWatchedFilesRegistrationOptions>(method);
 }
 
 /**
@@ -2175,7 +2205,9 @@ export interface PublishDiagnosticsParams {
  * results of validation runs.
  */
 export namespace PublishDiagnosticsNotification {
-	export const type = new ProtocolNotificationType<PublishDiagnosticsParams, void>('textDocument/publishDiagnostics');
+  export const method: 'textDocument/publishDiagnostics' = 'textDocument/publishDiagnostics';
+	export const messageDirection: MessageDirection = MessageDirection.serverToClient;
+	export const type = new ProtocolNotificationType<PublishDiagnosticsParams, void>(method);
 }
 
 //---- Completion Support --------------------------
@@ -2456,6 +2488,7 @@ export interface CompletionRegistrationOptions extends TextDocumentRegistrationO
  */
 export namespace CompletionRequest {
 	export const method: 'textDocument/completion' = 'textDocument/completion';
+	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
 	export const type = new ProtocolRequestType<CompletionParams, CompletionItem[] | CompletionList | null, CompletionItem[], void, CompletionRegistrationOptions>(method);
 }
 
@@ -2466,6 +2499,7 @@ export namespace CompletionRequest {
  */
 export namespace CompletionResolveRequest {
 	export const method: 'completionItem/resolve' = 'completionItem/resolve';
+	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
 	export const type = new ProtocolRequestType<CompletionItem, CompletionItem, never, void, void>(method);
 }
 
@@ -2509,6 +2543,7 @@ export interface HoverRegistrationOptions extends TextDocumentRegistrationOption
  */
 export namespace HoverRequest {
 	export const method: 'textDocument/hover' = 'textDocument/hover';
+	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
 	export const type = new ProtocolRequestType<HoverParams, Hover | null, never, void, HoverRegistrationOptions>(method);
 }
 
@@ -2664,6 +2699,7 @@ export interface SignatureHelpRegistrationOptions extends TextDocumentRegistrati
 
 export namespace SignatureHelpRequest {
 	export const method: 'textDocument/signatureHelp' = 'textDocument/signatureHelp';
+	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
 	export const type = new ProtocolRequestType<SignatureHelpParams, SignatureHelp | null, never, void, SignatureHelpRegistrationOptions>(method);
 }
 
@@ -2713,6 +2749,7 @@ export interface DefinitionRegistrationOptions extends TextDocumentRegistrationO
  */
 export namespace DefinitionRequest {
 	export const method: 'textDocument/definition' = 'textDocument/definition';
+	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
 	export const type = new ProtocolRequestType<DefinitionParams, Definition | DefinitionLink[] | null, Location[] | DefinitionLink[], void, DefinitionRegistrationOptions>(method);
 }
 
@@ -2755,6 +2792,7 @@ export interface ReferenceRegistrationOptions extends TextDocumentRegistrationOp
  */
 export namespace ReferencesRequest {
 	export const method: 'textDocument/references' = 'textDocument/references';
+	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
 	export const type = new ProtocolRequestType<ReferenceParams, Location[] | null, Location[], void, ReferenceRegistrationOptions>(method);
 }
 
@@ -2796,6 +2834,7 @@ export interface DocumentHighlightRegistrationOptions extends TextDocumentRegist
  */
 export namespace DocumentHighlightRequest {
 	export const method: 'textDocument/documentHighlight' = 'textDocument/documentHighlight';
+	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
 	export const type = new ProtocolRequestType<DocumentHighlightParams, DocumentHighlight[] | null, DocumentHighlight[], void, DocumentHighlightRegistrationOptions>(method);
 }
 
@@ -2893,6 +2932,7 @@ export interface DocumentSymbolRegistrationOptions extends TextDocumentRegistrat
  */
 export namespace DocumentSymbolRequest {
 	export const method: 'textDocument/documentSymbol' = 'textDocument/documentSymbol';
+	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
 	export const type = new ProtocolRequestType<DocumentSymbolParams, SymbolInformation[] | DocumentSymbol[] | null, SymbolInformation[] | DocumentSymbol[], void, DocumentSymbolRegistrationOptions>(method);
 }
 
@@ -3031,6 +3071,7 @@ export interface CodeActionRegistrationOptions extends TextDocumentRegistrationO
  */
 export namespace CodeActionRequest {
 	export const method: 'textDocument/codeAction' = 'textDocument/codeAction';
+	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
 	export const type = new ProtocolRequestType<CodeActionParams, (Command | CodeAction)[] | null, (Command | CodeAction)[], void, CodeActionRegistrationOptions>(method);
 }
 
@@ -3041,6 +3082,7 @@ export namespace CodeActionRequest {
  */
 export namespace CodeActionResolveRequest {
 	export const method: 'codeAction/resolve' = 'codeAction/resolve';
+	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
 	export const type = new ProtocolRequestType<CodeAction, CodeAction, never, void, void>(method);
 }
 
@@ -3145,6 +3187,7 @@ export interface WorkspaceSymbolRegistrationOptions extends WorkspaceSymbolOptio
  */
 export namespace WorkspaceSymbolRequest {
 	export const method: 'workspace/symbol' = 'workspace/symbol';
+	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
 	export const type = new ProtocolRequestType<WorkspaceSymbolParams, SymbolInformation[] | WorkspaceSymbol[] | null, SymbolInformation[] | WorkspaceSymbol[], void, WorkspaceSymbolRegistrationOptions>(method);
 }
 
@@ -3156,6 +3199,7 @@ export namespace WorkspaceSymbolRequest {
  */
 export namespace WorkspaceSymbolResolveRequest {
 	export const method: 'workspaceSymbol/resolve' = 'workspaceSymbol/resolve';
+	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
 	export const type = new ProtocolRequestType<WorkspaceSymbol, WorkspaceSymbol, never, void, void>(method);
 }
 
@@ -3218,6 +3262,7 @@ export interface CodeLensRegistrationOptions extends TextDocumentRegistrationOpt
  */
 export namespace CodeLensRequest {
 	export const method: 'textDocument/codeLens' = 'textDocument/codeLens';
+	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
 	export const type = new ProtocolRequestType<CodeLensParams, CodeLens[] | null, CodeLens[], void, CodeLensRegistrationOptions>(method);
 }
 
@@ -3226,6 +3271,7 @@ export namespace CodeLensRequest {
  */
 export namespace CodeLensResolveRequest {
 	export const method: 'codeLens/resolve' = 'codeLens/resolve';
+	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
 	export const type = new ProtocolRequestType<CodeLens, CodeLens, never, void, void>(method);
 }
 
@@ -3288,6 +3334,7 @@ export interface DocumentLinkRegistrationOptions extends TextDocumentRegistratio
  */
 export namespace DocumentLinkRequest {
 	export const method: 'textDocument/documentLink' = 'textDocument/documentLink';
+	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
 	export const type = new ProtocolRequestType<DocumentLinkParams, DocumentLink[] | null, DocumentLink[], void, DocumentLinkRegistrationOptions>(method);
 }
 
@@ -3298,6 +3345,7 @@ export namespace DocumentLinkRequest {
  */
 export namespace DocumentLinkResolveRequest {
 	export const method: 'documentLink/resolve' = 'documentLink/resolve';
+	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
 	export const type = new ProtocolRequestType<DocumentLink, DocumentLink, never, void, void>(method);
 }
 
@@ -3345,6 +3393,7 @@ export interface DocumentFormattingRegistrationOptions extends TextDocumentRegis
  */
 export namespace DocumentFormattingRequest {
 	export const method: 'textDocument/formatting' = 'textDocument/formatting';
+	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
 	export const type = new ProtocolRequestType<DocumentFormattingParams, TextEdit[] | null, never, void, DocumentFormattingRegistrationOptions>(method);
 }
 
@@ -3395,6 +3444,7 @@ export interface DocumentRangeFormattingRegistrationOptions extends TextDocument
  */
 export namespace DocumentRangeFormattingRequest {
 	export const method: 'textDocument/rangeFormatting' = 'textDocument/rangeFormatting';
+	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
 	export const type = new ProtocolRequestType<DocumentRangeFormattingParams, TextEdit[] | null, never, void, DocumentRangeFormattingRegistrationOptions>(method);
 }
 
@@ -3465,6 +3515,7 @@ export interface DocumentOnTypeFormattingRegistrationOptions extends TextDocumen
  */
 export namespace DocumentOnTypeFormattingRequest {
 	export const method: 'textDocument/onTypeFormatting' = 'textDocument/onTypeFormatting';
+	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
 	export const type = new ProtocolRequestType<DocumentOnTypeFormattingParams, TextEdit[] | null, never, void, DocumentOnTypeFormattingRegistrationOptions>(method);
 }
 
@@ -3561,6 +3612,7 @@ export interface RenameRegistrationOptions extends TextDocumentRegistrationOptio
  */
 export namespace RenameRequest {
 	export const method: 'textDocument/rename' = 'textDocument/rename';
+	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
 	export const type = new ProtocolRequestType<RenameParams, WorkspaceEdit | null, never, void, RenameRegistrationOptions>(method);
 }
 
@@ -3576,6 +3628,7 @@ export type PrepareRenameResult = Range | { range: Range; placeholder: string } 
  */
 export namespace PrepareRenameRequest {
 	export const method: 'textDocument/prepareRename' = 'textDocument/prepareRename';
+	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
 	export const type = new ProtocolRequestType<PrepareRenameParams, PrepareRenameResult | null, never, void, void>(method);
 }
 
@@ -3627,7 +3680,9 @@ export interface ExecuteCommandRegistrationOptions extends ExecuteCommandOptions
  * a workspace edit which the client will apply to the workspace.
  */
 export namespace ExecuteCommandRequest {
-	export const type = new ProtocolRequestType<ExecuteCommandParams, LSPAny | null, never, void, ExecuteCommandRegistrationOptions>('workspace/executeCommand');
+  export const method: 'workspace/executeCommand' = 'workspace/executeCommand';
+	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
+	export const type = new ProtocolRequestType<ExecuteCommandParams, LSPAny | null, never, void, ExecuteCommandRegistrationOptions>(method);
 }
 
 //---- Apply Edit request ----------------------------------------
@@ -3733,6 +3788,8 @@ export type ApplyWorkspaceEditResponse = ApplyWorkspaceEditResult;
  * A request sent from the server to the client to modified certain resources.
  */
 export namespace ApplyWorkspaceEditRequest {
+  export const method: 'workspace/applyEdit' = 'workspace/applyEdit';
+	export const messageDirection: MessageDirection = MessageDirection.serverToClient;
 	export const type = new ProtocolRequestType<ApplyWorkspaceEditParams, ApplyWorkspaceEditResult, never, void, void>('workspace/applyEdit');
 }
 

--- a/protocol/src/common/protocol.ts
+++ b/protocol/src/common/protocol.ts
@@ -332,7 +332,7 @@ export interface RegistrationParams {
  * handler on the client side.
  */
 export namespace RegistrationRequest {
-  export const method: 'client/registerCapability' = 'client/registerCapability';
+	export const method: 'client/registerCapability' = 'client/registerCapability';
 	export const messageDirection: MessageDirection = MessageDirection.serverToClient;
 	export const type = new ProtocolRequestType<RegistrationParams, void, never, void, void>(method);
 }
@@ -365,7 +365,7 @@ export interface UnregistrationParams {
  * handler on the client side.
  */
 export namespace UnregistrationRequest {
-  export const method: 'client/unregisterCapability' = 'client/unregisterCapability';
+	export const method: 'client/unregisterCapability' = 'client/unregisterCapability';
 	export const messageDirection: MessageDirection = MessageDirection.serverToClient;
 	export const type = new ProtocolRequestType<UnregistrationParams, void, never, void, void>(method);
 }
@@ -1278,7 +1278,7 @@ export interface ServerCapabilities<T = LSPAny> {
  * resolves to such.
  */
 export namespace InitializeRequest {
-  export const method: 'initialize' = 'initialize';
+	export const method: 'initialize' = 'initialize';
 	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
 	export const type = new ProtocolRequestType<InitializeParams, InitializeResult, never, InitializeError, void>(method);
 }
@@ -1431,7 +1431,7 @@ export interface InitializedParams {
  * is allowed to send requests from the server to the client.
  */
 export namespace InitializedNotification {
-  export const method: 'initialized' = 'initialized';
+	export const method: 'initialized' = 'initialized';
 	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
 	export const type = new ProtocolNotificationType<InitializedParams, void>(method);
 }
@@ -1445,7 +1445,7 @@ export namespace InitializedNotification {
  * is the exit event.
  */
 export namespace ShutdownRequest {
-  export const method: 'shutdown' = 'shutdown';
+	export const method: 'shutdown' = 'shutdown';
 	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
 	export const type = new ProtocolRequestType0<void, never, void, void>(method);
 }
@@ -1457,7 +1457,7 @@ export namespace ShutdownRequest {
  * ask the server to exit its process.
  */
 export namespace ExitNotification {
-  export const method: 'exit' = 'exit';
+	export const method: 'exit' = 'exit';
 	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
 	export const type = new ProtocolNotificationType0<void>(method);
 }
@@ -1477,7 +1477,7 @@ export interface DidChangeConfigurationClientCapabilities {
  * the changed configuration as defined by the language client.
  */
 export namespace DidChangeConfigurationNotification {
-  export const method: 'workspace/didChangeConfiguration' = 'workspace/didChangeConfiguration';
+	export const method: 'workspace/didChangeConfiguration' = 'workspace/didChangeConfiguration';
 	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
 	export const type = new ProtocolNotificationType<DidChangeConfigurationParams, DidChangeConfigurationRegistrationOptions>(method);
 }
@@ -1542,7 +1542,7 @@ export interface ShowMessageParams {
  * the client to display a particular message in the user interface.
  */
 export namespace ShowMessageNotification {
-  export const method: 'window/showMessage' = 'window/showMessage';
+	export const method: 'window/showMessage' = 'window/showMessage';
 	export const messageDirection: MessageDirection = MessageDirection.serverToClient;
 	export const type = new ProtocolNotificationType<ShowMessageParams, void>(method);
 }
@@ -1600,7 +1600,7 @@ export interface ShowMessageRequestParams {
  * and a set of options actions to the user.
  */
 export namespace ShowMessageRequest {
-  export const method: 'window/showMessageRequest' = 'window/showMessageRequest';
+	export const method: 'window/showMessageRequest' = 'window/showMessageRequest';
 	export const messageDirection: MessageDirection = MessageDirection.serverToClient;
 	export const type = new ProtocolRequestType<ShowMessageRequestParams, MessageActionItem | null, never, void, void>(method);
 }
@@ -1610,7 +1610,7 @@ export namespace ShowMessageRequest {
  * the client to log a particular message.
  */
 export namespace LogMessageNotification {
-  export const method: 'window/logMessage' = 'window/logMessage';
+	export const method: 'window/logMessage' = 'window/logMessage';
 	export const messageDirection: MessageDirection = MessageDirection.serverToClient;
 	export const type = new ProtocolNotificationType<LogMessageParams, void>(method);
 }
@@ -1637,7 +1637,7 @@ export interface LogMessageParams {
  * the client to log telemetry data.
  */
 export namespace TelemetryEventNotification {
-  export const method: 'telemetry/event' = 'telemetry/event';
+	export const method: 'telemetry/event' = 'telemetry/event';
 	export const messageDirection: MessageDirection = MessageDirection.serverToClient;
 	export const type = new ProtocolNotificationType<LSPAny, void>(method);
 }
@@ -1989,7 +1989,7 @@ export interface DidChangeWatchedFilesClientCapabilities {
  * the client detects changes to file watched by the language client.
  */
 export namespace DidChangeWatchedFilesNotification {
-  export const method: 'workspace/didChangeWatchedFiles' = 'workspace/didChangeWatchedFiles';
+	export const method: 'workspace/didChangeWatchedFiles' = 'workspace/didChangeWatchedFiles';
 	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
 	export const type = new ProtocolNotificationType<DidChangeWatchedFilesParams, DidChangeWatchedFilesRegistrationOptions>(method);
 }
@@ -2205,7 +2205,7 @@ export interface PublishDiagnosticsParams {
  * results of validation runs.
  */
 export namespace PublishDiagnosticsNotification {
-  export const method: 'textDocument/publishDiagnostics' = 'textDocument/publishDiagnostics';
+	export const method: 'textDocument/publishDiagnostics' = 'textDocument/publishDiagnostics';
 	export const messageDirection: MessageDirection = MessageDirection.serverToClient;
 	export const type = new ProtocolNotificationType<PublishDiagnosticsParams, void>(method);
 }
@@ -3680,7 +3680,7 @@ export interface ExecuteCommandRegistrationOptions extends ExecuteCommandOptions
  * a workspace edit which the client will apply to the workspace.
  */
 export namespace ExecuteCommandRequest {
-  export const method: 'workspace/executeCommand' = 'workspace/executeCommand';
+	export const method: 'workspace/executeCommand' = 'workspace/executeCommand';
 	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
 	export const type = new ProtocolRequestType<ExecuteCommandParams, LSPAny | null, never, void, ExecuteCommandRegistrationOptions>(method);
 }
@@ -3788,7 +3788,7 @@ export type ApplyWorkspaceEditResponse = ApplyWorkspaceEditResult;
  * A request sent from the server to the client to modified certain resources.
  */
 export namespace ApplyWorkspaceEditRequest {
-  export const method: 'workspace/applyEdit' = 'workspace/applyEdit';
+	export const method: 'workspace/applyEdit' = 'workspace/applyEdit';
 	export const messageDirection: MessageDirection = MessageDirection.serverToClient;
 	export const type = new ProtocolRequestType<ApplyWorkspaceEditParams, ApplyWorkspaceEditResult, never, void, void>('workspace/applyEdit');
 }

--- a/protocol/src/common/protocol.typeDefinition.ts
+++ b/protocol/src/common/protocol.typeDefinition.ts
@@ -4,7 +4,7 @@
  * ------------------------------------------------------------------------------------------ */
 
 import { RequestHandler } from 'vscode-jsonrpc';
-import { Definition, DefinitionLink, LocationLink, Location } from 'vscode-languageserver-types';
+import { MessageDirection, Definition, DefinitionLink, LocationLink, Location } from 'vscode-languageserver-types';
 
 import { ProtocolRequestType } from './messages';
 import type {
@@ -51,6 +51,7 @@ export interface TypeDefinitionParams extends TextDocumentPositionParams, WorkDo
  */
 export namespace TypeDefinitionRequest {
 	export const method: 'textDocument/typeDefinition' = 'textDocument/typeDefinition';
+	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
 	export const type = new ProtocolRequestType<TypeDefinitionParams, Definition | DefinitionLink[] | null, Location[] | DefinitionLink[], void, TypeDefinitionRegistrationOptions>(method);
 	export type HandlerSignature = RequestHandler<TypeDefinitionParams, Definition | DefinitionLink[] | null, void>;
 }

--- a/protocol/src/common/protocol.typeDefinition.ts
+++ b/protocol/src/common/protocol.typeDefinition.ts
@@ -4,9 +4,9 @@
  * ------------------------------------------------------------------------------------------ */
 
 import { RequestHandler } from 'vscode-jsonrpc';
-import { MessageDirection, Definition, DefinitionLink, LocationLink, Location } from 'vscode-languageserver-types';
+import { Definition, DefinitionLink, LocationLink, Location } from 'vscode-languageserver-types';
 
-import { ProtocolRequestType } from './messages';
+import { MessageDirection, ProtocolRequestType } from './messages';
 import type {
 	TextDocumentRegistrationOptions, StaticRegistrationOptions, TextDocumentPositionParams, PartialResultParams, WorkDoneProgressParams,
 	WorkDoneProgressOptions

--- a/protocol/src/common/protocol.typeHierarchy.ts
+++ b/protocol/src/common/protocol.typeHierarchy.ts
@@ -6,7 +6,7 @@
 import { RequestHandler } from 'vscode-jsonrpc';
 import { TypeHierarchyItem } from 'vscode-languageserver-types';
 
-import { ProtocolRequestType } from './messages';
+import { MessageDirection, ProtocolRequestType } from './messages';
 import type {
 	TextDocumentRegistrationOptions, StaticRegistrationOptions, TextDocumentPositionParams, PartialResultParams,
 	WorkDoneProgressParams, WorkDoneProgressOptions
@@ -53,6 +53,7 @@ export type TypeHierarchyPrepareParams = TextDocumentPositionParams & WorkDonePr
  */
 export namespace TypeHierarchyPrepareRequest {
 	export const method: 'textDocument/prepareTypeHierarchy' = 'textDocument/prepareTypeHierarchy';
+	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
 	export const type = new ProtocolRequestType<TypeHierarchyPrepareParams, TypeHierarchyItem[] | null, never, void, TypeHierarchyRegistrationOptions>(method);
 	export type HandlerSignature = RequestHandler<TypeHierarchyPrepareParams, TypeHierarchyItem[] | null, void>;
 }
@@ -73,6 +74,7 @@ export type TypeHierarchySupertypesParams = WorkDoneProgressParams & PartialResu
  */
 export namespace TypeHierarchySupertypesRequest {
 	export const method: 'typeHierarchy/supertypes' = 'typeHierarchy/supertypes';
+	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
 	export const type = new ProtocolRequestType<TypeHierarchySupertypesParams, TypeHierarchyItem[] | null, TypeHierarchyItem[], void, void>(method);
 	export type HandlerSignature = RequestHandler<TypeHierarchySupertypesParams, TypeHierarchyItem[] | null, void>;
 }
@@ -93,6 +95,7 @@ export type TypeHierarchySubtypesParams = WorkDoneProgressParams & PartialResult
  */
 export namespace TypeHierarchySubtypesRequest {
 	export const method: 'typeHierarchy/subtypes' = 'typeHierarchy/subtypes';
+	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
 	export const type = new ProtocolRequestType<TypeHierarchySubtypesParams, TypeHierarchyItem[] | null, TypeHierarchyItem[], void, void>(method);
 	export type HandlerSignature = RequestHandler<TypeHierarchySubtypesParams, TypeHierarchyItem[] | null, void>;
 }

--- a/protocol/src/common/protocol.workspaceFolder.ts
+++ b/protocol/src/common/protocol.workspaceFolder.ts
@@ -6,7 +6,7 @@
 import { WorkspaceFolder } from 'vscode-languageserver-types';
 import { RequestHandler0, NotificationHandler, HandlerResult, CancellationToken } from 'vscode-jsonrpc';
 
-import { ProtocolRequestType0, ProtocolNotificationType } from './messages';
+import { MessageDirection, ProtocolRequestType0, ProtocolNotificationType } from './messages';
 
 export interface WorkspaceFoldersInitializeParams {
 	/**
@@ -44,7 +44,9 @@ export interface WorkspaceFoldersServerCapabilities {
  * The `workspace/workspaceFolders` is sent from the server to the client to fetch the open workspace folders.
  */
 export namespace WorkspaceFoldersRequest {
-	export const type = new ProtocolRequestType0<WorkspaceFolder[] | null, never, void, void>('workspace/workspaceFolders');
+	export const method: 'workspace/workspaceFolders' = 'workspace/workspaceFolders';
+	export const messageDirection: MessageDirection = MessageDirection.serverToClient;
+	export const type = new ProtocolRequestType0<WorkspaceFolder[] | null, never, void, void>(method);
 	export type HandlerSignature = RequestHandler0<WorkspaceFolder[] | null, void>;
 	export type MiddlewareSignature = (token: CancellationToken, next: HandlerSignature) => HandlerResult<WorkspaceFolder[] | null, void>;
 }
@@ -54,7 +56,9 @@ export namespace WorkspaceFoldersRequest {
  * folder configuration changes.
  */
 export namespace DidChangeWorkspaceFoldersNotification {
-	export const type = new ProtocolNotificationType<DidChangeWorkspaceFoldersParams, void>('workspace/didChangeWorkspaceFolders');
+	export const method: 'workspace/didChangeWorkspaceFolders' = 'workspace/didChangeWorkspaceFolders';
+	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
+	export const type = new ProtocolNotificationType<DidChangeWorkspaceFoldersParams, void>(method);
 	export type HandlerSignature = NotificationHandler<DidChangeWorkspaceFoldersParams>;
 	export type MiddlewareSignature = (params: DidChangeWorkspaceFoldersParams, next: HandlerSignature) => void;
 }

--- a/tools/src/metaModel.ts
+++ b/tools/src/metaModel.ts
@@ -163,11 +163,12 @@ export type Request = {
 	 */
 	registrationOptions?: Type;
 
-    /**
-     * The direction in which this request is sent
-     * in the protocol.
-     */
-	messageDirection: MessageDirection;
+	// TODO: make this mandatory when we fill it in
+	/**
+	 * The direction in which this request is sent
+	 * in the protocol.
+	 */
+	messageDirection?: MessageDirection;
 
 	/**
 	 * An optional documentation;
@@ -213,11 +214,12 @@ export type Notification = {
 	 */
 	registrationOptions?: Type;
 
-    /**
-     * The direction in which this notification is sent
-     * in the protocol.
-     */
-	messageDirection: MessageDirection;
+	// TODO: make this mandatory when we fill it in
+	/**
+	 * The direction in which this notification is sent
+	 * in the protocol.
+	 */
+	messageDirection?: MessageDirection;
 
 	/**
 	 * An optional documentation;

--- a/tools/src/metaModel.ts
+++ b/tools/src/metaModel.ts
@@ -8,6 +8,11 @@ export type BaseTypes = 'Uri' | 'DocumentUri' | 'integer' | 'uinteger' | 'decima
 export type TypeKind = 'base' | 'reference' | 'array' | 'map' | 'and' | 'or' | 'tuple' | 'literal' | 'stringLiteral' | 'integerLiteral' | 'booleanLiteral';
 
 /**
+ * Indicates in which direction a message is sent in the protocol.
+ */
+export type MessageDirection = 'clientToServer' | 'serverToClient' | 'both';
+
+/**
  * Represents a base type like `string` or `DocumentUri`.
  */
 export type BaseType = {
@@ -158,6 +163,12 @@ export type Request = {
 	 */
 	registrationOptions?: Type;
 
+    /**
+     * The direction in which this request is sent
+     * in the protocol.
+     */
+	messageDirection: MessageDirection;
+
 	/**
 	 * An optional documentation;
 	 */
@@ -201,6 +212,12 @@ export type Notification = {
 	 * supports dynamic registration.
 	 */
 	registrationOptions?: Type;
+
+    /**
+     * The direction in which this notification is sent
+     * in the protocol.
+     */
+	messageDirection: MessageDirection;
 
 	/**
 	 * An optional documentation;


### PR DESCRIPTION
Fixes #998.

It would be good to get the info checked! I went through and everything that said it's sent from the server got `serverToClient`, `progress` and `cancelRequest` got `both`, and everything else got `clientToServer`.