### PR TITLE
Fixes regression introduced in latest next version

### DIFF
--- a/client-node-tests/src/integration.test.ts
+++ b/client-node-tests/src/integration.test.ts
@@ -10,7 +10,6 @@ import * as vscode from 'vscode';
 import * as lsclient from 'vscode-languageclient/node';
 import { MemoryFileSystemProvider } from './memoryFileSystemProvider';
 import { vsdiag, DiagnosticProviderMiddleware } from 'vscode-languageclient/lib/common/diagnostic';
-import { LanguageClient } from 'vscode-languageclient/node';
 
 namespace GotNotifiedRequest {
 	export const method: 'testing/gotNotified' = 'testing/gotNotified';
@@ -66,6 +65,69 @@ function isInstanceOf<T>(value: T, clazz: any): asserts value is Exclude<T, unde
 function isFullDocumentDiagnosticReport(value: vsdiag.DocumentDiagnosticReport): asserts value is vsdiag.FullDocumentDiagnosticReport {
 	assert.ok(value.kind === vsdiag.DocumentDiagnosticReportKind.full);
 }
+
+interface FoldingRangeTestFeature {
+	getRegistration(documentSelector: lsclient.DocumentSelector | undefined, capability: undefined | lsclient.FoldingRangeOptions | (lsclient.FoldingRangeRegistrationOptions & lsclient.StaticRegistrationOptions)): [string | undefined, (lsclient.FoldingRangeRegistrationOptions & { documentSelector: lsclient.DocumentSelector }) | undefined];
+	getRegistrationOptions(documentSelector: lsclient.DocumentSelector | undefined, capability: undefined | lsclient.FoldingRangeOptions) : (lsclient.FoldingRangeRegistrationOptions & { documentSelector: lsclient.DocumentSelector }) | undefined;
+}
+
+suite ('Client Features', () => {
+
+	const documentSelector: lsclient.DocumentSelector = [{ scheme: 'lsptests', language: 'bat' }];
+
+	function createClient(): lsclient.LanguageClient {
+		const serverModule = path.join(__dirname, './servers/nullServer.js');
+		const serverOptions: lsclient.ServerOptions = {
+			run: { module: serverModule, transport: lsclient.TransportKind.ipc },
+			debug: { module: serverModule, transport: lsclient.TransportKind.ipc, options: { execArgv: ['--nolazy', '--inspect=6014'] } }
+		};
+
+		const clientOptions: lsclient.LanguageClientOptions = {
+			documentSelector,
+			synchronize: {},
+			initializationOptions: {},
+			middleware: {},
+		};
+		(clientOptions as ({ $testMode?: boolean })).$testMode = true;
+
+		const result = new lsclient.LanguageClient('test svr', 'Test Language Server', serverOptions, clientOptions);
+		result.registerProposedFeatures();
+		return result;
+	}
+
+	test('Document Selector - Client only', () => {
+		const client = createClient();
+
+		const feature = client.getFeature(lsclient.FoldingRangeRequest.method) as unknown as FoldingRangeTestFeature;
+		const [, options] = feature.getRegistration(documentSelector, {});
+		isDefined(options);
+		const filter = options.documentSelector[0] as lsclient.TextDocumentFilter;
+		assert.strictEqual(filter.scheme, 'lsptests');
+		assert.strictEqual(filter.language, 'bat');
+	});
+
+	test('Document Selector - Server null', () => {
+		const client = createClient();
+
+		const feature = client.getFeature(lsclient.FoldingRangeRequest.method) as unknown as FoldingRangeTestFeature;
+		const [, options] = feature.getRegistration(documentSelector, { documentSelector: null });
+		isDefined(options);
+		const filter = options.documentSelector[0] as lsclient.TextDocumentFilter;
+		assert.strictEqual(filter.scheme, 'lsptests');
+		assert.strictEqual(filter.language, 'bat');
+	});
+
+	test('Document Selector - Client and server', () => {
+		const client = createClient();
+
+		const feature = client.getFeature(lsclient.FoldingRangeRequest.method) as unknown as FoldingRangeTestFeature;
+		const [, options] = feature.getRegistration(documentSelector, { documentSelector: [{ scheme: 'file', language: 'test' }] });
+		isDefined(options);
+		const filter = options.documentSelector[0] as lsclient.TextDocumentFilter;
+		assert.strictEqual(filter.scheme, 'file');
+		assert.strictEqual(filter.language, 'test');
+	});
+});
 
 suite('Client integration', () => {
 
@@ -1800,7 +1862,7 @@ suite('Server activation', () => {
 		}, /Client got disposed and can't be restarted./);
 	});
 
-	async function checkServerStart(client: LanguageClient, disposable: vscode.Disposable): Promise<void> {
+	async function checkServerStart(client: lsclient.LanguageClient, disposable: vscode.Disposable): Promise<void> {
 		return new Promise((resolve, reject) => {
 			const timeout = setTimeout(() => {
 				reject(new Error(`Server didn't start in 1000 ms.`));

--- a/client/src/common/features.ts
+++ b/client/src/common/features.ts
@@ -493,7 +493,7 @@ export abstract class TextDocumentLanguageFeature<PO, RO extends TextDocumentReg
 		}
 	}
 
-	public get registrationType():  RegistrationType<RO> {
+	public get registrationType(): RegistrationType<RO> {
 		return this._registrationType;
 	}
 
@@ -530,15 +530,15 @@ export abstract class TextDocumentLanguageFeature<PO, RO extends TextDocumentReg
 			return [undefined, undefined];
 		} else if (TextDocumentRegistrationOptions.is(capability)) {
 			const id = StaticRegistrationOptions.hasId(capability) ? capability.id : UUID.generateUuid();
-			const selector = capability.documentSelector || documentSelector;
+			const selector = capability.documentSelector ?? documentSelector;
 			if (selector) {
-				return [id, Object.assign({}, { documentSelector: selector }, capability)];
+				return [id, Object.assign({}, capability, { documentSelector: selector })];
 			}
 		} else if (Is.boolean(capability) && capability === true || WorkDoneProgressOptions.is(capability)) {
 			if (!documentSelector) {
 				return [undefined, undefined];
 			}
-			const options: RO & { documentSelector: DocumentSelector } = (Is.boolean(capability) && capability === true ? { documentSelector } : Object.assign({}, { documentSelector }, capability)) as any;
+			const options: RO & { documentSelector: DocumentSelector } = (Is.boolean(capability) && capability === true ? { documentSelector } : Object.assign({}, capability, { documentSelector })) as any;
 			return [UUID.generateUuid(), options];
 		}
 		return [undefined, undefined];


### PR DESCRIPTION
Fixes are:

- remove unnecessary error dialog when a request got cancel claiming that the request has failed.
- make sure that server document selector wins over client one. 