### PR TITLE
Fixes #1199: Clarify Spec regarding default behavior for Position.line containing an out-of-range value

### DIFF
--- a/textDocument/src/main.ts
+++ b/textDocument/src/main.ts
@@ -22,8 +22,12 @@ export type DocumentUri = string;
 export interface Position {
 	/**
 	 * Line position in a document (zero-based).
-	 * If a line number is greater than the number of lines in a document, it defaults back to the number of lines in the document.
+	 *
+	 * If a line number is greater than the number of lines in a document, it
+	 * defaults back to the number of lines in the document.
 	 * If a line number is negative, it defaults to 0.
+	 *
+	 * The above two properties are implementation specific.
 	 */
 	line: number;
 
@@ -33,8 +37,8 @@ export interface Position {
 	 * The meaning of this offset is determined by the negotiated
 	 * `PositionEncodingKind`.
 	 *
-	 * If the character value is greater than the line length it defaults back to the
-	 * line length.
+	 * If the character value is greater than the line length it defaults back
+	 * to the line length. This property is implementation specific.
 	 */
 	character: number;
 }


### PR DESCRIPTION
Fixes #1199