### PR TITLE
Fixes #1231: Setting exactOptionalPropertyTypes results in TS2720 errors in vscode-languageserver-protocol

### DIFF
--- a/jsonrpc/src/common/connection.ts
+++ b/jsonrpc/src/common/connection.ts
@@ -59,8 +59,8 @@ export class ProgressType<PR> {
 	 * Clients must not use these properties. They are here to ensure correct typing.
 	 * in TypeScript
 	 */
-	public readonly __?: [PR, _EM];
-	public readonly _pr?: PR;
+	public readonly __: [PR, _EM] | undefined;
+	public readonly _pr: PR | undefined;
 
 	constructor() {
 	}

--- a/protocol/src/common/messages.ts
+++ b/protocol/src/common/messages.ts
@@ -28,6 +28,7 @@ export class ProtocolRequestType0<R, PR, E, RO> extends RequestType0<R, E> imple
 	 * Clients must not use these properties. They are here to ensure correct typing.
 	 * in TypeScript
 	 */
+	public readonly __: [PR, _EM] | undefined;
 	public readonly ___: [PR, RO, _EM] | undefined;
 	public readonly ____: [RO, _EM] | undefined;
 	public readonly _pr: PR | undefined;
@@ -41,6 +42,7 @@ export class ProtocolRequestType<P, R, PR, E, RO> extends RequestType<P, R, E> i
 	/**
 	 * Clients must not use this property. It is here to ensure correct typing.
 	 */
+	public readonly __: [PR, _EM] | undefined;
 	public readonly ___: [PR, RO, _EM] | undefined;
 	public readonly ____: [RO, _EM] | undefined;
 	public readonly _pr: PR | undefined;


### PR DESCRIPTION
Fixes #1231