### PR TITLE
add a new environment jshost to jsonrpc

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -72,6 +72,7 @@
 		"evaluatable",
 		"hover's",
 		"ipynb",
+		"Jshost",
 		"lsclient",
 		"LSIF",
 		"lsptests",

--- a/client/.eslintrc.json
+++ b/client/.eslintrc.json
@@ -1,7 +1,7 @@
 {
 	"extends": "../.eslintrc.base.json",
 	"parserOptions": {
-		"project": ["src/browser/tsconfig.json", "src/common/tsconfig.json", "src/node/tsconfig.json"]
+		"project": ["src/browser/tsconfig.json", "src/common/tsconfig.json", "src/node/tsconfig.json", "src/jshost/tsconfig.json"]
 	},
 	"rules": {
 	}

--- a/client/jshost.d.ts
+++ b/client/jshost.d.ts
@@ -1,0 +1,6 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ----------------------------------------------------------------------------------------- */
+
+export * from './lib/jshost/main';

--- a/client/jshost.js
+++ b/client/jshost.js
@@ -1,0 +1,7 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ----------------------------------------------------------------------------------------- */
+'use strict';
+
+module.exports = require('./lib/jshost/main');

--- a/client/src/jshost/main.ts
+++ b/client/src/jshost/main.ts
@@ -1,0 +1,33 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import { BaseLanguageClient, LanguageClientOptions, MessageTransports } from '../common/api';
+
+import { JshostMessageReader, JshostMessageWriter } from 'vscode-languageserver-protocol/jshost';
+import { MessageChannel } from 'vscode-languageserver-protocol/jshost';
+
+export * from 'vscode-languageserver-protocol/jshost';
+export * from '../common/api';
+
+export class LanguageClient extends BaseLanguageClient {
+	private readonly messageChannel: MessageChannel;
+
+	constructor(id: string, name: string, clientOptions: LanguageClientOptions, messageChannel: MessageChannel) {
+		super(id, name, clientOptions);
+		this.messageChannel = messageChannel;
+	}
+
+	protected createMessageTransports(_encoding: string): Promise<MessageTransports> {
+		const reader = new JshostMessageReader(this.messageChannel.port1);
+		const writer = new JshostMessageWriter(this.messageChannel.port2);
+		return Promise.resolve({ reader, writer });
+	}
+
+	protected getLocale(): string {
+		// ToDo: need to find a way to let the locale
+		// travel to the worker extension host.
+		return 'en';
+	}
+}

--- a/client/src/jshost/tsconfig-watch.json
+++ b/client/src/jshost/tsconfig-watch.json
@@ -1,0 +1,13 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"noUnusedLocals": false,
+		"noUnusedParameters": false,
+		"assumeChangesOnlyAffectDirectDependencies": true,
+		"tsBuildInfoFile":"../../lib/jshost/watch.tsbuildInfo"
+	},
+	"references": [
+		{ "path": "../common/tsconfig-watch.json" },
+		{ "path": "../../../protocol/src/jshost/tsconfig-watch.json" }
+	]
+}

--- a/client/src/jshost/tsconfig.json
+++ b/client/src/jshost/tsconfig.json
@@ -1,0 +1,17 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"tsBuildInfoFile":"../../lib/jshost/compile.tsbuildInfo",
+		"rootDir": ".",
+		"outDir": "../../lib/jshost",
+		"types": [ "node" ],
+		"lib": [ "es2017"]
+	},
+	"include": [
+		"."
+	],
+	"references": [
+		{ "path": "../common/tsconfig.json" },
+		{ "path": "../../../protocol/src/jshost/tsconfig.json" }
+	]
+}

--- a/client/tsconfig-watch.json
+++ b/client/tsconfig-watch.json
@@ -5,6 +5,7 @@
 		{ "path": "../protocol/tsconfig-watch.json" },
 		{ "path": "./src/common/tsconfig-watch.json" },
 		{ "path": "./src/node/tsconfig-watch.json" },
-		{ "path": "./src/browser/tsconfig-watch.json" }
+		{ "path": "./src/browser/tsconfig-watch.json" },
+		{ "path": "./src/jshost/tsconfig-watch.json" },
 	]
 }

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -5,6 +5,7 @@
 		{ "path": "../protocol/tsconfig.json" },
 		{ "path": "./src/common/tsconfig.json" },
 		{ "path": "./src/node/tsconfig.json" },
-		{ "path": "./src/browser/tsconfig.json" }
+		{ "path": "./src/browser/tsconfig.json" },
+		{ "path": "./src/jshost/tsconfig.json" }
 	]
 }

--- a/jsonrpc/.eslintrc.json
+++ b/jsonrpc/.eslintrc.json
@@ -1,7 +1,7 @@
 {
 	"extends": "../.eslintrc.base.json",
 	"parserOptions": {
-		"project": ["src/browser/tsconfig.json", "src/browser/test/tsconfig.json", "src/common/tsconfig.json", "src/common/test/tsconfig.json", "src/node/tsconfig.json", "src/node/test/tsconfig.json"]
+		"project": ["src/browser/tsconfig.json", "src/browser/test/tsconfig.json", "src/common/tsconfig.json", "src/common/test/tsconfig.json", "src/node/tsconfig.json", "src/node/test/tsconfig.json", "src/jshost/tsconfig.json", "src/jshost/test/tsconfig.json"]
 	},
 	"rules": {
 		"no-console": "error"

--- a/jsonrpc/.mocharc.json
+++ b/jsonrpc/.mocharc.json
@@ -1,5 +1,5 @@
 {
-	"spec": ["lib/common/test", "lib/node/test"],
+	"spec": ["lib/common/test", "lib/jshost/test", "lib/node/test"],
 	"extension": ["js"],
 	"recursive": true,
 	"ui": "tdd"

--- a/jsonrpc/jshost.d.ts
+++ b/jsonrpc/jshost.d.ts
@@ -1,0 +1,6 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ----------------------------------------------------------------------------------------- */
+
+export * from './lib/jshost/main';

--- a/jsonrpc/jshost.js
+++ b/jsonrpc/jshost.js
@@ -1,0 +1,7 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ----------------------------------------------------------------------------------------- */
+'use strict';
+
+module.exports = require('./lib/jshost/main');

--- a/jsonrpc/package-lock.json
+++ b/jsonrpc/package-lock.json
@@ -10,7 +10,8 @@
 			"license": "MIT",
 			"devDependencies": {
 				"@types/msgpack-lite": "^0.1.7",
-				"msgpack-lite": "^0.1.26"
+				"msgpack-lite": "^0.1.26",
+				"text-decoding": "^1.0.0"
 			},
 			"engines": {
 				"node": ">=14.0.0"
@@ -69,6 +70,12 @@
 			"bin": {
 				"msgpack": "bin/msgpack"
 			}
+		},
+		"node_modules/text-decoding": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/text-decoding/-/text-decoding-1.0.0.tgz",
+			"integrity": "sha512-/0TJD42KDnVwKmDK6jj3xP7E2MG7SHAOG4tyTgyUCRPdHwvkquYNLEQltmdMa3owq3TkddCVcTsoctJI8VQNKA==",
+			"dev": true
 		}
 	},
 	"dependencies": {
@@ -122,6 +129,12 @@
 				"int64-buffer": "^0.1.9",
 				"isarray": "^1.0.0"
 			}
+		},
+		"text-decoding": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/text-decoding/-/text-decoding-1.0.0.tgz",
+			"integrity": "sha512-/0TJD42KDnVwKmDK6jj3xP7E2MG7SHAOG4tyTgyUCRPdHwvkquYNLEQltmdMa3owq3TkddCVcTsoctJI8VQNKA==",
+			"dev": true
 		}
 	}
 }

--- a/jsonrpc/package.json
+++ b/jsonrpc/package.json
@@ -21,6 +21,7 @@
 	},
 	"typings": "./lib/common/api.d.ts",
 	"devDependencies": {
+		"text-decoding": "^1.0.0",
 		"@types/msgpack-lite": "^0.1.7",
 		"msgpack-lite": "^0.1.26"
 	},
@@ -35,8 +36,13 @@
 		"test": "npm run test:node && npm run test:browser",
 		"test:node": "node ../node_modules/mocha/bin/_mocha",
 		"test:browser": "npm run webpack:test:silent && node ../build/bin/runBrowserTests.js  http://127.0.0.1:8080/jsonrpc/src/browser/test/",
+		"test:jshost": "node ../node_modules/mocha/bin/_mocha",
 		"webpack": "node ../build/bin/webpack  --mode none --config ./webpack.config.js",
-		"webpack:test": "node ../build/bin/webpack --mode none --config ./src/browser/test/webpack.config.js",
-		"webpack:test:silent": "node ../build/bin/webpack --no-stats --mode none --config ./src/browser/test/webpack.config.js"
+		"webpack:test": "npm run webpack:test:browser && npm run webpack:test:jshost",
+		"webpack:test:silent": "npm run webpack:test:browser:silent && npm run webpack:test:jshost:silent",
+		"webpack:test:browser": "node ../build/bin/webpack --mode none --config ./src/browser/test/webpack.config.js",
+		"webpack:test:browser:silent": "node ../build/bin/webpack --no-stats --mode none --config ./src/browser/test/webpack.config.js ",
+		"webpack:test:jshost": "node ../build/bin/webpack --mode none --config ./src/jshost/test/webpack.config.js",
+		"webpack:test:jshost:silent": "node ../build/bin/webpack --no-stats --mode none --config ./src/jshost/test/webpack.config.js"
 	}
 }

--- a/jsonrpc/src/jshost/main.ts
+++ b/jsonrpc/src/jshost/main.ts
@@ -1,0 +1,81 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import RIL from './ril';
+
+// Install the jshost runtime abstract.
+RIL.install();
+
+import {
+	AbstractMessageReader, DataCallback, AbstractMessageWriter, Message, Disposable, Emitter, NullLogger, ConnectionStrategy, ConnectionOptions,
+	createMessageConnection as _createMessageConnection, MessageReader, MessageWriter, Logger, MessageConnection
+} from '../common/api';
+
+import { MessagePort } from './messagePort';
+
+export * from '../common/api';
+export * from './messageChannel';
+export * from './messagePort';
+
+export class JshostMessageReader extends AbstractMessageReader implements MessageReader {
+
+	private _onData: Emitter<Message>;
+	private _messageListener: (event: any) => void;
+
+	public constructor(context: MessagePort) {
+		super();
+		this._onData = new Emitter<Message>();
+		this._messageListener = (event: any) => {
+			this._onData.fire(event.data);
+		};
+		context.addEventListener('error', (event : any) => this.fireError(event));
+		context.onmessage = this._messageListener;
+	}
+
+	public listen(callback: DataCallback): Disposable {
+		return this._onData.event(callback);
+	}
+}
+
+export class JshostMessageWriter extends AbstractMessageWriter implements MessageWriter {
+
+	private errorCount: number;
+
+	public constructor(private context: MessagePort) {
+		super();
+		this.errorCount = 0;
+		context.addEventListener('error', (event : any) => this.fireError(event));
+	}
+
+	public write(msg: Message): Promise<void> {
+		try {
+			this.context.postMessage(msg);
+			return Promise.resolve();
+		} catch (error) {
+			this.handleError(error, msg);
+			return Promise.reject(error);
+		}
+	}
+
+	private handleError(error: any, msg: Message): void {
+		this.errorCount++;
+		this.fireError(error, msg, this.errorCount);
+	}
+
+	public end(): void {
+	}
+}
+
+export function createMessageConnection(reader: MessageReader, writer: MessageWriter, logger?: Logger, options?: ConnectionStrategy | ConnectionOptions): MessageConnection {
+	if (logger === undefined) {
+		logger = NullLogger;
+	}
+
+	if (ConnectionStrategy.is(options)) {
+		options = { connectionStrategy: options } as ConnectionOptions;
+	}
+
+	return _createMessageConnection(reader, writer, logger, options);
+}

--- a/jsonrpc/src/jshost/messageChannel.ts
+++ b/jsonrpc/src/jshost/messageChannel.ts
@@ -1,0 +1,16 @@
+'use strict';
+
+import { MessagePort } from './messagePort';
+
+// A message channel has two ports.
+// port1 is attached to the context that originated the channel.
+// port2 is attached to other end of the channel.
+export class MessageChannel {
+	public port1: MessagePort;
+	public port2: MessagePort;
+
+	public constructor() {
+		this.port1 = new MessagePort();
+		this.port2 = new MessagePort();
+	}
+}

--- a/jsonrpc/src/jshost/messagePort.ts
+++ b/jsonrpc/src/jshost/messagePort.ts
@@ -1,0 +1,118 @@
+'use strict';
+
+// A MessageChannel has two MessagePorts.
+// Messages are sent from one port and listening out for them arriving at the other.
+export class MessagePort {
+	private _messageListeners: any[] = [];
+	private _errorListeners: any[] = [];
+	private _workerMessageListeners: any[] = [];
+	private _workerErrorListeners: any[] = [];
+	private _terminated = false;
+
+	public onerror: any;
+	public onmessage: any;
+
+	public constructor() {
+	}
+
+	public start() {
+		this._terminated = true;
+	}
+
+	public close() {
+		this._terminated = true;
+	}
+
+	public postMessage(msg: any, transfer?: any) {
+		if (typeof msg === 'undefined') {
+			throw new Error('postMessage() requires an argument');
+		}
+
+		if (this._terminated) {
+			return;
+		}
+
+		this._runPostMessage(msg, transfer);
+	}
+
+	public addEventListener(eventType: string, func: any) {
+		if (eventType === 'message') {
+			this._messageListeners.push(func);
+		} else if (eventType === 'error') {
+			this._errorListeners.push(func);
+		} else
+		{
+			return;
+		}
+	}
+
+	public removeEventListener(eventType: string, func: any) {
+		var listeners;
+		if (eventType === 'message') {
+			listeners = this._messageListeners;
+		} else if (eventType === 'error') {
+			listeners = this._errorListeners;
+		} else {
+			return;
+		}
+
+		var i = -1;
+		while (++i < listeners.length) {
+			var listener = listeners[i];
+			if (listener === func) {
+				delete listeners[i];
+				break;
+			}
+		}
+	}
+
+	private _runPostMessage(msg: any, transfer?: any) {
+		var self = this;
+		function _callFun(listener: (arg0: { data: any; ports: any }) => void) {
+			try {
+				listener({data: msg, ports: transfer});
+			} catch (err) {
+				self._postError(err);
+			}
+		}
+
+		if (typeof self.onmessage === 'function') {
+			_callFun(self.onmessage);
+		}
+
+		this._executeEach(this._workerMessageListeners, _callFun);
+	}
+
+	private _executeEach(arr: string | any[], fun: { (listener: any): void; (listener: any): void; (listener: any): void; (listener: any): void; (arg0: any): void }) {
+		var i = -1;
+		while (++i < arr.length) {
+			if (arr[i]) {
+				fun(arr[i]);
+			}
+		}
+	}
+
+	private _callErrorListener(err: { message: any }) {
+		return function (listener: (arg0: { type: string; error: any; message: any }) => void) {
+			listener({
+				type: 'error',
+				error: err,
+				message: err.message
+			});
+		};
+	}
+
+	private _postError(err: any) {
+		var callFun = this._callErrorListener(err);
+		if (typeof this.onerror === 'function') {
+			callFun(this.onerror);
+		}
+
+		if (typeof this.onerror === 'function') {
+			callFun(this.onerror);
+		}
+
+		this._executeEach(this._errorListeners, callFun);
+		this._executeEach(this._workerErrorListeners, callFun);
+	}
+}

--- a/jsonrpc/src/jshost/ril.ts
+++ b/jsonrpc/src/jshost/ril.ts
@@ -1,0 +1,153 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import RAL from '../common/ral';
+import { Disposable } from '../common/disposable';
+import { Message } from '../common/messages';
+import { ContentTypeEncoderOptions, ContentTypeDecoderOptions } from '../common/encoding';
+import { AbstractMessageBuffer } from '../common/messageBuffer';
+import { TextEncoder, TextDecoder } from 'text-decoding';
+
+class MessageBuffer extends AbstractMessageBuffer {
+
+	private static readonly emptyBuffer: Uint8Array = new Uint8Array(0);
+
+	private asciiDecoder: typeof TextDecoder;
+
+	constructor(encoding: RAL.MessageBufferEncoding = 'utf-8') {
+		super(encoding);
+		this.asciiDecoder = new TextDecoder('ascii');
+	}
+
+	protected emptyBuffer(): Uint8Array {
+		return MessageBuffer.emptyBuffer;
+	}
+
+	protected fromString(value: string, _encoding: RAL.MessageBufferEncoding): Uint8Array {
+		return (new TextEncoder()).encode(value);
+	}
+
+	protected toString(value: Uint8Array, encoding: RAL.MessageBufferEncoding): string {
+		if (encoding === 'ascii') {
+			return this.asciiDecoder.decode(value);
+		} else {
+			return (new TextDecoder(encoding)).decode(value);
+		}
+	}
+
+	protected asNative(buffer: Uint8Array, length?: number): Uint8Array {
+		if (length === undefined) {
+			return buffer;
+		} else {
+			return buffer.slice(0, length);
+		}
+	}
+
+	protected allocNative(length: number): Uint8Array {
+		return new Uint8Array(length);
+	}
+}
+
+class ReadableStreamWrapper implements RAL.ReadableStream {
+
+	constructor() {
+	}
+
+	public onClose(listener: () => void): Disposable {
+		return Disposable.create(() => {} );
+	}
+
+	public onError(listener: (error: any) => void): Disposable {
+		return Disposable.create(() => {} );
+	}
+
+	public onEnd(listener: () => void): Disposable {
+		return Disposable.create(() => {} );
+	}
+
+	public onData(listener: (data: Uint8Array) => void): Disposable {
+		return Disposable.create(() => {} );
+	}
+}
+
+class WritableStreamWrapper implements RAL.WritableStream {
+
+	constructor() {
+	}
+
+	public onClose(listener: () => void): Disposable {
+		return Disposable.create(() => {} );
+	}
+
+	public onError(listener: (error: any) => void): Disposable {
+		return Disposable.create(() => {} );
+	}
+
+	public onEnd(listener: () => void): Disposable {
+		return Disposable.create(() => {} );
+	}
+
+	public write(data: Uint8Array | string, encoding?: RAL.MessageBufferEncoding): Promise<void> {
+		return Promise.resolve();
+	}
+
+	public end(): void {
+	}
+}
+
+interface RIL extends RAL {
+	readonly stream: {
+		readonly asReadableStream: (stream: any) => RAL.ReadableStream;
+		readonly asWritableStream: (stream: any) => RAL.WritableStream;
+	};
+}
+
+const _ril: RIL = Object.freeze<RIL>({
+	messageBuffer: Object.freeze({
+		create: (encoding: RAL.MessageBufferEncoding) => new MessageBuffer(encoding)
+	}),
+	applicationJson: Object.freeze({
+		encoder: Object.freeze({
+			name: 'application/json',
+			encode: (msg: Message, options: ContentTypeEncoderOptions): Promise<Uint8Array> => {
+				throw new Error(`In a jshost environments only utf-8 text encoding is supported. But got encoding: ${options.charset}`);
+			}
+		}),
+		decoder: Object.freeze({
+			name: 'application/json',
+			decode: (buffer: Uint8Array, options: ContentTypeDecoderOptions): Promise<Message> => {
+				throw new Error(`In a jshost environments only Uint8Arrays are supported.`);
+			}
+		})
+	}),
+	stream: Object.freeze({
+		asReadableStream: () => new ReadableStreamWrapper(),
+		asWritableStream: () => new WritableStreamWrapper()
+	}),
+	console: console,
+	timer: Object.freeze({
+		setTimeout(callback: (...args: any[]) => void, ms: number, ...args: any[]): Disposable {
+			return { dispose: () => {} };
+		},
+		setImmediate(callback: (...args: any[]) => void, ...args: any[]): Disposable {
+			return { dispose: () => {} };
+		},
+		setInterval(callback: (...args: any[]) => void, ms: number, ...args: any[]): Disposable {
+			return { dispose: () => {} };
+		},
+	})
+});
+
+function RIL(): RIL {
+	return _ril;
+}
+
+namespace RIL {
+	export function install(): void {
+		RAL.install(_ril);
+	}
+}
+
+export default RIL;

--- a/jsonrpc/src/jshost/test/server.ts
+++ b/jsonrpc/src/jshost/test/server.ts
@@ -1,0 +1,23 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import { ResponseMessage } from '../../common/messages';
+import { JshostMessageReader, JshostMessageWriter, MessageChannel } from '../main';
+
+export class Server {
+	public constructor(messageChannel: MessageChannel) {
+		const reader: JshostMessageReader = new JshostMessageReader(messageChannel.port2);
+		const writer: JshostMessageWriter = new JshostMessageWriter(messageChannel.port1);
+
+		reader.listen(async (_message) => {
+			const response: ResponseMessage = {
+				jsonrpc: '2.0',
+				id: 1,
+				result: 42
+			};
+			await writer.write(response);
+		});
+	}
+}

--- a/jsonrpc/src/jshost/test/test.ts
+++ b/jsonrpc/src/jshost/test/test.ts
@@ -1,0 +1,100 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import * as assert from 'assert';
+
+import { RequestMessage, ResponseMessage } from '../../common/api';
+import { JshostMessageReader, JshostMessageWriter, MessageChannel } from '../main';
+import RIL from '../ril';
+
+import { TextEncoder, TextDecoder } from 'text-decoding';
+import { Server } from './server';
+
+function assertDefined<T>(value: T | undefined | null): asserts value is T {
+	assert.ok(value !== undefined && value !== null);
+}
+
+suite('Jshost Reader / Writer', () => {
+	test('Simple request message with response', (done) => {
+		var messageChannel = new MessageChannel();
+		new Server(messageChannel);
+		const reader = new JshostMessageReader(messageChannel.port1);
+		const writer = new JshostMessageWriter(messageChannel.port2);
+
+		reader.listen((message) => {
+			const response: ResponseMessage = message as ResponseMessage;
+			assert.strictEqual(response.result, 42);
+			done();
+		});
+
+		const request: RequestMessage = {
+			jsonrpc: '2.0',
+			id: 1,
+			method: 'example'
+		};
+
+		void writer.write(request);
+	});
+
+	test('MessageBuffer Simple', () => {
+		const buffer = RIL().messageBuffer.create('utf-8');
+		// TextEncoder don't support ascii. But utf-8 creates the same for the header.
+		const encoder: typeof TextEncoder = new TextEncoder();
+		buffer.append(encoder.encode('Content-Length: 43\r\n\r\n'));
+		buffer.append(encoder.encode('{"jsonrpc":"2.0","id":1,"method":"example"}'));
+		const headers = buffer.tryReadHeaders();
+		assertDefined(headers);
+		assert.strictEqual(headers.size, 1);
+		assert.strictEqual(headers.get('Content-Length'), '43');
+		const decoder = new TextDecoder('utf-8');
+		const content = JSON.parse(decoder.decode(buffer.tryReadBody(43)));
+		assert.strictEqual(content.id, 1);
+		assert.strictEqual(content.method, 'example');
+	});
+
+	test('MessageBuffer Random', () => {
+		interface Item {
+			index: number;
+			label: string;
+		}
+		const data: Item[] = [];
+		for (let i = 0; i < 1000; i++) {
+			data.push({ index: i, label: `label${i}`});
+		}
+		const encoder: typeof TextEncoder = new TextEncoder();
+		const content = encoder.encode(JSON.stringify(data));
+		const header = encoder.encode(`Content-Length: ${content.byteLength}\r\n\r\n`);
+		const payload = new Uint8Array(header.byteLength + content.byteLength);
+		payload.set(header);
+		payload.set(content, header.byteLength);
+		const buffer = RIL().messageBuffer.create('utf-8');
+
+		for (const upper of [10, 64, 512, 1024]) {
+			let sent: number = 0;
+			while (sent < payload.byteLength) {
+				let piece = Math.floor((Math.random() * upper) + 1);
+				if (piece > payload.byteLength - sent) {
+					piece = payload.byteLength - sent;
+				}
+				buffer.append(payload.slice(sent, sent + piece));
+				sent = sent + piece;
+			}
+			const headers = buffer.tryReadHeaders();
+			assertDefined(headers);
+			assert.strictEqual(headers.size, 1);
+			const length = parseInt(headers.get('Content-Length')!);
+			assert.strictEqual(length, content.byteLength);
+			const decoder = new TextDecoder('utf-8');
+			const body: Item[] = JSON.parse(decoder.decode(buffer.tryReadBody(length)));
+			assert.ok(Array.isArray(body));
+			assert.strictEqual(body.length, 1000);
+			for (let i = 0; i < body.length; i++) {
+				const item = body[i];
+				assert.strictEqual(item.index, i);
+				assert.strictEqual(item.label, `label${i}`);
+			}
+		}
+	});
+});

--- a/jsonrpc/src/jshost/test/text-decoding.d.ts
+++ b/jsonrpc/src/jshost/test/text-decoding.d.ts
@@ -1,0 +1,1 @@
+declare module 'text-decoding';

--- a/jsonrpc/src/jshost/test/tsconfig-watch.json
+++ b/jsonrpc/src/jshost/test/tsconfig-watch.json
@@ -1,0 +1,12 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"noUnusedLocals": false,
+		"noUnusedParameters": false,
+		"assumeChangesOnlyAffectDirectDependencies": true,
+		"tsBuildInfoFile":"../../../lib/jshost/test/watch.tsbuildInfo",
+	},
+	"references": [
+		{ "path": "../tsconfig-watch.json" },
+	]
+}

--- a/jsonrpc/src/jshost/test/tsconfig.json
+++ b/jsonrpc/src/jshost/test/tsconfig.json
@@ -1,0 +1,20 @@
+{
+	"extends": "../../../tsconfig.base.json",
+	"compilerOptions": {
+		"tsBuildInfoFile":"../../../lib/jshost/test/compile.tsbuildInfo",
+		"esModuleInterop": true,
+		"allowSyntheticDefaultImports": true,
+		"rootDir": ".",
+		"outDir": "../../../lib/jshost/test",
+		"lib": [ "es2017"],
+		"types": [
+			"mocha", "node"
+		]
+	},
+	"include": [
+		"."
+	],
+	"references": [
+		{ "path": "../tsconfig.json" },
+	]
+}

--- a/jsonrpc/src/jshost/test/webpack.config.js
+++ b/jsonrpc/src/jshost/test/webpack.config.js
@@ -7,35 +7,21 @@
 
 'use strict';
 
-const browserConfig = {
-	context: __dirname,
-	mode: 'none',
-	target: 'webworker',
-	resolve: {
-		mainFields: ['module', 'main'],
-		extensions: ['.js'] // support ts-files and js-files
-	},
-	entry: {
-		extension: './lib/browser/main.js',
-	},
-	devtool: 'source-map',
-	output: {
-		filename: 'main.js'
-	}
-};
+const NodePolyfillPlugin = require('node-polyfill-webpack-plugin');
 
-const jshostConfig = {
+module.exports = {
 	context: __dirname,
 	mode: 'none',
 	target: 'node',
+	plugins: [
+		new NodePolyfillPlugin()
+	],
 	resolve: {
 		mainFields: ['module', 'main'],
-		extensions: ['.js'] // support ts-files and js-files
+		extensions: ['.js']
 	},
 	entry: {
-		main: './lib/jshost/main.js',
-		messageChannel: './lib/jshost/messageChannel.js',
-		messagePort: '/lib/jshost/messagePort.js',
+		extension: '../../../lib/jshost/test/test.js',
 	},
 	resolve: {
 		alias: {
@@ -43,11 +29,6 @@ const jshostConfig = {
 	},
 	devtool: 'source-map',
 	output: {
-		filename: '[name].jshost.js'
+		filename: 'tests.jshost.js'
 	}
 };
-
-module.exports = [
-	browserConfig,
-	jshostConfig
-];

--- a/jsonrpc/src/jshost/text-decoding.d.ts
+++ b/jsonrpc/src/jshost/text-decoding.d.ts
@@ -1,0 +1,1 @@
+declare module 'text-decoding';

--- a/jsonrpc/src/jshost/tsconfig-watch.json
+++ b/jsonrpc/src/jshost/tsconfig-watch.json
@@ -1,0 +1,12 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"noUnusedLocals": false,
+		"noUnusedParameters": false,
+		"assumeChangesOnlyAffectDirectDependencies": true,
+		"tsBuildInfoFile":"../../lib/jshost/watch.tsbuildInfo"
+	},
+	"references": [
+		{ "path": "../common/tsconfig-watch.json" },
+	]
+}

--- a/jsonrpc/src/jshost/tsconfig.json
+++ b/jsonrpc/src/jshost/tsconfig.json
@@ -1,0 +1,20 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"noUnusedParameters": false,
+		"tsBuildInfoFile":"../../lib/jshost/compile.tsbuildInfo",
+		"rootDir": ".",
+		"outDir": "../../lib/jshost",
+		"types": [ "node" ],
+		"lib": [ "es2017" ]
+	},
+	"include": [
+		"."
+	],
+	"exclude": [
+		"test",
+	],
+	"references": [
+		{ "path": "../common/tsconfig.json" },
+	]
+}

--- a/jsonrpc/tsconfig.json
+++ b/jsonrpc/tsconfig.json
@@ -8,5 +8,7 @@
 		{ "path": "./src/node/test/tsconfig.json" },
 		{ "path": "./src/browser/tsconfig.json" },
 		{ "path": "./src/browser/test/tsconfig.json" },
+		{ "path": "./src/jshost/tsconfig.json" },
+		{ "path": "./src/jshost/test/tsconfig.json" }
 	]
 }

--- a/protocol/.eslintrc.json
+++ b/protocol/.eslintrc.json
@@ -1,7 +1,7 @@
 {
 	"extends": "../.eslintrc.base.json",
 	"parserOptions": {
-		"project": ["src/common/tsconfig.json", "src/browser/tsconfig.json", "src/browser/test/tsconfig.json", "src/node/tsconfig.json", "src/node/test/tsconfig.json"]
+		"project": ["src/common/tsconfig.json", "src/browser/tsconfig.json", "src/browser/test/tsconfig.json", "src/node/tsconfig.json", "src/node/test/tsconfig.json", "src/jshost/tsconfig.json", "src/jshost/test/tsconfig.json"]
 	},
 	"rules": {
 		"no-console": "error",

--- a/protocol/.mocharc.json
+++ b/protocol/.mocharc.json
@@ -1,5 +1,5 @@
 {
-	"spec": "lib/node/test",
+	"spec": ["lib/jshost/test", "lib/node/test"],
 	"extension": ["js"],
 	"recursive": true,
 	"ui": "tdd"

--- a/protocol/jshost.d.ts
+++ b/protocol/jshost.d.ts
@@ -1,0 +1,6 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ----------------------------------------------------------------------------------------- */
+
+export * from './lib/jshost/main';

--- a/protocol/jshost.js
+++ b/protocol/jshost.js
@@ -1,0 +1,7 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ----------------------------------------------------------------------------------------- */
+'use strict';
+
+module.exports = require('./lib/jshost/main');

--- a/protocol/package.json
+++ b/protocol/package.json
@@ -32,7 +32,12 @@
 		"test": "npm run test:node && npm run test:browser",
 		"test:node": "node ../node_modules/mocha/bin/_mocha",
 		"test:browser": "npm run webpack:test:silent && node ../build/bin/runBrowserTests.js  http://127.0.0.1:8080/protocol/src/browser/test/",
-		"webpack:test": "cd ../types && npm run compile:esm && cd ../protocol && node ../build/bin/webpack --mode none --config ./src/browser/test/webpack.config.js",
-		"webpack:test:silent": "cd ../types && npm run compile:esm && cd ../protocol && node ../build/bin/webpack --no-stats --mode none --config ./src/browser/test/webpack.config.js"
+		"test:jshost": "node ../node_modules/mocha/bin/_mocha",
+		"webpack:test": "npm run webpack:test:browser && npm run webpack:test:jshost",
+		"webpack:test:silent": "npm run webpack:test:browser:silent && npm run webpack:test:jshost:silent",
+		"webpack:test:browser": "cd ../types && npm run compile:esm && cd ../protocol && node ../build/bin/webpack --mode none --config ./src/browser/test/webpack.config.js",
+		"webpack:test:browser:silent": "cd ../types && npm run compile:esm && cd ../protocol && node ../build/bin/webpack --no-stats --mode none --config ./src/browser/test/webpack.config.js",
+		"webpack:test:jshost": "cd ../types && npm run compile:esm && cd ../protocol && node ../build/bin/webpack --mode none --config ./src/jshost/test/webpack.config.js",
+		"webpack:test:jshost:silent": "cd ../types && npm run compile:esm && cd ../protocol && node ../build/bin/webpack --no-stats --mode none --config ./src/jshost/test/webpack.config.js"
 	}
 }

--- a/protocol/src/jshost/main.ts
+++ b/protocol/src/jshost/main.ts
@@ -1,0 +1,14 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import { MessageReader, MessageWriter, Logger, ConnectionStrategy, ConnectionOptions, ProtocolConnection } from '../common/api';
+import { createMessageConnection } from 'vscode-jsonrpc/jshost';
+
+export * from 'vscode-jsonrpc/jshost';
+export * from '../common/api';
+
+export function createProtocolConnection(reader: MessageReader, writer: MessageWriter, logger?: Logger, options?: ConnectionStrategy | ConnectionOptions): ProtocolConnection {
+	return createMessageConnection(reader, writer, logger, options);
+}

--- a/protocol/src/jshost/test/server.ts
+++ b/protocol/src/jshost/test/server.ts
@@ -1,0 +1,23 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import { createProtocolConnection, JshostMessageReader, JshostMessageWriter } from '../main';
+import { CompletionRequest } from '../../common/api';
+import { MessageChannel } from 'vscode-jsonrpc/jshost';
+
+export class Server {
+	public constructor(messageChannel: MessageChannel) {
+		const reader: JshostMessageReader = new JshostMessageReader(messageChannel.port2);
+		const writer: JshostMessageWriter = new JshostMessageWriter(messageChannel.port1);
+
+		const connection = createProtocolConnection(reader, writer);
+
+		connection.onRequest(CompletionRequest.type, (_params: any) => {
+			return [];
+		});
+
+		connection.listen();
+	}
+}

--- a/protocol/src/jshost/test/test.ts
+++ b/protocol/src/jshost/test/test.ts
@@ -1,0 +1,27 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import * as assert from 'assert';
+
+import { CompletionRequest, CompletionParams, CompletionItem } from '../../common/api';
+import { JshostMessageReader, JshostMessageWriter, createProtocolConnection, MessageChannel } from '../main';
+import { Server } from './server';
+
+suite('Jshost Protocol Tests', () => {
+	var messageChannel = new MessageChannel();
+	new Server(messageChannel);
+	const reader = new JshostMessageReader(messageChannel.port1);
+	const writer = new JshostMessageWriter(messageChannel.port2);
+	const connection = createProtocolConnection(reader, writer);
+	connection.listen();
+	test('Test Code Completion Request', async () => {
+		const params: CompletionParams = {
+			textDocument: { uri: 'file:///folder/a.ts' },
+			position: { line: 1, character: 1}
+		};
+		const result = (await connection.sendRequest(CompletionRequest.type, params)) as CompletionItem[];
+		assert.strictEqual(result!.length, 0);
+	});
+});

--- a/protocol/src/jshost/test/tsconfig-watch.json
+++ b/protocol/src/jshost/test/tsconfig-watch.json
@@ -1,0 +1,12 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"noUnusedLocals": false,
+		"noUnusedParameters": false,
+		"assumeChangesOnlyAffectDirectDependencies": true,
+		"tsBuildInfoFile":"../../../lib/jshost/test/watch.tsbuildInfo",
+	},
+	"references": [
+		{ "path": "../tsconfig-watch.json" },
+	]
+}

--- a/protocol/src/jshost/test/tsconfig.json
+++ b/protocol/src/jshost/test/tsconfig.json
@@ -1,0 +1,18 @@
+{
+	"extends": "../../../tsconfig.base.json",
+	"compilerOptions": {
+		"tsBuildInfoFile":"../../../lib/jshost/test/compile.tsbuildInfo",
+		"rootDir": ".",
+		"outDir": "../../../lib/jshost/test",
+		"lib": [ "es2017"],
+		"types": [
+			"mocha", "node"
+		]
+	},
+	"include": [
+		"."
+	],
+	"references": [
+		{ "path": "../tsconfig.json" },
+	]
+}

--- a/protocol/src/jshost/test/webpack.config.js
+++ b/protocol/src/jshost/test/webpack.config.js
@@ -1,0 +1,30 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+//@ts-check
+/** @typedef {import('webpack').Configuration} WebpackConfig **/
+
+'use strict';
+
+const NodePolyfillPlugin = require('node-polyfill-webpack-plugin');
+
+module.exports = [{
+	context: __dirname,
+	mode: 'none',
+	target: 'node',
+	plugins: [
+		new NodePolyfillPlugin()
+	],
+	resolve: {
+		mainFields: ['module', 'main'],
+		extensions: ['.js']
+	},
+	entry: {
+		extension: '../../../lib/jshost/test/test.js',
+	},
+	devtool: 'source-map',
+	output: {
+		filename: 'tests.jshost.js'
+	}
+}];

--- a/protocol/src/jshost/tsconfig-watch.json
+++ b/protocol/src/jshost/tsconfig-watch.json
@@ -1,0 +1,12 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"noUnusedLocals": false,
+		"noUnusedParameters": false,
+		"assumeChangesOnlyAffectDirectDependencies": true,
+		"tsBuildInfoFile":"../../lib/jshost/watch.tsbuildInfo"
+	},
+	"references": [
+		{ "path": "../common/tsconfig-watch.json" },
+	]
+}

--- a/protocol/src/jshost/tsconfig.json
+++ b/protocol/src/jshost/tsconfig.json
@@ -1,0 +1,19 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"tsBuildInfoFile":"../../lib/jshost/compile.tsbuildInfo",
+		"rootDir": ".",
+		"outDir": "../../lib/jshost",
+		"lib": [ "es2017"]
+	},
+	"include": [
+		"."
+	],
+	"exclude": [
+		"test"
+	],
+	"references": [
+		{ "path": "../common/tsconfig.json" },
+		{ "path": "../../../jsonrpc/src/jshost/tsconfig.json" }
+	]
+}

--- a/protocol/tsconfig.json
+++ b/protocol/tsconfig.json
@@ -8,6 +8,8 @@
 		{ "path": "./src/node/tsconfig.json" },
 		{ "path": "./src/node/test/tsconfig.json" },
 		{ "path": "./src/browser/tsconfig.json" },
-		{ "path": "./src/browser/test/tsconfig.json" }
+		{ "path": "./src/browser/test/tsconfig.json" },
+		{ "path": "./src/jshost/tsconfig.json" },
+		{ "path": "./src/jshost/test/tsconfig.json" }
 	]
 }

--- a/server/.eslintrc.json
+++ b/server/.eslintrc.json
@@ -1,7 +1,7 @@
 {
 	"extends": "../.eslintrc.base.json",
 	"parserOptions": {
-		"project": ["src/browser/tsconfig.json", "src/common/tsconfig.json", "src/node/tsconfig.json", "src/node/test/tsconfig.json"]
+		"project": ["src/browser/tsconfig.json", "src/common/tsconfig.json", "src/node/tsconfig.json", "src/node/test/tsconfig.json", "src/jshost/tsconfig.json"]
 	},
 	"rules": {
 	}

--- a/server/jshost.d.ts
+++ b/server/jshost.d.ts
@@ -1,0 +1,6 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ----------------------------------------------------------------------------------------- */
+
+export * from './lib/jshost/main';

--- a/server/jshost.js
+++ b/server/jshost.js
@@ -1,0 +1,7 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ----------------------------------------------------------------------------------------- */
+'use strict';
+
+module.exports = require('./lib/jshost/main');

--- a/server/src/jshost/main.ts
+++ b/server/src/jshost/main.ts
@@ -1,0 +1,72 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import {
+	MessageReader, MessageWriter, Logger, ConnectionStrategy, ConnectionOptions, ProtocolConnection, WatchDog, InitializeParams, createProtocolConnection,
+	createConnection as createCommonConnection, Connection, Features, _Connection, _
+} from '../common/api';
+
+export * from 'vscode-languageserver-protocol/jshost';
+export * from '../common/api';
+
+let _shutdownReceived: boolean = false;
+const watchDog: WatchDog = {
+	initialize: (_params: InitializeParams): void => {
+	},
+	get shutdownReceived(): boolean {
+		return _shutdownReceived;
+	},
+	set shutdownReceived(value: boolean) {
+		_shutdownReceived = value;
+	},
+	exit: (_code: number): void => {
+	}
+};
+
+/**
+ * Creates a new connection.
+ *
+ * @param factories: The factories for proposed features.
+ * @param reader The message reader to read messages from.
+ * @param writer The message writer to write message to.
+ * @param options An optional connection strategy or connection options to control additional settings
+ */
+export function createConnection<PConsole = _, PTracer = _, PTelemetry = _, PClient = _, PWindow = _, PWorkspace = _, PLanguages = _>(
+	factories: Features<PConsole, PTracer, PTelemetry, PClient, PWindow, PWorkspace, PLanguages>,
+	reader: MessageReader, writer: MessageWriter, options?: ConnectionStrategy | ConnectionOptions
+): _Connection<PConsole, PTracer, PTelemetry, PClient, PWindow, PWorkspace, PLanguages>;
+
+
+/**
+ * Creates a new connection.
+ *
+ * @param reader The message reader to read messages from.
+ * @param writer The message writer to write message to.
+ * @param options An optional connection strategy or connection options to control additional settings
+ */
+export function createConnection(reader: MessageReader, writer: MessageWriter, options?: ConnectionStrategy | ConnectionOptions): Connection;
+export function createConnection(arg1: any, arg2: any, arg3?: any, arg4?: any): Connection {
+	let factories: Features | undefined;
+	let reader: MessageReader | undefined;
+	let writer: MessageWriter | undefined;
+	let options: ConnectionStrategy | ConnectionOptions | undefined;
+
+	if (arg1 !== void 0 && (arg1 as Features).__brand === 'features') {
+		factories = arg1;
+		arg1 = arg2; arg2 = arg3; arg3 = arg4;
+	}
+	if (ConnectionStrategy.is(arg1) || ConnectionOptions.is(arg1)) {
+		options = arg1;
+	} else {
+		reader = arg1;
+		writer = arg2;
+		options = arg3;
+	}
+
+	const connectionFactory = (logger: Logger): ProtocolConnection => {
+		return createProtocolConnection(reader!, writer!, logger, options);
+	};
+	return createCommonConnection(connectionFactory, watchDog, factories);
+}

--- a/server/src/jshost/tsconfig-watch.json
+++ b/server/src/jshost/tsconfig-watch.json
@@ -1,0 +1,13 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"noUnusedLocals": false,
+		"noUnusedParameters": false,
+		"assumeChangesOnlyAffectDirectDependencies": true,
+		"tsBuildInfoFile":"../../lib/jshost/watch.tsbuildInfo"
+	},
+	"references": [
+		{ "path": "../common/tsconfig-watch.json" },
+		{ "path": "../../../protocol/src/jshost/tsconfig-watch.json" }
+	]
+}

--- a/server/src/jshost/tsconfig.json
+++ b/server/src/jshost/tsconfig.json
@@ -1,0 +1,16 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"tsBuildInfoFile":"../../lib/jshost/compile.tsbuildInfo",
+		"rootDir": ".",
+		"outDir": "../../lib/jshost",
+		"lib": [ "es2017"]
+	},
+	"include": [
+		"."
+	],
+	"references": [
+		{ "path": "../common/tsconfig.json" },
+		{ "path": "../../../protocol/src/jshost/tsconfig.json" }
+	]
+}


### PR DESCRIPTION
Add a new environment jshost to jsonrpc. This new environment is similar to the browser environment except that it doesn't have full browser support. For example, the jshost environment would have a javascript runtime, but it will not all the web APIs. In this environment, the client and server will be running in the same thread.

To implement the message reader/writer, a simple MessageChannel and MessagePort class are implemented. A message channel has two message ports. On the client side, messages are received on port1 and posted to port2. On the server side, messages are received on port2, and posted to port1. Since client and server are running in the same thread, we don't really need message ports, but we do it in order to mimic the current communication between main thread and worker thread.

We add a dev dependency to nodejs package "text-decoding" when implementing the MessageBuffer for the RIL layer. The read/write stream wrappers are stubbed out as they are not being used.

The tests are running under Node but they do not have real Node dependencies.