### PR TITLE
A more reliable way to check the document version when handling ApplyWorkspaceEdit

### DIFF
--- a/client/src/common/client.ts
+++ b/client/src/common/client.ts
@@ -1803,7 +1803,8 @@ export abstract class BaseLanguageClient implements FeatureClient<Middleware, La
 		if (workspaceEdit.documentChanges) {
 			for (const change of workspaceEdit.documentChanges) {
 				if (TextDocumentEdit.is(change) && change.textDocument.version && change.textDocument.version >= 0) {
-					const textDocument = openTextDocuments.get(change.textDocument.uri);
+					const changeUri = this._p2c.asUri(change.textDocument.uri).toString();
+					const textDocument = openTextDocuments.get(changeUri);
 					if (textDocument && textDocument.version !== change.textDocument.version) {
 						versionMismatch = true;
 						break;


### PR DESCRIPTION
Some language servers and vscode have a bit different ways to encode uri to string. For example [csharp-language-server-protocol](https://github.com/OmniSharp/csharp-language-server-protocol) encodes uri `C:\abc` to `file:///c:/abc` but vscode encodes this uri a bit more aggressive: `file:///c%3A/abc`. As a result we have a problem with lookup in a map in the method `handleApplyWorkspaceEdit`. To fix it I am going to call converter `asUri` before call map lookup by uri.