### PR TITLE
Add defaultBehavior response to onPrepareRename

### DIFF
--- a/server/src/common/server.ts
+++ b/server/src/common/server.ts
@@ -1283,7 +1283,7 @@ export interface _Connection<PConsole = _, PTracer = _, PTelemetry = _, PClient 
 	 *
 	 * @param handler The corresponding handler.
 	 */
-	onPrepareRename(handler: RequestHandler<PrepareRenameParams, Range | { range: Range; placeholder: string } | undefined | null, void>): Disposable;
+	onPrepareRename(handler: RequestHandler<PrepareRenameParams, Range | { range: Range; placeholder: string } | { defaultBehavior: boolean } | undefined | null, void>): Disposable;
 
 	/**
 	 * Installs a handler for the document links request.


### PR DESCRIPTION
The feature works fine, but TypeScript is unaware that the response is allowed. Sync with `protocol.ts`:

https://github.com/microsoft/vscode-languageserver-node/blob/c91c2f89e0a3d8aa8923355a65a2977b2b3d3b57/protocol/src/common/protocol.ts#L3623

Background: https://github.com/microsoft/vscode/issues/85157#issuecomment-688111130

