### PR TITLE
Fixed a typo

### DIFF
--- a/protocol/metaModel.json
+++ b/protocol/metaModel.json
@@ -102,7 +102,7 @@
 				"kind": "reference",
 				"name": "TypeDefinitionRegistrationOptions"
 			},
-			"documentation": "A request to resolve the type definition locations of a symbol at a given text\ndocument position. The request's parameter is of type [TextDocumentPositioParams]\n(#TextDocumentPositionParams) the response is of type [Definition](#Definition) or a\nThenable that resolves to such."
+			"documentation": "A request to resolve the type definition locations of a symbol at a given text\ndocument position. The request's parameter is of type [TextDocumentPositionParams]\n(#TextDocumentPositionParams) the response is of type [Definition](#Definition) or a\nThenable that resolves to such."
 		},
 		{
 			"method": "workspace/workspaceFolders",

--- a/protocol/src/common/protocol.typeDefinition.ts
+++ b/protocol/src/common/protocol.typeDefinition.ts
@@ -45,7 +45,7 @@ export interface TypeDefinitionParams extends TextDocumentPositionParams, WorkDo
 
 /**
  * A request to resolve the type definition locations of a symbol at a given text
- * document position. The request's parameter is of type [TextDocumentPositioParams]
+ * document position. The request's parameter is of type [TextDocumentPositionParams]
  * (#TextDocumentPositionParams) the response is of type [Definition](#Definition) or a
  * Thenable that resolves to such.
  */


### PR DESCRIPTION
`TextDocumentPositioParams` -> `TextDocumentPositionParams`