### PR TITLE
Fix resolveCodeAction middleware call

### DIFF
--- a/client/src/common/codeAction.ts
+++ b/client/src/common/codeAction.ts
@@ -99,7 +99,7 @@ export class CodeActionFeature extends TextDocumentLanguageFeature<boolean | Cod
 				? (item: VCodeAction, token: CancellationToken) => {
 					const client = this._client;
 					const middleware = this._client.middleware;
-					const resolveCodeAction: ResolveCodeActionSignature = async (item, token) => {
+					const _resolveCodeAction: ResolveCodeActionSignature = async (item, token) => {
 						return client.sendRequest(CodeActionResolveRequest.type, await client.code2ProtocolConverter.asCodeAction(item, token), token).then((result) => {
 							if (token.isCancellationRequested) {
 								return item;
@@ -110,8 +110,8 @@ export class CodeActionFeature extends TextDocumentLanguageFeature<boolean | Cod
 						});
 					};
 					return middleware.resolveCodeAction
-						? middleware.resolveCodeAction(item, token, resolveCodeAction)
-						: resolveCodeAction(item, token);
+						? middleware.resolveCodeAction(item, token, _resolveCodeAction)
+						: _resolveCodeAction(item, token);
 				}
 				: undefined
 		};


### PR DESCRIPTION
Change the name of the local resolveCodeAction function so it is actually called, otherwise the original is called instead, and the middleware is not invoked.

This matches what happens for the provideCodeAction call too, in the section above it.