### PR TITLE
Added registerCapability and unregisterCapability to the client middleware

### DIFF
--- a/client/src/common/client.ts
+++ b/client/src/common/client.ts
@@ -1817,14 +1817,14 @@ export abstract class BaseLanguageClient implements FeatureClient<Middleware, La
 
 	private async handleRegistrationRequest(params: RegistrationParams): Promise<void> {
 		const middleware = this.clientOptions.middleware?.handleRegisterCapability;
-		if(middleware) {
-			return middleware(params, nextParams => this.tryToRegisterCapability(nextParams));
+		if (middleware) {
+			return middleware(params, nextParams => this.doRegisterCapability(nextParams));
 		} else {
-			return this.tryToRegisterCapability(params);
+			return this.doRegisterCapability(params);
 		}
 	}
 
-	private async tryToRegisterCapability(params: RegistrationParams): Promise<void> {
+	private async doRegisterCapability(params: RegistrationParams): Promise<void> {
 		// We will not receive a registration call before a client is running
 		// from a server. However if we stop or shutdown we might which might
 		// try to restart the server. So ignore registrations if we are not running
@@ -1860,13 +1860,13 @@ export abstract class BaseLanguageClient implements FeatureClient<Middleware, La
 	private async handleUnregistrationRequest(params: UnregistrationParams): Promise<void> {
 		const middleware = this.clientOptions.middleware?.handleUnregisterCapability;
 		if(middleware) {
-			return middleware(params, nextParams => this.tryToUnregisterCapability(nextParams));
+			return middleware(params, nextParams => this.doUnregisterCapability(nextParams));
 		} else {
-			return this.tryToUnregisterCapability(params);
+			return this.doUnregisterCapability(params);
 		}
 	}
 
-	private async tryToUnregisterCapability(params: UnregistrationParams): Promise<void> {
+	private async doUnregisterCapability(params: UnregistrationParams): Promise<void> {
 		for (const unregistration of params.unregisterations) {
 			if (this._ignoredRegistrations.has(unregistration.id)) {
 				continue;

--- a/client/src/common/client.ts
+++ b/client/src/common/client.ts
@@ -313,6 +313,8 @@ export interface HandleWorkDoneProgressSignature {
 interface _Middleware {
 	handleDiagnostics?: (this: void, uri: Uri, diagnostics: VDiagnostic[], next: HandleDiagnosticsSignature) => void;
 	handleWorkDoneProgress?: (this: void, token: ProgressToken, params: WorkDoneProgressBegin | WorkDoneProgressReport | WorkDoneProgressEnd, next: HandleWorkDoneProgressSignature) => void;
+	handleRegisterCapability?: (this: void, params: RegistrationParams, next: RegistrationRequest.HandlerSignature) => Promise<void>;
+	handleUnregisterCapability?: (this: void, params: UnregistrationParams, next: UnregistrationRequest.HandlerSignature) => Promise<void>;
 	workspace?: WorkspaceMiddleware;
 	window?: WindowMiddleware;
 }
@@ -1814,6 +1816,15 @@ export abstract class BaseLanguageClient implements FeatureClient<Middleware, La
 	}
 
 	private async handleRegistrationRequest(params: RegistrationParams): Promise<void> {
+		const middleware = this.clientOptions.middleware?.handleRegisterCapability;
+		if(middleware) {
+			return middleware(params, nextParams => this.tryToRegisterCapability(nextParams));
+		} else {
+			return this.tryToRegisterCapability(params);
+		}
+	}
+
+	private async tryToRegisterCapability(params: RegistrationParams): Promise<void> {
 		// We will not receive a registration call before a client is running
 		// from a server. However if we stop or shutdown we might which might
 		// try to restart the server. So ignore registrations if we are not running
@@ -1823,6 +1834,7 @@ export abstract class BaseLanguageClient implements FeatureClient<Middleware, La
 			}
 			return;
 		}
+
 		interface WithDocumentSelector {
 			documentSelector: DocumentSelector | undefined;
 		}
@@ -1846,7 +1858,16 @@ export abstract class BaseLanguageClient implements FeatureClient<Middleware, La
 	}
 
 	private async handleUnregistrationRequest(params: UnregistrationParams): Promise<void> {
-		for (let unregistration of params.unregisterations) {
+		const middleware = this.clientOptions.middleware?.handleUnregisterCapability;
+		if(middleware) {
+			return middleware(params, nextParams => this.tryToUnregisterCapability(nextParams));
+		} else {
+			return this.tryToUnregisterCapability(params);
+		}
+	}
+
+	private async tryToUnregisterCapability(params: UnregistrationParams): Promise<void> {
+		for (const unregistration of params.unregisterations) {
 			if (this._ignoredRegistrations.has(unregistration.id)) {
 				continue;
 			}

--- a/protocol/src/common/protocol.ts
+++ b/protocol/src/common/protocol.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 
-import { ProgressToken, TraceValues } from 'vscode-jsonrpc';
+import { ProgressToken, RequestHandler, TraceValues } from 'vscode-jsonrpc';
 
 import { MessageDirection, ProtocolRequestType, ProtocolRequestType0, ProtocolNotificationType, ProtocolNotificationType0 } from './messages';
 
@@ -335,6 +335,7 @@ export namespace RegistrationRequest {
 	export const method: 'client/registerCapability' = 'client/registerCapability';
 	export const messageDirection: MessageDirection = MessageDirection.serverToClient;
 	export const type = new ProtocolRequestType<RegistrationParams, void, never, void, void>(method);
+	export type HandlerSignature = RequestHandler<RegistrationParams, void, void>;
 }
 
 /**
@@ -368,6 +369,7 @@ export namespace UnregistrationRequest {
 	export const method: 'client/unregisterCapability' = 'client/unregisterCapability';
 	export const messageDirection: MessageDirection = MessageDirection.serverToClient;
 	export const type = new ProtocolRequestType<UnregistrationParams, void, never, void, void>(method);
+	export type HandlerSignature = RequestHandler<UnregistrationParams, void, void>;
 }
 
 export interface WorkDoneProgressParams {


### PR DESCRIPTION
As mentioned in https://github.com/microsoft/vscode-languageserver-node/issues/1101, currently there is no way to intercept `client/registerCapability`/`client/unregisterCapability`. This PR adds both of these requests to the middleware.

Not entirely sure if if these calls should be placed directly in `_Middleware` so any help is appreciated 🙏 