### PR TITLE
Refer to TextDocumentFilter for glob format on pattern field

### DIFF
--- a/protocol/src/common/protocol.ts
+++ b/protocol/src/common/protocol.ts
@@ -127,10 +127,6 @@ import { InlineCompletionClientCapabilities, InlineCompletionOptions, InlineComp
 let __noDynamicImport: LocationLink | undefined;
 
 /**
-**​/*.{ts,js}
-*/
-
-/**
  * A document filter denotes a document by different properties like
  * the {@link TextDocument.languageId language}, the {@link Uri.scheme scheme} of
  * its resource, or a glob-pattern that is applied to the {@link TextDocument.fileName path}.

--- a/protocol/src/common/protocol.ts
+++ b/protocol/src/common/protocol.ts
@@ -150,21 +150,21 @@ export type TextDocumentFilter = {
 	language: string;
 	/** A Uri {@link Uri.scheme scheme}, like `file` or `untitled`. */
 	scheme?: string;
-	/** A glob pattern, like `*.{ts,js}`. */
+	/** A glob pattern, see TextDocumentFilter for examples`. */
 	pattern?: string;
 } | {
 	/** A language id, like `typescript`. */
 	language?: string;
 	/** A Uri {@link Uri.scheme scheme}, like `file` or `untitled`. */
 	scheme: string;
-	/** A glob pattern, like `*.{ts,js}`. */
+	/** A glob pattern, see TextDocumentFilter for examples`. */
 	pattern?: string;
 } | {
 	/** A language id, like `typescript`. */
 	language?: string;
 	/** A Uri {@link Uri.scheme scheme}, like `file` or `untitled`. */
 	scheme?: string;
-	/** A glob pattern, like `*.{ts,js}`. */
+	/** A glob pattern, see TextDocumentFilter for examples`. */
 	pattern: string;
 };
 

--- a/protocol/src/common/protocol.ts
+++ b/protocol/src/common/protocol.ts
@@ -126,6 +126,9 @@ import { InlineCompletionClientCapabilities, InlineCompletionOptions, InlineComp
 // @ts-ignore: to avoid inlining LocationLink as dynamic import
 let __noDynamicImport: LocationLink | undefined;
 
+/**
+**​/*.{ts,js}
+*/
 
 /**
  * A document filter denotes a document by different properties like
@@ -150,21 +153,21 @@ export type TextDocumentFilter = {
 	language: string;
 	/** A Uri {@link Uri.scheme scheme}, like `file` or `untitled`. */
 	scheme?: string;
-	/** A glob pattern, see TextDocumentFilter for examples`. */
+	/** A glob pattern, like **​/*.{ts,js}. See TextDocumentFilter for examples`. */
 	pattern?: string;
 } | {
 	/** A language id, like `typescript`. */
 	language?: string;
 	/** A Uri {@link Uri.scheme scheme}, like `file` or `untitled`. */
 	scheme: string;
-	/** A glob pattern, see TextDocumentFilter for examples`. */
+	/** A glob pattern, like **​/*.{ts,js}. See TextDocumentFilter for examples`. */
 	pattern?: string;
 } | {
 	/** A language id, like `typescript`. */
 	language?: string;
 	/** A Uri {@link Uri.scheme scheme}, like `file` or `untitled`. */
 	scheme?: string;
-	/** A glob pattern, see TextDocumentFilter for examples`. */
+	/** A glob pattern, like **​/*.{ts,js}. See TextDocumentFilter for examples`. */
 	pattern: string;
 };
 


### PR DESCRIPTION
The existing example led me to incorrectly try something like`*.{ts,js}`, which won't ever match anything: it's `**/*.{ts,js}`.

I updated with the more useful example (though note, just like the comment above, I had to insert a nbsp because JS grammar).