### PR TITLE
Adopt `@link` for jsdoc comments

### DIFF
--- a/jsonrpc/src/common/cancellation.ts
+++ b/jsonrpc/src/common/cancellation.ts
@@ -21,7 +21,7 @@ export interface CancellationToken {
 	readonly isCancellationRequested: boolean;
 
 	/**
-	 * An [event](#Event) which fires upon cancellation.
+	 * An {@link Event event} which fires upon cancellation.
 	 */
 	readonly onCancellationRequested: Event<any>;
 }

--- a/protocol/src/common/protocol.colorProvider.ts
+++ b/protocol/src/common/protocol.colorProvider.ts
@@ -31,7 +31,7 @@ export interface DocumentColorRegistrationOptions extends TextDocumentRegistrati
 //---- Color Symbol Provider ---------------------------
 
 /**
- * Parameters for a [DocumentColorRequest](#DocumentColorRequest).
+ * Parameters for a {@link DocumentColorRequest}.
  */
 export interface DocumentColorParams extends WorkDoneProgressParams, PartialResultParams {
 	/**
@@ -42,8 +42,8 @@ export interface DocumentColorParams extends WorkDoneProgressParams, PartialResu
 
 /**
  * A request to list all color symbols found in a given text document. The request's
- * parameter is of type [DocumentColorParams](#DocumentColorParams) the
- * response is of type [ColorInformation[]](#ColorInformation) or a Thenable
+ * parameter is of type {@link DocumentColorParams} the
+ * response is of type {@link ColorInformation ColorInformation[]} or a Thenable
  * that resolves to such.
  */
 export namespace DocumentColorRequest {
@@ -54,7 +54,7 @@ export namespace DocumentColorRequest {
 }
 
 /**
- * Parameters for a [ColorPresentationRequest](#ColorPresentationRequest).
+ * Parameters for a {@link ColorPresentationRequest}.
  */
 export interface ColorPresentationParams extends WorkDoneProgressParams, PartialResultParams {
 	/**
@@ -75,8 +75,8 @@ export interface ColorPresentationParams extends WorkDoneProgressParams, Partial
 
 /**
  * A request to list all presentation for a color. The request's
- * parameter is of type [ColorPresentationParams](#ColorPresentationParams) the
- * response is of type [ColorInformation[]](#ColorInformation) or a Thenable
+ * parameter is of type {@link ColorPresentationParams} the
+ * response is of type {@link ColorInformation ColorInformation[]} or a Thenable
  * that resolves to such.
  */
 export namespace ColorPresentationRequest {

--- a/protocol/src/common/protocol.declaration.ts
+++ b/protocol/src/common/protocol.declaration.ts
@@ -44,8 +44,8 @@ export interface DeclarationParams extends TextDocumentPositionParams, WorkDoneP
 /**
  * A request to resolve the type definition locations of a symbol at a given text
  * document position. The request's parameter is of type [TextDocumentPositionParams]
- * (#TextDocumentPositionParams) the response is of type [Declaration](#Declaration)
- * or a typed array of [DeclarationLink](#DeclarationLink) or a Thenable that resolves
+ * (#TextDocumentPositionParams) the response is of type {@link Declaration}
+ * or a typed array of {@link DeclarationLink} or a Thenable that resolves
  * to such.
  */
 export namespace DeclarationRequest {

--- a/protocol/src/common/protocol.foldingRange.ts
+++ b/protocol/src/common/protocol.foldingRange.ts
@@ -75,7 +75,7 @@ export interface FoldingRangeRegistrationOptions extends TextDocumentRegistratio
 }
 
 /**
- * Parameters for a [FoldingRangeRequest](#FoldingRangeRequest).
+ * Parameters for a {@link FoldingRangeRequest}.
  */
 export interface FoldingRangeParams extends WorkDoneProgressParams, PartialResultParams {
 	/**
@@ -86,8 +86,8 @@ export interface FoldingRangeParams extends WorkDoneProgressParams, PartialResul
 
 /**
  * A request to provide folding ranges in a document. The request's
- * parameter is of type [FoldingRangeParams](#FoldingRangeParams), the
- * response is of type [FoldingRangeList](#FoldingRangeList) or a Thenable
+ * parameter is of type {@link FoldingRangeParams}, the
+ * response is of type {@link FoldingRangeList} or a Thenable
  * that resolves to such.
  */
 export namespace FoldingRangeRequest {

--- a/protocol/src/common/protocol.implementation.ts
+++ b/protocol/src/common/protocol.implementation.ts
@@ -46,7 +46,7 @@ export interface ImplementationParams extends TextDocumentPositionParams, WorkDo
 /**
  * A request to resolve the implementation locations of a symbol at a given text
  * document position. The request's parameter is of type [TextDocumentPositionParams]
- * (#TextDocumentPositionParams) the response is of type [Definition](#Definition) or a
+ * (#TextDocumentPositionParams) the response is of type {@link Definition} or a
  * Thenable that resolves to such.
  */
 export namespace ImplementationRequest {

--- a/protocol/src/common/protocol.inlayHint.ts
+++ b/protocol/src/common/protocol.inlayHint.ts
@@ -92,8 +92,8 @@ export type InlayHintParams = WorkDoneProgressParams & {
 
 /**
  * A request to provide inlay hints in a document. The request's parameter is of
- * type [InlayHintsParams](#InlayHintsParams), the response is of type
- * [InlayHint[]](#InlayHint[]) or a Thenable that resolves to such.
+ * type {@link InlayHintsParams}, the response is of type
+ * {@link InlayHint InlayHint[]} or a Thenable that resolves to such.
  *
  * @since 3.17.0
  */
@@ -106,8 +106,8 @@ export namespace InlayHintRequest {
 
 /**
  * A request to resolve additional properties for an inlay hint.
- * The request's parameter is of type [InlayHint](#InlayHint), the response is
- * of type [InlayHint](#InlayHint) or a Thenable that resolves to such.
+ * The request's parameter is of type {@link InlayHint}, the response is
+ * of type {@link InlayHint} or a Thenable that resolves to such.
  *
  * @since 3.17.0
  */

--- a/protocol/src/common/protocol.inlineValue.ts
+++ b/protocol/src/common/protocol.inlineValue.ts
@@ -80,8 +80,8 @@ export type InlineValueParams = WorkDoneProgressParams & {
 
 /**
  * A request to provide inline values in a document. The request's parameter is of
- * type [InlineValueParams](#InlineValueParams), the response is of type
- * [InlineValue[]](#InlineValue[]) or a Thenable that resolves to such.
+ * type {@link InlineValueParams}, the response is of type
+ * {@link InlineValue InlineValue[]} or a Thenable that resolves to such.
  *
  * @since 3.17.0
  */

--- a/protocol/src/common/protocol.moniker.ts
+++ b/protocol/src/common/protocol.moniker.ts
@@ -123,8 +123,8 @@ export interface MonikerParams extends TextDocumentPositionParams, WorkDoneProgr
 
 /**
  * A request to get the moniker of a symbol at a given text document position.
- * The request parameter is of type [TextDocumentPositionParams](#TextDocumentPositionParams).
- * The response is of type [Moniker[]](#Moniker[]) or `null`.
+ * The request parameter is of type {@link TextDocumentPositionParams}.
+ * The response is of type {@link Moniker Moniker[]} or `null`.
  */
 export namespace MonikerRequest {
 	export const method: 'textDocument/moniker' = 'textDocument/moniker';

--- a/protocol/src/common/protocol.selectionRange.ts
+++ b/protocol/src/common/protocol.selectionRange.ts
@@ -45,8 +45,8 @@ export interface SelectionRangeParams extends WorkDoneProgressParams, PartialRes
 
 /**
  * A request to provide selection ranges in a document. The request's
- * parameter is of type [SelectionRangeParams](#SelectionRangeParams), the
- * response is of type [SelectionRange[]](#SelectionRange[]) or a Thenable
+ * parameter is of type {@link SelectionRangeParams}, the
+ * response is of type {@link SelectionRange SelectionRange[]} or a Thenable
  * that resolves to such.
  */
 export namespace SelectionRangeRequest {

--- a/protocol/src/common/protocol.ts
+++ b/protocol/src/common/protocol.ts
@@ -127,8 +127,8 @@ let __noDynamicImport: LocationLink | undefined;
 
 /**
  * A document filter denotes a document by different properties like
- * the [language](#TextDocument.languageId), the [scheme](#Uri.scheme) of
- * its resource, or a glob-pattern that is applied to the [path](#TextDocument.fileName).
+ * the {@link TextDocument.languageId language}, the {@link Uri.scheme scheme} of
+ * its resource, or a glob-pattern that is applied to the {@link TextDocument.fileName path}.
  *
  * Glob patterns can have the following syntax:
  * - `*` to match one or more characters in a path segment
@@ -146,21 +146,21 @@ let __noDynamicImport: LocationLink | undefined;
 export type TextDocumentFilter = {
 	/** A language id, like `typescript`. */
 	language: string;
-	/** A Uri [scheme](#Uri.scheme), like `file` or `untitled`. */
+	/** A Uri {@link Uri.scheme scheme}, like `file` or `untitled`. */
 	scheme?: string;
 	/** A glob pattern, like `*.{ts,js}`. */
 	pattern?: string;
 } | {
 	/** A language id, like `typescript`. */
 	language?: string;
-	/** A Uri [scheme](#Uri.scheme), like `file` or `untitled`. */
+	/** A Uri {@link Uri.scheme scheme}, like `file` or `untitled`. */
 	scheme: string;
 	/** A glob pattern, like `*.{ts,js}`. */
 	pattern?: string;
 } | {
 	/** A language id, like `typescript`. */
 	language?: string;
-	/** A Uri [scheme](#Uri.scheme), like `file` or `untitled`. */
+	/** A Uri {@link Uri.scheme scheme}, like `file` or `untitled`. */
 	scheme?: string;
 	/** A glob pattern, like `*.{ts,js}`. */
 	pattern: string;
@@ -168,7 +168,7 @@ export type TextDocumentFilter = {
 
 /**
  * The TextDocumentFilter namespace provides helper functions to work with
- * [TextDocumentFilter](#TextDocumentFilter) literals.
+ * {@link TextDocumentFilter} literals.
  *
  * @since 3.17.0
  */
@@ -190,7 +190,7 @@ export type NotebookDocumentFilter = {
 	/** The type of the enclosing notebook. */
 	notebookType: string;
 
-	/** A Uri [scheme](#Uri.scheme), like `file` or `untitled`. */
+	/** A Uri {@link Uri.scheme scheme}, like `file` or `untitled`. */
 	scheme?: string;
 
 	/** A glob pattern. */
@@ -199,7 +199,7 @@ export type NotebookDocumentFilter = {
 	/** The type of the enclosing notebook. */
 	notebookType?: string;
 
-	/** A Uri [scheme](#Uri.scheme), like `file` or `untitled`.*/
+	/** A Uri {@link Uri.scheme scheme}, like `file` or `untitled`.*/
 	scheme: string;
 
 	/** A glob pattern. */
@@ -208,7 +208,7 @@ export type NotebookDocumentFilter = {
 	/** The type of the enclosing notebook. */
 	notebookType?: string;
 
-	/** A Uri [scheme](#Uri.scheme), like `file` or `untitled`. */
+	/** A Uri {@link Uri.scheme scheme}, like `file` or `untitled`. */
 	scheme?: string;
 
 	/** A glob pattern. */
@@ -217,7 +217,7 @@ export type NotebookDocumentFilter = {
 
 /**
  * The NotebookDocumentFilter namespace provides helper functions to work with
- * [NotebookDocumentFilter](#NotebookDocumentFilter) literals.
+ * {@link NotebookDocumentFilter} literals.
  *
  * @since 3.17.0
  */
@@ -254,7 +254,7 @@ export type NotebookCellTextDocumentFilter = {
 
 /**
  * The NotebookCellTextDocumentFilter namespace provides helper functions to work with
- * [NotebookCellTextDocumentFilter](#NotebookCellTextDocumentFilter) literals.
+ * {@link NotebookCellTextDocumentFilter} literals.
  *
  * @since 3.17.0
  */
@@ -286,7 +286,7 @@ export type DocumentSelector = (string | DocumentFilter)[];
 
 /**
  * The DocumentSelector namespace provides helper functions to work with
- * [DocumentSelector](#DocumentSelector)s.
+ * {@link DocumentSelector}s.
  */
 export namespace DocumentSelector {
 	export function is(value: any[] | undefined | null): value is DocumentSelector {
@@ -982,7 +982,7 @@ export interface StaticRegistrationOptions {
 
 /**
  * The StaticRegistrationOptions namespace provides helper functions to work with
- * [StaticRegistrationOptions](#StaticRegistrationOptions) literals.
+ * {@link StaticRegistrationOptions} literals.
  */
 export namespace StaticRegistrationOptions {
 	export function hasId(value: object): value is { id: string } {
@@ -1004,7 +1004,7 @@ export interface TextDocumentRegistrationOptions {
 
 /**
  * The TextDocumentRegistrationOptions namespace provides helper functions to work with
- * [TextDocumentRegistrationOptions](#TextDocumentRegistrationOptions) literals.
+ * {@link TextDocumentRegistrationOptions} literals.
  */
 export namespace TextDocumentRegistrationOptions {
 	export function is(value: any): value is TextDocumentRegistrationOptions {
@@ -1029,7 +1029,7 @@ export interface WorkDoneProgressOptions {
 
 /**
  * The WorkDoneProgressOptions namespace provides helper functions to work with
- * [WorkDoneProgressOptions](#WorkDoneProgressOptions) literals.
+ * {@link WorkDoneProgressOptions} literals.
  */
 export namespace WorkDoneProgressOptions {
 	export function is(value: any): value is WorkDoneProgressOptions {
@@ -1273,8 +1273,8 @@ export interface ServerCapabilities<T = LSPAny> {
 /**
  * The initialize request is sent from the client to the server.
  * It is sent once as the request after starting up the server.
- * The requests parameter is of type [InitializeParams](#InitializeParams)
- * the response if of type [InitializeResult](#InitializeResult) of a Thenable that
+ * The requests parameter is of type {@link InitializeParams}
+ * the response if of type {@link InitializeResult} of a Thenable that
  * resolves to such.
  */
 export namespace InitializeRequest {
@@ -2470,19 +2470,19 @@ export interface CompletionOptions extends WorkDoneProgressOptions {
 }
 
 /**
- * Registration options for a [CompletionRequest](#CompletionRequest).
+ * Registration options for a {@link CompletionRequest}.
  */
 export interface CompletionRegistrationOptions extends TextDocumentRegistrationOptions, CompletionOptions {
 }
 
 /**
  * Request to request completion at a given text document position. The request's
- * parameter is of type [TextDocumentPosition](#TextDocumentPosition) the response
- * is of type [CompletionItem[]](#CompletionItem) or [CompletionList](#CompletionList)
+ * parameter is of type {@link TextDocumentPosition} the response
+ * is of type {@link CompletionItem CompletionItem[]} or {@link CompletionList}
  * or a Thenable that resolves to such.
  *
- * The request can delay the computation of the [`detail`](#CompletionItem.detail)
- * and [`documentation`](#CompletionItem.documentation) properties to the `completionItem/resolve`
+ * The request can delay the computation of the {@link CompletionItem.detail `detail`}
+ * and {@link CompletionItem.documentation `documentation`} properties to the `completionItem/resolve`
  * request. However, properties that are needed for the initial sorting and filtering, like `sortText`,
  * `filterText`, `insertText`, and `textEdit`, must not be changed during resolve.
  */
@@ -2494,8 +2494,8 @@ export namespace CompletionRequest {
 
 /**
  * Request to resolve additional information for a given completion item.The request's
- * parameter is of type [CompletionItem](#CompletionItem) the response
- * is of type [CompletionItem](#CompletionItem) or a Thenable that resolves to such.
+ * parameter is of type {@link CompletionItem} the response
+ * is of type {@link CompletionItem} or a Thenable that resolves to such.
  */
 export namespace CompletionResolveRequest {
 	export const method: 'completionItem/resolve' = 'completionItem/resolve';
@@ -2525,21 +2525,21 @@ export interface HoverOptions extends WorkDoneProgressOptions {
 }
 
 /**
- * Parameters for a [HoverRequest](#HoverRequest).
+ * Parameters for a {@link HoverRequest}.
  */
 export interface HoverParams extends TextDocumentPositionParams, WorkDoneProgressParams {
 }
 
 /**
- * Registration options for a [HoverRequest](#HoverRequest).
+ * Registration options for a {@link HoverRequest}.
  */
 export interface HoverRegistrationOptions extends TextDocumentRegistrationOptions, HoverOptions {
 }
 
 /**
  * Request to request hover information at a given text document position. The request's
- * parameter is of type [TextDocumentPosition](#TextDocumentPosition) the response is of
- * type [Hover](#Hover) or a Thenable that resolves to such.
+ * parameter is of type {@link TextDocumentPosition} the response is of
+ * type {@link Hover} or a Thenable that resolves to such.
  */
 export namespace HoverRequest {
 	export const method: 'textDocument/hover' = 'textDocument/hover';
@@ -2550,7 +2550,7 @@ export namespace HoverRequest {
 //---- SignatureHelp ----------------------------------
 
 /**
- * Client Capabilities for a [SignatureHelpRequest](#SignatureHelpRequest).
+ * Client Capabilities for a {@link SignatureHelpRequest}.
  */
 export interface SignatureHelpClientCapabilities {
 	/**
@@ -2603,7 +2603,7 @@ export interface SignatureHelpClientCapabilities {
 }
 
 /**
- * Server Capabilities for a [SignatureHelpRequest](#SignatureHelpRequest).
+ * Server Capabilities for a {@link SignatureHelpRequest}.
  */
 export interface SignatureHelpOptions extends WorkDoneProgressOptions {
 	/**
@@ -2679,7 +2679,7 @@ export interface SignatureHelpContext {
 }
 
 /**
- * Parameters for a [SignatureHelpRequest](#SignatureHelpRequest).
+ * Parameters for a {@link SignatureHelpRequest}.
  */
 export interface SignatureHelpParams extends TextDocumentPositionParams, WorkDoneProgressParams {
 	/**
@@ -2692,7 +2692,7 @@ export interface SignatureHelpParams extends TextDocumentPositionParams, WorkDon
 }
 
 /**
- * Registration options for a [SignatureHelpRequest](#SignatureHelpRequest).
+ * Registration options for a {@link SignatureHelpRequest}.
  */
 export interface SignatureHelpRegistrationOptions extends TextDocumentRegistrationOptions, SignatureHelpOptions {
 }
@@ -2706,7 +2706,7 @@ export namespace SignatureHelpRequest {
 //---- Goto Definition -------------------------------------
 
 /**
- * Client Capabilities for a [DefinitionRequest](#DefinitionRequest).
+ * Client Capabilities for a {@link DefinitionRequest}.
  */
 export interface DefinitionClientCapabilities {
 	/**
@@ -2723,19 +2723,19 @@ export interface DefinitionClientCapabilities {
 }
 
 /**
- * Server Capabilities for a [DefinitionRequest](#DefinitionRequest).
+ * Server Capabilities for a {@link DefinitionRequest}.
  */
 export interface DefinitionOptions extends WorkDoneProgressOptions {
 }
 
 /**
- * Parameters for a [DefinitionRequest](#DefinitionRequest).
+ * Parameters for a {@link DefinitionRequest}.
  */
 export interface DefinitionParams extends TextDocumentPositionParams, WorkDoneProgressParams, PartialResultParams {
 }
 
 /**
- * Registration options for a [DefinitionRequest](#DefinitionRequest).
+ * Registration options for a {@link DefinitionRequest}.
  */
 export interface DefinitionRegistrationOptions extends TextDocumentRegistrationOptions, DefinitionOptions {
 }
@@ -2743,8 +2743,8 @@ export interface DefinitionRegistrationOptions extends TextDocumentRegistrationO
 /**
  * A request to resolve the definition location of a symbol at a given text
  * document position. The request's parameter is of type [TextDocumentPosition]
- * (#TextDocumentPosition) the response is of either type [Definition](#Definition)
- * or a typed array of [DefinitionLink](#DefinitionLink) or a Thenable that resolves
+ * (#TextDocumentPosition) the response is of either type {@link Definition}
+ * or a typed array of {@link DefinitionLink} or a Thenable that resolves
  * to such.
  */
 export namespace DefinitionRequest {
@@ -2756,7 +2756,7 @@ export namespace DefinitionRequest {
 //---- Reference Provider ----------------------------------
 
 /**
- * Client Capabilities for a [ReferencesRequest](#ReferencesRequest).
+ * Client Capabilities for a {@link ReferencesRequest}.
  */
 export interface ReferenceClientCapabilities {
 	/**
@@ -2766,7 +2766,7 @@ export interface ReferenceClientCapabilities {
 }
 
 /**
- * Parameters for a [ReferencesRequest](#ReferencesRequest).
+ * Parameters for a {@link ReferencesRequest}.
  */
 export interface ReferenceParams extends TextDocumentPositionParams, WorkDoneProgressParams, PartialResultParams {
 	context: ReferenceContext;
@@ -2779,7 +2779,7 @@ export interface ReferenceOptions extends WorkDoneProgressOptions {
 }
 
 /**
- * Registration options for a [ReferencesRequest](#ReferencesRequest).
+ * Registration options for a {@link ReferencesRequest}.
  */
 export interface ReferenceRegistrationOptions extends TextDocumentRegistrationOptions, ReferenceOptions {
 }
@@ -2787,8 +2787,8 @@ export interface ReferenceRegistrationOptions extends TextDocumentRegistrationOp
 /**
  * A request to resolve project-wide references for the symbol denoted
  * by the given text document position. The request's parameter is of
- * type [ReferenceParams](#ReferenceParams) the response is of type
- * [Location[]](#Location) or a Thenable that resolves to such.
+ * type {@link ReferenceParams} the response is of type
+ * {@link Location Location[]} or a Thenable that resolves to such.
  */
 export namespace ReferencesRequest {
 	export const method: 'textDocument/references' = 'textDocument/references';
@@ -2799,7 +2799,7 @@ export namespace ReferencesRequest {
 //---- Document Highlight ----------------------------------
 
 /**
- * Client Capabilities for a [DocumentHighlightRequest](#DocumentHighlightRequest).
+ * Client Capabilities for a {@link DocumentHighlightRequest}.
  */
 export interface DocumentHighlightClientCapabilities {
 	/**
@@ -2809,25 +2809,25 @@ export interface DocumentHighlightClientCapabilities {
 }
 
 /**
- * Parameters for a [DocumentHighlightRequest](#DocumentHighlightRequest).
+ * Parameters for a {@link DocumentHighlightRequest}.
  */
 export interface DocumentHighlightParams extends TextDocumentPositionParams, WorkDoneProgressParams, PartialResultParams {
 }
 
 /**
- * Provider options for a [DocumentHighlightRequest](#DocumentHighlightRequest).
+ * Provider options for a {@link DocumentHighlightRequest}.
  */
 export interface DocumentHighlightOptions extends WorkDoneProgressOptions {
 }
 
 /**
- * Registration options for a [DocumentHighlightRequest](#DocumentHighlightRequest).
+ * Registration options for a {@link DocumentHighlightRequest}.
  */
 export interface DocumentHighlightRegistrationOptions extends TextDocumentRegistrationOptions, DocumentHighlightOptions {
 }
 
 /**
- * Request to resolve a [DocumentHighlight](#DocumentHighlight) for a given
+ * Request to resolve a {@link DocumentHighlight} for a given
  * text document position. The request's parameter is of type [TextDocumentPosition]
  * (#TextDocumentPosition) the request response is of type [DocumentHighlight[]]
  * (#DocumentHighlight) or a Thenable that resolves to such.
@@ -2841,7 +2841,7 @@ export namespace DocumentHighlightRequest {
 //---- Document Symbol Provider ---------------------------
 
 /**
- * Client Capabilities for a [DocumentSymbolRequest](#DocumentSymbolRequest).
+ * Client Capabilities for a {@link DocumentSymbolRequest}.
  */
 export interface DocumentSymbolClientCapabilities {
 	/**
@@ -2896,7 +2896,7 @@ export interface DocumentSymbolClientCapabilities {
 }
 
 /**
- * Parameters for a [DocumentSymbolRequest](#DocumentSymbolRequest).
+ * Parameters for a {@link DocumentSymbolRequest}.
  */
 export interface DocumentSymbolParams extends WorkDoneProgressParams, PartialResultParams {
 	/**
@@ -2906,7 +2906,7 @@ export interface DocumentSymbolParams extends WorkDoneProgressParams, PartialRes
 }
 
 /**
- * Provider options for a [DocumentSymbolRequest](#DocumentSymbolRequest).
+ * Provider options for a {@link DocumentSymbolRequest}.
  */
 export interface DocumentSymbolOptions extends WorkDoneProgressOptions {
 	/**
@@ -2919,15 +2919,15 @@ export interface DocumentSymbolOptions extends WorkDoneProgressOptions {
 }
 
 /**
- * Registration options for a [DocumentSymbolRequest](#DocumentSymbolRequest).
+ * Registration options for a {@link DocumentSymbolRequest}.
  */
 export interface DocumentSymbolRegistrationOptions extends TextDocumentRegistrationOptions, DocumentSymbolOptions {
 }
 
 /**
  * A request to list all symbols found in a given text document. The request's
- * parameter is of type [TextDocumentIdentifier](#TextDocumentIdentifier) the
- * response is of type [SymbolInformation[]](#SymbolInformation) or a Thenable
+ * parameter is of type {@link TextDocumentIdentifier} the
+ * response is of type {@link SymbolInformation SymbolInformation[]} or a Thenable
  * that resolves to such.
  */
 export namespace DocumentSymbolRequest {
@@ -2939,7 +2939,7 @@ export namespace DocumentSymbolRequest {
 //---- Code Action Provider ----------------------------------
 
 /**
- * The Client Capabilities of a [CodeActionRequest](#CodeActionRequest).
+ * The Client Capabilities of a {@link CodeActionRequest}.
  */
 export interface CodeActionClientCapabilities {
 	/**
@@ -3020,7 +3020,7 @@ export interface CodeActionClientCapabilities {
 }
 
 /**
- * The parameters of a [CodeActionRequest](#CodeActionRequest).
+ * The parameters of a {@link CodeActionRequest}.
  */
 export interface CodeActionParams extends WorkDoneProgressParams, PartialResultParams {
 	/**
@@ -3040,7 +3040,7 @@ export interface CodeActionParams extends WorkDoneProgressParams, PartialResultP
 }
 
 /**
- * Provider options for a [CodeActionRequest](#CodeActionRequest).
+ * Provider options for a {@link CodeActionRequest}.
  */
 export interface CodeActionOptions extends WorkDoneProgressOptions {
 	/**
@@ -3061,7 +3061,7 @@ export interface CodeActionOptions extends WorkDoneProgressOptions {
 }
 
 /**
- * Registration options for a [CodeActionRequest](#CodeActionRequest).
+ * Registration options for a {@link CodeActionRequest}.
  */
 export interface CodeActionRegistrationOptions extends TextDocumentRegistrationOptions, CodeActionOptions {
 }
@@ -3077,8 +3077,8 @@ export namespace CodeActionRequest {
 
 /**
  * Request to resolve additional information for a given code action.The request's
- * parameter is of type [CodeAction](#CodeAction) the response
- * is of type [CodeAction](#CodeAction) or a Thenable that resolves to such.
+ * parameter is of type {@link CodeAction} the response
+ * is of type {@link CodeAction} or a Thenable that resolves to such.
  */
 export namespace CodeActionResolveRequest {
 	export const method: 'codeAction/resolve' = 'codeAction/resolve';
@@ -3089,7 +3089,7 @@ export namespace CodeActionResolveRequest {
 //---- Workspace Symbol Provider ---------------------------
 
 /**
- * Client capabilities for a [WorkspaceSymbolRequest](#WorkspaceSymbolRequest).
+ * Client capabilities for a {@link WorkspaceSymbolRequest}.
  */
 export interface WorkspaceSymbolClientCapabilities {
 	/**
@@ -3144,7 +3144,7 @@ export interface WorkspaceSymbolClientCapabilities {
 }
 
 /**
- * The parameters of a [WorkspaceSymbolRequest](#WorkspaceSymbolRequest).
+ * The parameters of a {@link WorkspaceSymbolRequest}.
  */
 export interface WorkspaceSymbolParams extends WorkDoneProgressParams, PartialResultParams {
 	/**
@@ -3155,7 +3155,7 @@ export interface WorkspaceSymbolParams extends WorkDoneProgressParams, PartialRe
 }
 
 /**
- * Server capabilities for a [WorkspaceSymbolRequest](#WorkspaceSymbolRequest).
+ * Server capabilities for a {@link WorkspaceSymbolRequest}.
  */
 export interface WorkspaceSymbolOptions extends WorkDoneProgressOptions {
 	/**
@@ -3169,15 +3169,15 @@ export interface WorkspaceSymbolOptions extends WorkDoneProgressOptions {
 
 
 /**
- * Registration options for a [WorkspaceSymbolRequest](#WorkspaceSymbolRequest).
+ * Registration options for a {@link WorkspaceSymbolRequest}.
  */
 export interface WorkspaceSymbolRegistrationOptions extends WorkspaceSymbolOptions {
 }
 
 /**
  * A request to list project-wide symbols matching the query string given
- * by the [WorkspaceSymbolParams](#WorkspaceSymbolParams). The response is
- * of type [SymbolInformation[]](#SymbolInformation) or a Thenable that
+ * by the {@link WorkspaceSymbolParams}. The response is
+ * of type {@link SymbolInformation SymbolInformation[]} or a Thenable that
  * resolves to such.
  *
  * @since 3.17.0 - support for WorkspaceSymbol in the returned data. Clients
@@ -3206,7 +3206,7 @@ export namespace WorkspaceSymbolResolveRequest {
 //---- Code Lens Provider -------------------------------------------
 
 /**
- * The client capabilities  of a [CodeLensRequest](#CodeLensRequest).
+ * The client capabilities  of a {@link CodeLensRequest}.
  */
 export interface CodeLensClientCapabilities {
 	/**
@@ -3232,7 +3232,7 @@ export interface CodeLensWorkspaceClientCapabilities {
 }
 
 /**
- * The parameters of a [CodeLensRequest](#CodeLensRequest).
+ * The parameters of a {@link CodeLensRequest}.
  */
 export interface CodeLensParams extends WorkDoneProgressParams, PartialResultParams {
 	/**
@@ -3242,7 +3242,7 @@ export interface CodeLensParams extends WorkDoneProgressParams, PartialResultPar
 }
 
 /**
- * Code Lens provider options of a [CodeLensRequest](#CodeLensRequest).
+ * Code Lens provider options of a {@link CodeLensRequest}.
  */
 export interface CodeLensOptions extends WorkDoneProgressOptions {
 	/**
@@ -3252,7 +3252,7 @@ export interface CodeLensOptions extends WorkDoneProgressOptions {
 }
 
 /**
- * Registration options for a [CodeLensRequest](#CodeLensRequest).
+ * Registration options for a {@link CodeLensRequest}.
  */
 export interface CodeLensRegistrationOptions extends TextDocumentRegistrationOptions, CodeLensOptions {
 }
@@ -3288,7 +3288,7 @@ export namespace CodeLensRefreshRequest {
 //---- Document Links ----------------------------------------------
 
 /**
- * The client capabilities of a [DocumentLinkRequest](#DocumentLinkRequest).
+ * The client capabilities of a {@link DocumentLinkRequest}.
  */
 export interface DocumentLinkClientCapabilities {
 	/**
@@ -3305,7 +3305,7 @@ export interface DocumentLinkClientCapabilities {
 }
 
 /**
- * The parameters of a [DocumentLinkRequest](#DocumentLinkRequest).
+ * The parameters of a {@link DocumentLinkRequest}.
  */
 export interface DocumentLinkParams extends WorkDoneProgressParams, PartialResultParams {
 	/**
@@ -3315,7 +3315,7 @@ export interface DocumentLinkParams extends WorkDoneProgressParams, PartialResul
 }
 
 /**
- * Provider options for a [DocumentLinkRequest](#DocumentLinkRequest).
+ * Provider options for a {@link DocumentLinkRequest}.
  */
 export interface DocumentLinkOptions extends WorkDoneProgressOptions {
 	/**
@@ -3325,7 +3325,7 @@ export interface DocumentLinkOptions extends WorkDoneProgressOptions {
 }
 
 /**
- * Registration options for a [DocumentLinkRequest](#DocumentLinkRequest).
+ * Registration options for a {@link DocumentLinkRequest}.
  */
 export interface DocumentLinkRegistrationOptions extends TextDocumentRegistrationOptions, DocumentLinkOptions {
 }
@@ -3341,8 +3341,8 @@ export namespace DocumentLinkRequest {
 
 /**
  * Request to resolve additional information for a given document link. The request's
- * parameter is of type [DocumentLink](#DocumentLink) the response
- * is of type [DocumentLink](#DocumentLink) or a Thenable that resolves to such.
+ * parameter is of type {@link DocumentLink} the response
+ * is of type {@link DocumentLink} or a Thenable that resolves to such.
  */
 export namespace DocumentLinkResolveRequest {
 	export const method: 'documentLink/resolve' = 'documentLink/resolve';
@@ -3353,7 +3353,7 @@ export namespace DocumentLinkResolveRequest {
 //---- Formatting ----------------------------------------------
 
 /**
- * Client capabilities of a [DocumentFormattingRequest](#DocumentFormattingRequest).
+ * Client capabilities of a {@link DocumentFormattingRequest}.
  */
 export interface DocumentFormattingClientCapabilities {
 	/**
@@ -3363,7 +3363,7 @@ export interface DocumentFormattingClientCapabilities {
 }
 
 /**
- * The parameters of a [DocumentFormattingRequest](#DocumentFormattingRequest).
+ * The parameters of a {@link DocumentFormattingRequest}.
  */
 export interface DocumentFormattingParams extends WorkDoneProgressParams {
 	/**
@@ -3378,13 +3378,13 @@ export interface DocumentFormattingParams extends WorkDoneProgressParams {
 }
 
 /**
- * Provider options for a [DocumentFormattingRequest](#DocumentFormattingRequest).
+ * Provider options for a {@link DocumentFormattingRequest}.
  */
 export interface DocumentFormattingOptions extends WorkDoneProgressOptions {
 }
 
 /**
- * Registration options for a [DocumentFormattingRequest](#DocumentFormattingRequest).
+ * Registration options for a {@link DocumentFormattingRequest}.
  */
 export interface DocumentFormattingRegistrationOptions extends TextDocumentRegistrationOptions, DocumentFormattingOptions {
 }
@@ -3399,7 +3399,7 @@ export namespace DocumentFormattingRequest {
 }
 
 /**
- * Client capabilities of a [DocumentRangeFormattingRequest](#DocumentRangeFormattingRequest).
+ * Client capabilities of a {@link DocumentRangeFormattingRequest}.
  */
 export interface DocumentRangeFormattingClientCapabilities {
 	/**
@@ -3409,7 +3409,7 @@ export interface DocumentRangeFormattingClientCapabilities {
 }
 
 /**
- * The parameters of a [DocumentRangeFormattingRequest](#DocumentRangeFormattingRequest).
+ * The parameters of a {@link DocumentRangeFormattingRequest}.
  */
 export interface DocumentRangeFormattingParams extends WorkDoneProgressParams {
 	/**
@@ -3429,13 +3429,13 @@ export interface DocumentRangeFormattingParams extends WorkDoneProgressParams {
 }
 
 /**
- * Provider options for a [DocumentRangeFormattingRequest](#DocumentRangeFormattingRequest).
+ * Provider options for a {@link DocumentRangeFormattingRequest}.
  */
 export interface DocumentRangeFormattingOptions extends WorkDoneProgressOptions {
 }
 
 /**
- * Registration options for a [DocumentRangeFormattingRequest](#DocumentRangeFormattingRequest).
+ * Registration options for a {@link DocumentRangeFormattingRequest}.
  */
 export interface DocumentRangeFormattingRegistrationOptions extends TextDocumentRegistrationOptions, DocumentRangeFormattingOptions {
 }
@@ -3450,7 +3450,7 @@ export namespace DocumentRangeFormattingRequest {
 }
 
 /**
- * Client capabilities of a [DocumentOnTypeFormattingRequest](#DocumentOnTypeFormattingRequest).
+ * Client capabilities of a {@link DocumentOnTypeFormattingRequest}.
  */
 export interface DocumentOnTypeFormattingClientCapabilities {
 	/**
@@ -3460,7 +3460,7 @@ export interface DocumentOnTypeFormattingClientCapabilities {
 }
 
 /**
- * The parameters of a [DocumentOnTypeFormattingRequest](#DocumentOnTypeFormattingRequest).
+ * The parameters of a {@link DocumentOnTypeFormattingRequest}.
  */
 export interface DocumentOnTypeFormattingParams {
 
@@ -3491,7 +3491,7 @@ export interface DocumentOnTypeFormattingParams {
 }
 
 /**
- * Provider options for a [DocumentOnTypeFormattingRequest](#DocumentOnTypeFormattingRequest).
+ * Provider options for a {@link DocumentOnTypeFormattingRequest}.
  */
 export interface DocumentOnTypeFormattingOptions {
 	/**
@@ -3506,7 +3506,7 @@ export interface DocumentOnTypeFormattingOptions {
 }
 
 /**
- * Registration options for a [DocumentOnTypeFormattingRequest](#DocumentOnTypeFormattingRequest).
+ * Registration options for a {@link DocumentOnTypeFormattingRequest}.
  */
 export interface DocumentOnTypeFormattingRegistrationOptions extends TextDocumentRegistrationOptions, DocumentOnTypeFormattingOptions {
 }
@@ -3569,7 +3569,7 @@ export interface RenameClientCapabilities {
 }
 
 /**
- * The parameters of a [RenameRequest](#RenameRequest).
+ * The parameters of a {@link RenameRequest}.
  */
 export interface RenameParams extends WorkDoneProgressParams {
 	/**
@@ -3584,14 +3584,14 @@ export interface RenameParams extends WorkDoneProgressParams {
 
 	/**
 	 * The new name of the symbol. If the given name is not valid the
-	 * request must return a [ResponseError](#ResponseError) with an
+	 * request must return a {@link ResponseError} with an
 	 * appropriate message set.
 	 */
 	newName: string;
 }
 
 /**
- * Provider options for a [RenameRequest](#RenameRequest).
+ * Provider options for a {@link RenameRequest}.
  */
 export interface RenameOptions extends WorkDoneProgressOptions {
 	/**
@@ -3603,7 +3603,7 @@ export interface RenameOptions extends WorkDoneProgressOptions {
 }
 
 /**
- * Registration options for a [RenameRequest](#RenameRequest).
+ * Registration options for a {@link RenameRequest}.
  */
 export interface RenameRegistrationOptions extends TextDocumentRegistrationOptions, RenameOptions {
 }
@@ -3636,7 +3636,7 @@ export namespace PrepareRenameRequest {
 //---- Command Execution -------------------------------------------
 
 /**
- * The client capabilities of a [ExecuteCommandRequest](#ExecuteCommandRequest).
+ * The client capabilities of a {@link ExecuteCommandRequest}.
  */
 export interface ExecuteCommandClientCapabilities {
 	/**
@@ -3646,7 +3646,7 @@ export interface ExecuteCommandClientCapabilities {
 }
 
 /**
- * The parameters of a [ExecuteCommandRequest](#ExecuteCommandRequest).
+ * The parameters of a {@link ExecuteCommandRequest}.
  */
 export interface ExecuteCommandParams extends WorkDoneProgressParams {
 
@@ -3661,7 +3661,7 @@ export interface ExecuteCommandParams extends WorkDoneProgressParams {
 }
 
 /**
- * The server capabilities of a [ExecuteCommandRequest](#ExecuteCommandRequest).
+ * The server capabilities of a {@link ExecuteCommandRequest}.
  */
 export interface ExecuteCommandOptions extends WorkDoneProgressOptions {
 	/**
@@ -3671,7 +3671,7 @@ export interface ExecuteCommandOptions extends WorkDoneProgressOptions {
 }
 
 /**
- * Registration options for a [ExecuteCommandRequest](#ExecuteCommandRequest).
+ * Registration options for a {@link ExecuteCommandRequest}.
  */
 export interface ExecuteCommandRegistrationOptions extends ExecuteCommandOptions {
 }

--- a/protocol/src/common/protocol.typeDefinition.ts
+++ b/protocol/src/common/protocol.typeDefinition.ts
@@ -46,7 +46,7 @@ export interface TypeDefinitionParams extends TextDocumentPositionParams, WorkDo
 /**
  * A request to resolve the type definition locations of a symbol at a given text
  * document position. The request's parameter is of type [TextDocumentPositionParams]
- * (#TextDocumentPositionParams) the response is of type [Definition](#Definition) or a
+ * (#TextDocumentPositionParams) the response is of type {@link Definition} or a
  * Thenable that resolves to such.
  */
 export namespace TypeDefinitionRequest {

--- a/server/src/common/server.ts
+++ b/server/src/common/server.ts
@@ -880,9 +880,9 @@ export interface _Connection<PConsole = _, PTracer = _, PTelemetry = _, PClient 
 	listen(): void;
 
 	/**
-	 * Installs a request handler described by the given [RequestType](#RequestType).
+	 * Installs a request handler described by the given {@link RequestType}.
 	 *
-	 * @param type The [RequestType](#RequestType) describing the request.
+	 * @param type The {@link RequestType} describing the request.
 	 * @param handler The handler to install
 	 */
 	onRequest<R, PR, E, RO>(type: ProtocolRequestType0<R, PR, E, RO>, handler: RequestHandler0<R, E>): Disposable;
@@ -908,7 +908,7 @@ export interface _Connection<PConsole = _, PTracer = _, PTelemetry = _, PClient 
 	/**
 	 * Send a request to the client.
 	 *
-	 * @param type The [RequestType](#RequestType) describing the request.
+	 * @param type The {@link RequestType} describing the request.
 	 * @param params The request's parameters.
 	 */
 	sendRequest<R, PR, E, RO>(type: ProtocolRequestType0<R, PR, E, RO>, token?: CancellationToken): Promise<R>;
@@ -926,9 +926,9 @@ export interface _Connection<PConsole = _, PTracer = _, PTelemetry = _, PClient 
 	sendRequest<R>(method: string, params: any, token?: CancellationToken): Promise<R>;
 
 	/**
-	 * Installs a notification handler described by the given [NotificationType](#NotificationType).
+	 * Installs a notification handler described by the given {@link NotificationType}.
 	 *
-	 * @param type The [NotificationType](#NotificationType) describing the notification.
+	 * @param type The {@link NotificationType} describing the notification.
 	 * @param handler The handler to install.
 	 */
 	onNotification<RO>(type: ProtocolNotificationType0<RO>, handler: NotificationHandler0): Disposable;
@@ -954,7 +954,7 @@ export interface _Connection<PConsole = _, PTracer = _, PTelemetry = _, PClient 
 	/**
 	 * Send a notification to the client.
 	 *
-	 * @param type The [NotificationType](#NotificationType) describing the notification.
+	 * @param type The {@link NotificationType} describing the notification.
 	 * @param params The notification's parameters.
 	 */
 	sendNotification<RO>(type: ProtocolNotificationType0<RO>): Promise<void>;
@@ -1234,7 +1234,7 @@ export interface _Connection<PConsole = _, PTracer = _, PTelemetry = _, PClient 
 	onCodeActionResolve(handler: RequestHandler<CodeAction, CodeAction, void>): Disposable;
 
 	/**
-	 * Compute a list of [lenses](#CodeLens). This call should return as fast as possible and if
+	 * Compute a list of {@link CodeLens lenses}. This call should return as fast as possible and if
 	 * computing the commands is expensive implementers should only return code lens objects with the
 	 * range set and handle the resolve request.
 	 *

--- a/server/src/node/main.ts
+++ b/server/src/node/main.ts
@@ -117,7 +117,7 @@ export function createConnection(options?: ConnectionStrategy | ConnectionOption
  * @param inputStream The stream to read messages from.
  * @param outputStream The stream to write messages to.
  * @param options An optional connection strategy or connection options to control additional settings
- * @return a [connection](#IConnection)
+ * @return A {@link Connection connection}
  */
 export function createConnection(inputStream: NodeJS.ReadableStream, outputStream: NodeJS.WritableStream, options?: ConnectionStrategy | ConnectionOptions): Connection;
 
@@ -147,7 +147,7 @@ export function createConnection<PConsole = _, PTracer = _, PTelemetry = _, PCli
  * @param inputStream The stream to read messages from.
  * @param outputStream The stream to write messages to.
  * @param options An optional connection strategy or connection options to control additional settings
- * @return a [connection](#IConnection)
+ * @return A {@link Connection connection}
  */
 export function createConnection<PConsole = _, PTracer = _, PTelemetry = _, PClient = _, PWindow = _, PWorkspace = _, PLanguages = _, PNotebooks = _>(
 	factories: Features<PConsole, PTracer, PTelemetry, PClient, PWindow, PWorkspace, PLanguages, PNotebooks>,

--- a/textDocument/src/main.ts
+++ b/textDocument/src/main.ts
@@ -145,8 +145,8 @@ export interface TextDocument {
 	 *
 	 * @param range (optional) An range within the document to return.
 	 * If no range is passed, the full content is returned.
-	 * Invalid range positions are adjusted as described in [Position.line](#Position.line)
-	 * and [Position.character](#Position.character).
+	 * Invalid range positions are adjusted as described in {@link Position.line}
+	 * and {@link Position.character}.
 	 * If the start range position is greater than the end range position,
 	 * then the effect of getText is as if the two positions were swapped.
 
@@ -159,7 +159,7 @@ export interface TextDocument {
 	 * Converts a zero-based offset to a position.
 	 *
 	 * @param offset A zero-based offset.
-	 * @return A valid [position](#Position).
+	 * @return A valid {@link Position position}.
 	 * @example The text document "ab\ncd" produces:
 	 * * position { line: 0, character: 0 } for `offset` 0.
 	 * * position { line: 0, character: 1 } for `offset` 1.
@@ -171,8 +171,8 @@ export interface TextDocument {
 
 	/**
 	 * Converts the position to a zero-based offset.
-	 * Invalid positions are adjusted as described in [Position.line](#Position.line)
-	 * and [Position.character](#Position.character).
+	 * Invalid positions are adjusted as described in {@link Position.line}
+	 * and {@link Position.character}.
 	 *
 	 * @param position A position.
 	 * @return A valid zero-based offset.

--- a/types/src/main.ts
+++ b/types/src/main.ts
@@ -143,7 +143,7 @@ export interface Position {
 
 /**
  * The Position namespace provides helper functions to work with
- * [Position](#Position) literals.
+ * {@link Position} literals.
  */
 export namespace Position {
 	/**
@@ -157,7 +157,7 @@ export namespace Position {
 		return { line, character };
 	}
 	/**
-	 * Checks whether the given literal conforms to the [Position](#Position) interface.
+	 * Checks whether the given literal conforms to the {@link Position} interface.
 	 */
 	export function is(value: any): value is Position {
 		let candidate = value as Position;
@@ -192,7 +192,7 @@ export interface Range {
 
 /**
  * The Range namespace provides helper functions to work with
- * [Range](#Range) literals.
+ * {@link Range} literals.
  */
 export namespace Range {
 	/**
@@ -219,7 +219,7 @@ export namespace Range {
 		}
 	}
 	/**
-	 * Checks whether the given literal conforms to the [Range](#Range) interface.
+	 * Checks whether the given literal conforms to the {@link Range} interface.
 	 */
 	export function is(value: any): value is Range {
 		let candidate = value as Range;
@@ -238,7 +238,7 @@ export interface Location {
 
 /**
  * The Location namespace provides helper functions to work with
- * [Location](#Location) literals.
+ * {@link Location} literals.
  */
 export namespace Location {
 	/**
@@ -250,7 +250,7 @@ export namespace Location {
 		return { uri, range };
 	}
 	/**
-	 * Checks whether the given literal conforms to the [Location](#Location) interface.
+	 * Checks whether the given literal conforms to the {@link Location} interface.
 	 */
 	export function is(value: any): value is Location {
 		let candidate = value as Location;
@@ -259,7 +259,7 @@ export namespace Location {
 }
 
 /**
-	 * Represents the connection of two locations. Provides additional metadata over normal [locations](#Location),
+	 * Represents the connection of two locations. Provides additional metadata over normal {@link Location locations},
 	 * including an origin range.
  */
 export interface LocationLink {
@@ -292,7 +292,7 @@ export interface LocationLink {
 
 /**
  * The LocationLink namespace provides helper functions to work with
- * [LocationLink](#LocationLink) literals.
+ * {@link LocationLink} literals.
  */
 export namespace LocationLink {
 
@@ -308,7 +308,7 @@ export namespace LocationLink {
 	}
 
 	/**
-	 * Checks whether the given literal conforms to the [LocationLink](#LocationLink) interface.
+	 * Checks whether the given literal conforms to the {@link LocationLink} interface.
 	 */
 	export function is(value: any): value is LocationLink {
 		let candidate = value as LocationLink;
@@ -346,7 +346,7 @@ export interface Color {
 
 /**
  * The Color namespace provides helper functions to work with
- * [Color](#Color) literals.
+ * {@link Color} literals.
  */
 export namespace Color {
 	/**
@@ -362,7 +362,7 @@ export namespace Color {
 	}
 
 	/**
-	 * Checks whether the given literal conforms to the [Color](#Color) interface.
+	 * Checks whether the given literal conforms to the {@link Color} interface.
 	 */
 	export function is(value: any): value is Color {
 		const candidate = value as Color;
@@ -391,7 +391,7 @@ export interface ColorInformation {
 
 /**
  * The ColorInformation namespace provides helper functions to work with
- * [ColorInformation](#ColorInformation) literals.
+ * {@link ColorInformation} literals.
  */
 export namespace ColorInformation {
 	/**
@@ -405,7 +405,7 @@ export namespace ColorInformation {
 	}
 
 	/**
-	 * Checks whether the given literal conforms to the [ColorInformation](#ColorInformation) interface.
+	 * Checks whether the given literal conforms to the {@link ColorInformation} interface.
 	 */
 	export function is(value: any): value is ColorInformation {
 		const candidate = value as ColorInformation;
@@ -421,21 +421,21 @@ export interface ColorPresentation {
 	 */
 	label: string;
 	/**
-	 * An [edit](#TextEdit) which is applied to a document when selecting
-	 * this presentation for the color.  When `falsy` the [label](#ColorPresentation.label)
+	 * An {@link TextEdit edit} which is applied to a document when selecting
+	 * this presentation for the color.  When `falsy` the {@link ColorPresentation.label label}
 	 * is used.
 	 */
 	textEdit?: TextEdit;
 	/**
-	 * An optional array of additional [text edits](#TextEdit) that are applied when
-	 * selecting this color presentation. Edits must not overlap with the main [edit](#ColorPresentation.textEdit) nor with themselves.
+	 * An optional array of additional {@link TextEdit text edits} that are applied when
+	 * selecting this color presentation. Edits must not overlap with the main {@link ColorPresentation.textEdit edit} nor with themselves.
 	 */
 	additionalTextEdits?: TextEdit[];
 }
 
 /**
  * The Color namespace provides helper functions to work with
- * [ColorPresentation](#ColorPresentation) literals.
+ * {@link ColorPresentation} literals.
  */
 export namespace ColorPresentation {
 	/**
@@ -450,7 +450,7 @@ export namespace ColorPresentation {
 	}
 
 	/**
-	 * Checks whether the given literal conforms to the [ColorInformation](#ColorInformation) interface.
+	 * Checks whether the given literal conforms to the {@link ColorInformation} interface.
 	 */
 	export function is(value: any): value is ColorPresentation {
 		const candidate = value as ColorPresentation;
@@ -518,7 +518,7 @@ export interface FoldingRange {
 	/**
 	 * Describes the kind of the folding range such as `comment' or 'region'. The kind
 	 * is used to categorize folding ranges and used by commands like 'Fold all comments'.
-	 * See [FoldingRangeKind](#FoldingRangeKind) for an enumeration of standardized kinds.
+	 * See {@link FoldingRangeKind} for an enumeration of standardized kinds.
 	 */
 	kind?: FoldingRangeKind;
 
@@ -534,7 +534,7 @@ export interface FoldingRange {
 
 /**
  * The folding range namespace provides helper functions to work with
- * [FoldingRange](#FoldingRange) literals.
+ * {@link FoldingRange} literals.
  */
 export namespace FoldingRange {
 	/**
@@ -561,7 +561,7 @@ export namespace FoldingRange {
 	}
 
 	/**
-	 * Checks whether the given literal conforms to the [FoldingRange](#FoldingRange) interface.
+	 * Checks whether the given literal conforms to the {@link FoldingRange} interface.
 	 */
 	export function is(value: any): value is FoldingRange {
 		const candidate = value as FoldingRange;
@@ -591,7 +591,7 @@ export interface DiagnosticRelatedInformation {
 
 /**
  * The DiagnosticRelatedInformation namespace provides helper functions to work with
- * [DiagnosticRelatedInformation](#DiagnosticRelatedInformation) literals.
+ * {@link DiagnosticRelatedInformation} literals.
  */
 export namespace DiagnosticRelatedInformation {
 
@@ -606,7 +606,7 @@ export namespace DiagnosticRelatedInformation {
 	}
 
 	/**
-	 * Checks whether the given literal conforms to the [DiagnosticRelatedInformation](#DiagnosticRelatedInformation) interface.
+	 * Checks whether the given literal conforms to the {@link DiagnosticRelatedInformation} interface.
 	 */
 	export function is(value: any): value is DiagnosticRelatedInformation {
 		let candidate: DiagnosticRelatedInformation = value as DiagnosticRelatedInformation;
@@ -752,7 +752,7 @@ export interface Diagnostic {
 
 /**
  * The Diagnostic namespace provides helper functions to work with
- * [Diagnostic](#Diagnostic) literals.
+ * {@link Diagnostic} literals.
  */
 export namespace Diagnostic {
 	/**
@@ -776,7 +776,7 @@ export namespace Diagnostic {
 	}
 
 	/**
-	 * Checks whether the given literal conforms to the [Diagnostic](#Diagnostic) interface.
+	 * Checks whether the given literal conforms to the {@link Diagnostic} interface.
 	 */
 	export function is(value: any): value is Diagnostic {
 		let candidate = value as Diagnostic;
@@ -817,7 +817,7 @@ export interface Command {
 
 /**
  * The Command namespace provides helper functions to work with
- * [Command](#Command) literals.
+ * {@link Command} literals.
  */
 export namespace Command {
 	/**
@@ -831,7 +831,7 @@ export namespace Command {
 		return result;
 	}
 	/**
-	 * Checks whether the given literal conforms to the [Command](#Command) interface.
+	 * Checks whether the given literal conforms to the {@link Command} interface.
 	 */
 	export function is(value: any): value is Command {
 		let candidate = value as Command;
@@ -1545,7 +1545,7 @@ export class WorkspaceChange {
 	}
 
 	/**
-	 * Returns the underlying [WorkspaceEdit](#WorkspaceEdit) literal
+	 * Returns the underlying {@link WorkspaceEdit} literal
 	 * use to be returned from a workspace edit operation like rename.
 	 */
 	public get edit(): WorkspaceEdit {
@@ -1561,7 +1561,7 @@ export class WorkspaceChange {
 	}
 
 	/**
-	 * Returns the [TextEditChange](#TextEditChange) to manage text edits
+	 * Returns the {@link TextEditChange} to manage text edits
 	 * for resources.
 	 */
 	public getTextEditChange(textDocument: OptionalVersionedTextDocumentIdentifier): TextEditChange;
@@ -1712,7 +1712,7 @@ export interface TextDocumentIdentifier {
 
 /**
  * The TextDocumentIdentifier namespace provides helper functions to work with
- * [TextDocumentIdentifier](#TextDocumentIdentifier) literals.
+ * {@link TextDocumentIdentifier} literals.
  */
 export namespace TextDocumentIdentifier {
 	/**
@@ -1723,7 +1723,7 @@ export namespace TextDocumentIdentifier {
 		return { uri };
 	}
 	/**
-	 * Checks whether the given literal conforms to the [TextDocumentIdentifier](#TextDocumentIdentifier) interface.
+	 * Checks whether the given literal conforms to the {@link TextDocumentIdentifier} interface.
 	 */
 	export function is(value: any): value is TextDocumentIdentifier {
 		let candidate = value as TextDocumentIdentifier;
@@ -1743,7 +1743,7 @@ export interface VersionedTextDocumentIdentifier extends TextDocumentIdentifier 
 
 /**
  * The VersionedTextDocumentIdentifier namespace provides helper functions to work with
- * [VersionedTextDocumentIdentifier](#VersionedTextDocumentIdentifier) literals.
+ * {@link VersionedTextDocumentIdentifier} literals.
  */
 export namespace VersionedTextDocumentIdentifier {
 	/**
@@ -1756,7 +1756,7 @@ export namespace VersionedTextDocumentIdentifier {
 	}
 
 	/**
-	 * Checks whether the given literal conforms to the [VersionedTextDocumentIdentifier](#VersionedTextDocumentIdentifier) interface.
+	 * Checks whether the given literal conforms to the {@link VersionedTextDocumentIdentifier} interface.
 	 */
 	export function is(value: any): value is VersionedTextDocumentIdentifier {
 		let candidate = value as VersionedTextDocumentIdentifier;
@@ -1780,7 +1780,7 @@ export interface OptionalVersionedTextDocumentIdentifier extends TextDocumentIde
 
 /**
  * The OptionalVersionedTextDocumentIdentifier namespace provides helper functions to work with
- * [OptionalVersionedTextDocumentIdentifier](#OptionalVersionedTextDocumentIdentifier) literals.
+ * {@link OptionalVersionedTextDocumentIdentifier} literals.
  */
 export namespace OptionalVersionedTextDocumentIdentifier {
 	/**
@@ -1793,7 +1793,7 @@ export namespace OptionalVersionedTextDocumentIdentifier {
 	}
 
 	/**
-	 * Checks whether the given literal conforms to the [OptionalVersionedTextDocumentIdentifier](#OptionalVersionedTextDocumentIdentifier) interface.
+	 * Checks whether the given literal conforms to the {@link OptionalVersionedTextDocumentIdentifier} interface.
 	 */
 	export function is(value: any): value is OptionalVersionedTextDocumentIdentifier {
 		let candidate = value as OptionalVersionedTextDocumentIdentifier;
@@ -1830,7 +1830,7 @@ export interface TextDocumentItem {
 
 /**
  * The TextDocumentItem namespace provides helper functions to work with
- * [TextDocumentItem](#TextDocumentItem) literals.
+ * {@link TextDocumentItem} literals.
  */
 export namespace TextDocumentItem {
 	/**
@@ -1845,7 +1845,7 @@ export namespace TextDocumentItem {
 	}
 
 	/**
-	 * Checks whether the given literal conforms to the [TextDocumentItem](#TextDocumentItem) interface.
+	 * Checks whether the given literal conforms to the {@link TextDocumentItem} interface.
 	 */
 	export function is(value: any): value is TextDocumentItem {
 		let candidate = value as TextDocumentItem;
@@ -1872,7 +1872,7 @@ export namespace MarkupKind {
 	export const Markdown: 'markdown' = 'markdown';
 
 	/**
-	 * Checks whether the given value is a value of the [MarkupKind](#MarkupKind) type.
+	 * Checks whether the given value is a value of the {@link MarkupKind} type.
 	 */
 	export function is(value: any): value is MarkupKind {
 		const candidate = value as MarkupKind;
@@ -1919,7 +1919,7 @@ export interface MarkupContent {
 
 export namespace MarkupContent {
 	/**
-	 * Checks whether the given value conforms to the [MarkupContent](#MarkupContent) interface.
+	 * Checks whether the given value conforms to the {@link MarkupContent} interface.
 	 */
 	export function is(value: any): value is MarkupContent {
 		const candidate = value as MarkupContent;
@@ -2039,7 +2039,7 @@ export namespace InsertReplaceEdit {
 	}
 
 	/**
-	 * Checks whether the given literal conforms to the [InsertReplaceEdit](#InsertReplaceEdit) interface.
+	 * Checks whether the given literal conforms to the {@link InsertReplaceEdit} interface.
 	 */
 	export function is(value: TextEdit | InsertReplaceEdit): value is InsertReplaceEdit {
 		const candidate: InsertReplaceEdit = value as InsertReplaceEdit;
@@ -2169,21 +2169,21 @@ export interface CompletionItem {
 
 	/**
 	 * A string that should be used when comparing this item
-	 * with other items. When `falsy` the [label](#CompletionItem.label)
+	 * with other items. When `falsy` the {@link CompletionItem.label label}
 	 * is used.
 	 */
 	sortText?: string;
 
 	/**
 	 * A string that should be used when filtering a set of
-	 * completion items. When `falsy` the [label](#CompletionItem.label)
+	 * completion items. When `falsy` the {@link CompletionItem.label label}
 	 * is used.
 	 */
 	filterText?: string;
 
 	/**
 	 * A string that should be inserted into a document when selecting
-	 * this completion. When `falsy` the [label](#CompletionItem.label)
+	 * this completion. When `falsy` the {@link CompletionItem.label label}
 	 * is used.
 	 *
 	 * The `insertText` is subject to interpretation by the client side.
@@ -2216,9 +2216,9 @@ export interface CompletionItem {
 	insertTextMode?: InsertTextMode;
 
 	/**
-	 * An [edit](#TextEdit) which is applied to a document when selecting
+	 * An {@link TextEdit edit} which is applied to a document when selecting
 	 * this completion. When an edit is provided the value of
-	 * [insertText](#CompletionItem.insertText) is ignored.
+	 * {@link CompletionItem.insertText insertText} is ignored.
 	 *
 	 * Most editors support two different operations when accepting a completion
 	 * item. One is to insert a completion text and the other is to replace an
@@ -2254,9 +2254,9 @@ export interface CompletionItem {
 	textEditText?: string;
 
 	/**
-	 * An optional array of additional [text edits](#TextEdit) that are applied when
+	 * An optional array of additional {@link TextEdit text edits} that are applied when
 	 * selecting this completion. Edits must not overlap (including the same insert position)
-	 * with the main [edit](#CompletionItem.textEdit) nor with themselves.
+	 * with the main {@link CompletionItem.textEdit edit} nor with themselves.
 	 *
 	 * Additional text edits should be used to change text unrelated to the current cursor position
 	 * (for example adding an import statement at the top of the file if the completion item will
@@ -2272,15 +2272,15 @@ export interface CompletionItem {
 	commitCharacters?: string[];
 
 	/**
-	 * An optional [command](#Command) that is executed *after* inserting this completion. *Note* that
+	 * An optional {@link Command command} that is executed *after* inserting this completion. *Note* that
 	 * additional modifications to the current document should be described with the
-	 * [additionalTextEdits](#CompletionItem.additionalTextEdits)-property.
+	 * {@link CompletionItem.additionalTextEdits additionalTextEdits}-property.
 	 */
 	command?: Command;
 
 	/**
 	 * A data entry field that is preserved on a completion item between a
-	 * [CompletionRequest](#CompletionRequest) and a [CompletionResolveRequest](#CompletionResolveRequest).
+	 * {@link CompletionRequest} and a {@link CompletionResolveRequest}.
 	 */
 	data?: LSPAny;
 }
@@ -2300,7 +2300,7 @@ export namespace CompletionItem {
 }
 
 /**
- * Represents a collection of [completion items](#CompletionItem) to be presented
+ * Represents a collection of {@link CompletionItem completion items} to be presented
  * in the editor.
  */
 export interface CompletionList {
@@ -2416,7 +2416,7 @@ export namespace MarkedString {
 	}
 
 	/**
-	 * Checks whether the given value conforms to the [MarkedString](#MarkedString) type.
+	 * Checks whether the given value conforms to the {@link MarkedString} type.
 	 */
 	export function is(value: any): value is MarkedString {
 		const candidate = value as MarkedString;
@@ -2442,7 +2442,7 @@ export interface Hover {
 
 export namespace Hover {
 	/**
-	 * Checks whether the given value conforms to the [Hover](#Hover) interface.
+	 * Checks whether the given value conforms to the {@link Hover} interface.
 	 */
 	export function is(value: any): value is Hover {
 		let candidate = value as Hover;
@@ -2483,7 +2483,7 @@ export interface ParameterInformation {
 
 /**
  * The ParameterInformation namespace provides helper functions to work with
- * [ParameterInformation](#ParameterInformation) literals.
+ * {@link ParameterInformation} literals.
  */
 export namespace ParameterInformation {
 	/**
@@ -2532,7 +2532,7 @@ export interface SignatureInformation {
 
 /**
  * The SignatureInformation namespace provides helper functions to work with
- * [SignatureInformation](#SignatureInformation) literals.
+ * {@link SignatureInformation} literals.
  */
 export namespace SignatureInformation {
 	export function create(label: string, documentation?: string, ...parameters: ParameterInformation[]): SignatureInformation {
@@ -2586,7 +2586,7 @@ export interface SignatureHelp {
 }
 
 /**
- * The definition of a symbol represented as one or many [locations](#Location).
+ * The definition of a symbol represented as one or many {@link Location locations}.
  * For most programming languages there is only one location at which a symbol is
  * defined.
  *
@@ -2598,20 +2598,20 @@ export type Definition = Location | Location[];
 /**
  * Information about where a symbol is defined.
  *
- * Provides additional metadata over normal [location](#Location) definitions, including the range of
+ * Provides additional metadata over normal {@link Location location} definitions, including the range of
  * the defining symbol
  */
 export type DefinitionLink = LocationLink;
 
 /**
- * The declaration of a symbol representation as one or many [locations](#Location).
+ * The declaration of a symbol representation as one or many {@link Location locations}.
  */
 export type Declaration = Location | Location[];
 
 /**
  * Information about where a symbol is declared.
  *
- * Provides additional metadata over normal [location](#Location) declarations, including the range of
+ * Provides additional metadata over normal {@link Location location} declarations, including the range of
  * the declaring symbol.
  *
  * Servers should prefer returning `DeclarationLink` over `Declaration` if supported
@@ -2664,14 +2664,14 @@ export interface DocumentHighlight {
 	range: Range;
 
 	/**
-	 * The highlight kind, default is [text](#DocumentHighlightKind.Text).
+	 * The highlight kind, default is {@link DocumentHighlightKind.Text text}.
 	 */
 	kind?: DocumentHighlightKind;
 }
 
 /**
  * DocumentHighlight namespace to provide helper functions to work with
- * [DocumentHighlight](#DocumentHighlight) literals.
+ * {@link DocumentHighlight} literals.
  */
 export namespace DocumentHighlight {
 	/**
@@ -2941,7 +2941,7 @@ export namespace DocumentSymbol {
 		return result;
 	}
 	/**
-	 * Checks whether the given literal conforms to the [DocumentSymbol](#DocumentSymbol) interface.
+	 * Checks whether the given literal conforms to the {@link DocumentSymbol} interface.
 	 */
 	export function is(value: any): value is DocumentSymbol {
 		let candidate: DocumentSymbol = value;
@@ -3072,7 +3072,7 @@ export type CodeActionTriggerKind = 1 | 2;
 
 /**
  * Contains additional diagnostic information about the context in which
- * a [code action](#CodeActionProvider.provideCodeActions) is run.
+ * a {@link CodeActionProvider.provideCodeActions code action} is run.
  */
 export interface CodeActionContext {
 	/**
@@ -3102,7 +3102,7 @@ export interface CodeActionContext {
 
 /**
  * The CodeActionContext namespace provides helper functions to work with
- * [CodeActionContext](#CodeActionContext) literals.
+ * {@link CodeActionContext} literals.
  */
 export namespace CodeActionContext {
 	/**
@@ -3119,7 +3119,7 @@ export namespace CodeActionContext {
 		return result;
 	}
 	/**
-	 * Checks whether the given literal conforms to the [CodeActionContext](#CodeActionContext) interface.
+	 * Checks whether the given literal conforms to the {@link CodeActionContext} interface.
 	 */
 	export function is(value: any): value is CodeActionContext {
 		let candidate = value as CodeActionContext;
@@ -3269,7 +3269,7 @@ export namespace CodeAction {
 }
 
 /**
- * A code lens represents a [command](#Command) that should be shown along with
+ * A code lens represents a {@link Command command} that should be shown along with
  * source text, like the number of references, a way to run tests, etc.
  *
  * A code lens is _unresolved_ when no command is associated to it. For performance
@@ -3288,7 +3288,7 @@ export interface CodeLens {
 
 	/**
 	 * A data entry field that is preserved on a code lens item between
-	 * a [CodeLensRequest](#CodeLensRequest) and a [CodeLensResolveRequest]
+	 * a {@link CodeLensRequest} and a [CodeLensResolveRequest]
 	 * (#CodeLensResolveRequest)
 	 */
 	data?: LSPAny;
@@ -3296,7 +3296,7 @@ export interface CodeLens {
 
 /**
  * The CodeLens namespace provides helper functions to work with
- * [CodeLens](#CodeLens) literals.
+ * {@link CodeLens} literals.
  */
 export namespace CodeLens {
 	/**
@@ -3308,7 +3308,7 @@ export namespace CodeLens {
 		return result;
 	}
 	/**
-	 * Checks whether the given literal conforms to the [CodeLens](#CodeLens) interface.
+	 * Checks whether the given literal conforms to the {@link CodeLens} interface.
 	 */
 	export function is(value: any): value is CodeLens {
 		let candidate = value as CodeLens;
@@ -3359,7 +3359,7 @@ export interface FormattingOptions {
 
 /**
  * The FormattingOptions namespace provides helper functions to work with
- * [FormattingOptions](#FormattingOptions) literals.
+ * {@link FormattingOptions} literals.
  */
 export namespace FormattingOptions {
 	/**
@@ -3369,7 +3369,7 @@ export namespace FormattingOptions {
 		return { tabSize, insertSpaces };
 	}
 	/**
-	 * Checks whether the given literal conforms to the [FormattingOptions](#FormattingOptions) interface.
+	 * Checks whether the given literal conforms to the {@link FormattingOptions} interface.
 	 */
 	export function is(value: any): value is FormattingOptions {
 		let candidate = value as FormattingOptions;
@@ -3413,7 +3413,7 @@ export interface DocumentLink {
 
 /**
  * The DocumentLink namespace provides helper functions to work with
- * [DocumentLink](#DocumentLink) literals.
+ * {@link DocumentLink} literals.
  */
 export namespace DocumentLink {
 	/**
@@ -3424,7 +3424,7 @@ export namespace DocumentLink {
 	}
 
 	/**
-	 * Checks whether the given literal conforms to the [DocumentLink](#DocumentLink) interface.
+	 * Checks whether the given literal conforms to the {@link DocumentLink} interface.
 	 */
 	export function is(value: any): value is DocumentLink {
 		let candidate = value as DocumentLink;
@@ -3439,7 +3439,7 @@ export namespace DocumentLink {
 export interface SelectionRange {
 
 	/**
-	 * The [range](#Range) of this selection range.
+	 * The {@link Range range} of this selection range.
 	 */
 	range: Range;
 
@@ -3509,7 +3509,7 @@ export interface CallHierarchyItem {
 
 	/**
 	 * The range that should be selected and revealed when this symbol is being picked, e.g. the name of a function.
-	 * Must be contained by the [`range`](#CallHierarchyItem.range).
+	 * Must be contained by the {@link CallHierarchyItem.range `range`}.
 	 */
 	selectionRange: Range;
 
@@ -3534,7 +3534,7 @@ export interface CallHierarchyIncomingCall {
 
 	/**
 	 * The ranges at which the calls appear. This is relative to the caller
-	 * denoted by [`this.from`](#CallHierarchyIncomingCall.from).
+	 * denoted by {@link CallHierarchyIncomingCall.from `this.from`}.
 	 */
 	fromRanges: Range[];
 }
@@ -3553,8 +3553,8 @@ export interface CallHierarchyOutgoingCall {
 
 	/**
 	 * The range at which this item is called. This is the range relative to the caller, e.g the item
-	 * passed to [`provideCallHierarchyOutgoingCalls`](#CallHierarchyItemProvider.provideCallHierarchyOutgoingCalls)
-	 * and not [`this.to`](#CallHierarchyOutgoingCall.to).
+	 * passed to {@link CallHierarchyItemProvider.provideCallHierarchyOutgoingCalls `provideCallHierarchyOutgoingCalls`}
+	 * and not {@link CallHierarchyOutgoingCall.to `this.to`}.
 	 */
 	fromRanges: Range[];
 }
@@ -3732,7 +3732,7 @@ export type TypeHierarchyItem = {
 	/**
 	 * The range that should be selected and revealed when this symbol is being
 	 * picked, e.g. the name of a function. Must be contained by the
-	 * [`range`](#TypeHierarchyItem.range).
+	 * {@link TypeHierarchyItem.range `range`}.
 	 */
 	selectionRange: Range;
 
@@ -3896,7 +3896,7 @@ export type InlineValueContext = {
 
 /**
  * The InlineValueContext namespace provides helper functions to work with
- * [InlineValueContext](#InlineValueContext) literals.
+ * {@link InlineValueContext} literals.
  *
  * @since 3.17.0
  */
@@ -3909,7 +3909,7 @@ export namespace InlineValueContext {
 	}
 
 	/**
-	 * Checks whether the given literal conforms to the [InlineValueContext](#InlineValueContext) interface.
+	 * Checks whether the given literal conforms to the {@link InlineValueContext} interface.
 	 */
 	export function is(value: any): value is InlineValueContext {
 		const candidate = value as InlineValueContext;
@@ -4150,8 +4150,8 @@ export interface TextDocument {
 	 *
 	 * @param range (optional) An range within the document to return.
 	 * If no range is passed, the full content is returned.
-	 * Invalid range positions are adjusted as described in [Position.line](#Position.line)
-	 * and [Position.character](#Position.character).
+	 * Invalid range positions are adjusted as described in {@link Position.line Position.line}
+	 * and {@link Position.character Position.character}.
 	 * If the start range position is greater than the end range position,
 	 * then the effect of getText is as if the two positions were swapped.
 
@@ -4164,14 +4164,14 @@ export interface TextDocument {
 	 * Converts a zero-based offset to a position.
 	 *
 	 * @param offset A zero-based offset.
-	 * @return A valid [position](#Position).
+	 * @return A valid {@link Position position}.
 	 */
 	positionAt(offset: uinteger): Position;
 
 	/**
 	 * Converts the position to a zero-based offset.
-	 * Invalid positions are adjusted as described in [Position.line](#Position.line)
-	 * and [Position.character](#Position.character).
+	 * Invalid positions are adjusted as described in {@link Position.line Position.line}
+	 * and {@link Position.character Position.character}.
 	 *
 	 * @param position A position.
 	 * @return A valid zero-based offset.
@@ -4201,7 +4201,7 @@ export namespace TextDocument {
 		return new FullTextDocument(uri, languageId, version, content);
 	}
 	/**
-	 * Checks whether the given literal conforms to the [ITextDocument](#ITextDocument) interface.
+	 * Checks whether the given literal conforms to the {@link ITextDocument} interface.
 	 */
 	export function is(value: any): value is TextDocument {
 		let candidate = value as TextDocument;


### PR DESCRIPTION
Fixes #1015

Converts the jsdoc comments to use `@link` syntax for links. This makes these links work inside editors like VS Code 