### PR TITLE
Client: Fix documentSelector being overwritten

### DIFF
--- a/client/src/common/features.ts
+++ b/client/src/common/features.ts
@@ -532,7 +532,7 @@ export abstract class TextDocumentLanguageFeature<PO, RO extends TextDocumentReg
 			const id = StaticRegistrationOptions.hasId(capability) ? capability.id : UUID.generateUuid();
 			const selector = capability.documentSelector || documentSelector;
 			if (selector) {
-				return [id, Object.assign({}, { documentSelector: selector }, capability)];
+				return [id, Object.assign({}, capability, { documentSelector: selector })];
 			}
 		} else if (Is.boolean(capability) && capability === true || WorkDoneProgressOptions.is(capability)) {
 			if (!documentSelector) {


### PR DESCRIPTION
Thank you for fixing #1133 and releasing it with "8.1.0-next.4". It fixed the search & replace functionality for [rescript-vscode](https://marketplace.visualstudio.com/items?itemName=chenglou92.rescript-vscode).

Unfortunately that version broke semantic highlighting for us. We supply a `documentSelector` object from the client side which got overwritten by the server side `capability.documentSelector` which is set to `null` in our case.

I think this is the correct way to merge the capabilities with the `documentSelector`, with the client being last, because it says in the docs: 
> "A document selector to identify the scope of the registration. If set to null\nthe document selector provided on the client side will be used."

Source: https://github.com/microsoft/vscode-languageserver-node/blob/main/protocol/metaModel.json#L2386