### PR TITLE
Fixes #1279: Links in the metaModel description sometimes uses markdown style

### DIFF
--- a/protocol/metaModel.json
+++ b/protocol/metaModel.json
@@ -53,7 +53,7 @@
 				"kind": "reference",
 				"name": "ImplementationRegistrationOptions"
 			},
-			"documentation": "A request to resolve the implementation locations of a symbol at a given text\ndocument position. The request's parameter is of type [TextDocumentPositionParams]\n(#TextDocumentPositionParams) the response is of type {@link Definition} or a\nThenable that resolves to such."
+			"documentation": "A request to resolve the implementation locations of a symbol at a given text\ndocument position. The request's parameter is of type {@link TextDocumentPositionParams}\nthe response is of type {@link Definition} or a Thenable that resolves to such."
 		},
 		{
 			"method": "textDocument/typeDefinition",
@@ -105,7 +105,7 @@
 				"kind": "reference",
 				"name": "TypeDefinitionRegistrationOptions"
 			},
-			"documentation": "A request to resolve the type definition locations of a symbol at a given text\ndocument position. The request's parameter is of type [TextDocumentPositionParams]\n(#TextDocumentPositionParams) the response is of type {@link Definition} or a\nThenable that resolves to such."
+			"documentation": "A request to resolve the type definition locations of a symbol at a given text\ndocument position. The request's parameter is of type {@link TextDocumentPositionParams}\nthe response is of type {@link Definition} or a Thenable that resolves to such."
 		},
 		{
 			"method": "workspace/workspaceFolders",
@@ -293,7 +293,7 @@
 				"kind": "reference",
 				"name": "DeclarationRegistrationOptions"
 			},
-			"documentation": "A request to resolve the type definition locations of a symbol at a given text\ndocument position. The request's parameter is of type [TextDocumentPositionParams]\n(#TextDocumentPositionParams) the response is of type {@link Declaration}\nor a typed array of {@link DeclarationLink} or a Thenable that resolves\nto such."
+			"documentation": "A request to resolve the type definition locations of a symbol at a given text\ndocument position. The request's parameter is of type {@link TextDocumentPositionParams}\nthe response is of type {@link Declaration} or a typed array of {@link DeclarationLink}\nor a Thenable that resolves to such."
 		},
 		{
 			"method": "textDocument/selectionRange",
@@ -1274,7 +1274,7 @@
 				"kind": "reference",
 				"name": "DefinitionRegistrationOptions"
 			},
-			"documentation": "A request to resolve the definition location of a symbol at a given text\ndocument position. The request's parameter is of type [TextDocumentPosition]\n(#TextDocumentPosition) the response is of either type {@link Definition}\nor a typed array of {@link DefinitionLink} or a Thenable that resolves\nto such."
+			"documentation": "A request to resolve the definition location of a symbol at a given text\ndocument position. The request's parameter is of type {@link TextDocumentPosition}\nthe response is of either type {@link Definition} or a typed array of\n{@link DefinitionLink} or a Thenable that resolves to such."
 		},
 		{
 			"method": "textDocument/references",
@@ -1346,7 +1346,7 @@
 				"kind": "reference",
 				"name": "DocumentHighlightRegistrationOptions"
 			},
-			"documentation": "Request to resolve a {@link DocumentHighlight} for a given\ntext document position. The request's parameter is of type [TextDocumentPosition]\n(#TextDocumentPosition) the request response is of type [DocumentHighlight[]]\n(#DocumentHighlight) or a Thenable that resolves to such."
+			"documentation": "Request to resolve a {@link DocumentHighlight} for a given\ntext document position. The request's parameter is of type {@link TextDocumentPosition}\nthe request response is an array of type {@link DocumentHighlight}\nor a Thenable that resolves to such."
 		},
 		{
 			"method": "textDocument/documentSymbol",
@@ -5818,7 +5818,7 @@
 						"name": "LSPAny"
 					},
 					"optional": true,
-					"documentation": "A data entry field that is preserved on a code lens item between\na {@link CodeLensRequest} and a [CodeLensResolveRequest]\n(#CodeLensResolveRequest)"
+					"documentation": "A data entry field that is preserved on a code lens item between\na {@link CodeLensRequest} and a {@link CodeLensResolveRequest}"
 				}
 			],
 			"documentation": "A code lens represents a {@link Command command} that should be shown along with\nsource text, like the number of references, a way to run tests, etc.\n\nA code lens is _unresolved_ when no command is associated to it. For performance\nreasons the creation of a code lens and resolving should be done in two stages."
@@ -6754,7 +6754,7 @@
 					"documentation": "Character offset on a line in a document (zero-based).\n\nThe meaning of this offset is determined by the negotiated\n`PositionEncodingKind`.\n\nIf the character value is greater than the line length it defaults back to the\nline length."
 				}
 			],
-			"documentation": "Position in a text document expressed as zero-based line and character\noffset. Prior to 3.17 the offsets were always based on a UTF-16 string\nrepresentation. So a string of the form `a𐐀b` the character offset of the\ncharacter `a` is 0, the character offset of `𐐀` is 1 and the character\noffset of b is 3 since `𐐀` is represented using two code units in UTF-16.\nSince 3.17 clients and servers can agree on a different string encoding\nrepresentation (e.g. UTF-8). The client announces it's supported encoding\nvia the client capability [`general.positionEncodings`](#clientCapabilities).\nThe value is an array of position encodings the client supports, with\ndecreasing preference (e.g. the encoding at index `0` is the most preferred\none). To stay backwards compatible the only mandatory encoding is UTF-16\nrepresented via the string `utf-16`. The server can pick one of the\nencodings offered by the client and signals that encoding back to the\nclient via the initialize result's property\n[`capabilities.positionEncoding`](#serverCapabilities). If the string value\n`utf-16` is missing from the client's capability `general.positionEncodings`\nservers can safely assume that the client supports UTF-16. If the server\nomits the position encoding in its initialize result the encoding defaults\nto the string value `utf-16`. Implementation considerations: since the\nconversion from one encoding into another requires the content of the\nfile / line the conversion is best done where the file is read which is\nusually on the server side.\n\nPositions are line end character agnostic. So you can not specify a position\nthat denotes `\\r|\\n` or `\\n|` where `|` represents the character offset.\n\n@since 3.17.0 - support for negotiated position encoding.",
+			"documentation": "Position in a text document expressed as zero-based line and character\noffset. Prior to 3.17 the offsets were always based on a UTF-16 string\nrepresentation. So a string of the form `a𐐀b` the character offset of the\ncharacter `a` is 0, the character offset of `𐐀` is 1 and the character\noffset of b is 3 since `𐐀` is represented using two code units in UTF-16.\nSince 3.17 clients and servers can agree on a different string encoding\nrepresentation (e.g. UTF-8). The client announces it's supported encoding\nvia the client capability [`general.positionEncodings`](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#clientCapabilities).\nThe value is an array of position encodings the client supports, with\ndecreasing preference (e.g. the encoding at index `0` is the most preferred\none). To stay backwards compatible the only mandatory encoding is UTF-16\nrepresented via the string `utf-16`. The server can pick one of the\nencodings offered by the client and signals that encoding back to the\nclient via the initialize result's property\n[`capabilities.positionEncoding`](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#serverCapabilities). If the string value\n`utf-16` is missing from the client's capability `general.positionEncodings`\nservers can safely assume that the client supports UTF-16. If the server\nomits the position encoding in its initialize result the encoding defaults\nto the string value `utf-16`. Implementation considerations: since the\nconversion from one encoding into another requires the content of the\nfile / line the conversion is best done where the file is read which is\nusually on the server side.\n\nPositions are line end character agnostic. So you can not specify a position\nthat denotes `\\r|\\n` or `\\n|` where `|` represents the character offset.\n\n@since 3.17.0 - support for negotiated position encoding.",
 			"since": "3.17.0 - support for negotiated position encoding."
 		},
 		{
@@ -14590,7 +14590,7 @@
 										"name": "string"
 									},
 									"optional": true,
-									"documentation": "A glob pattern, like `*.{ts,js}`."
+									"documentation": "A glob pattern, like **​/*.{ts,js}. See TextDocumentFilter for examples`."
 								}
 							]
 						}
@@ -14623,7 +14623,7 @@
 										"name": "string"
 									},
 									"optional": true,
-									"documentation": "A glob pattern, like `*.{ts,js}`."
+									"documentation": "A glob pattern, like **​/*.{ts,js}. See TextDocumentFilter for examples`."
 								}
 							]
 						}
@@ -14656,7 +14656,7 @@
 										"kind": "base",
 										"name": "string"
 									},
-									"documentation": "A glob pattern, like `*.{ts,js}`."
+									"documentation": "A glob pattern, like **​/*.{ts,js}. See TextDocumentFilter for examples`."
 								}
 							]
 						}

--- a/protocol/src/common/protocol.declaration.ts
+++ b/protocol/src/common/protocol.declaration.ts
@@ -43,10 +43,9 @@ export interface DeclarationParams extends TextDocumentPositionParams, WorkDoneP
 
 /**
  * A request to resolve the type definition locations of a symbol at a given text
- * document position. The request's parameter is of type [TextDocumentPositionParams]
- * (#TextDocumentPositionParams) the response is of type {@link Declaration}
- * or a typed array of {@link DeclarationLink} or a Thenable that resolves
- * to such.
+ * document position. The request's parameter is of type {@link TextDocumentPositionParams}
+ * the response is of type {@link Declaration} or a typed array of {@link DeclarationLink}
+ * or a Thenable that resolves to such.
  */
 export namespace DeclarationRequest {
 	export const method: 'textDocument/declaration' = 'textDocument/declaration';

--- a/protocol/src/common/protocol.implementation.ts
+++ b/protocol/src/common/protocol.implementation.ts
@@ -45,9 +45,8 @@ export interface ImplementationParams extends TextDocumentPositionParams, WorkDo
 
 /**
  * A request to resolve the implementation locations of a symbol at a given text
- * document position. The request's parameter is of type [TextDocumentPositionParams]
- * (#TextDocumentPositionParams) the response is of type {@link Definition} or a
- * Thenable that resolves to such.
+ * document position. The request's parameter is of type {@link TextDocumentPositionParams}
+ * the response is of type {@link Definition} or a Thenable that resolves to such.
  */
 export namespace ImplementationRequest {
 	export const method: 'textDocument/implementation' = 'textDocument/implementation';

--- a/protocol/src/common/protocol.ts
+++ b/protocol/src/common/protocol.ts
@@ -2761,10 +2761,9 @@ export interface DefinitionRegistrationOptions extends TextDocumentRegistrationO
 
 /**
  * A request to resolve the definition location of a symbol at a given text
- * document position. The request's parameter is of type [TextDocumentPosition]
- * (#TextDocumentPosition) the response is of either type {@link Definition}
- * or a typed array of {@link DefinitionLink} or a Thenable that resolves
- * to such.
+ * document position. The request's parameter is of type {@link TextDocumentPosition}
+ * the response is of either type {@link Definition} or a typed array of
+ * {@link DefinitionLink} or a Thenable that resolves to such.
  */
 export namespace DefinitionRequest {
 	export const method: 'textDocument/definition' = 'textDocument/definition';
@@ -2847,9 +2846,9 @@ export interface DocumentHighlightRegistrationOptions extends TextDocumentRegist
 
 /**
  * Request to resolve a {@link DocumentHighlight} for a given
- * text document position. The request's parameter is of type [TextDocumentPosition]
- * (#TextDocumentPosition) the request response is of type [DocumentHighlight[]]
- * (#DocumentHighlight) or a Thenable that resolves to such.
+ * text document position. The request's parameter is of type {@link TextDocumentPosition}
+ * the request response is an array of type {@link DocumentHighlight}
+ * or a Thenable that resolves to such.
  */
 export namespace DocumentHighlightRequest {
 	export const method: 'textDocument/documentHighlight' = 'textDocument/documentHighlight';

--- a/protocol/src/common/protocol.typeDefinition.ts
+++ b/protocol/src/common/protocol.typeDefinition.ts
@@ -45,9 +45,8 @@ export interface TypeDefinitionParams extends TextDocumentPositionParams, WorkDo
 
 /**
  * A request to resolve the type definition locations of a symbol at a given text
- * document position. The request's parameter is of type [TextDocumentPositionParams]
- * (#TextDocumentPositionParams) the response is of type {@link Definition} or a
- * Thenable that resolves to such.
+ * document position. The request's parameter is of type {@link TextDocumentPositionParams}
+ * the response is of type {@link Definition} or a Thenable that resolves to such.
  */
 export namespace TypeDefinitionRequest {
 	export const method: 'textDocument/typeDefinition' = 'textDocument/typeDefinition';

--- a/types/src/main.ts
+++ b/types/src/main.ts
@@ -99,14 +99,14 @@ export type LSPArray = any[];
  * offset of b is 3 since `𐐀` is represented using two code units in UTF-16.
  * Since 3.17 clients and servers can agree on a different string encoding
  * representation (e.g. UTF-8). The client announces it's supported encoding
- * via the client capability [`general.positionEncodings`](#clientCapabilities).
+ * via the client capability [`general.positionEncodings`](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#clientCapabilities).
  * The value is an array of position encodings the client supports, with
  * decreasing preference (e.g. the encoding at index `0` is the most preferred
  * one). To stay backwards compatible the only mandatory encoding is UTF-16
  * represented via the string `utf-16`. The server can pick one of the
  * encodings offered by the client and signals that encoding back to the
  * client via the initialize result's property
- * [`capabilities.positionEncoding`](#serverCapabilities). If the string value
+ * [`capabilities.positionEncoding`](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#serverCapabilities). If the string value
  * `utf-16` is missing from the client's capability `general.positionEncodings`
  * servers can safely assume that the client supports UTF-16. If the server
  * omits the position encoding in its initialize result the encoding defaults
@@ -3288,8 +3288,7 @@ export interface CodeLens {
 
 	/**
 	 * A data entry field that is preserved on a code lens item between
-	 * a {@link CodeLensRequest} and a [CodeLensResolveRequest]
-	 * (#CodeLensResolveRequest)
+	 * a {@link CodeLensRequest} and a {@link CodeLensResolveRequest}
 	 */
 	data?: LSPAny;
 }


### PR DESCRIPTION
Fixes #1279