### PR TITLE
Fixes #1293: metamodel documentation strings contains unmatched back-ticks

### DIFF
--- a/protocol/metaModel.json
+++ b/protocol/metaModel.json
@@ -14590,7 +14590,7 @@
 										"name": "string"
 									},
 									"optional": true,
-									"documentation": "A glob pattern, like **​/*.{ts,js}. See TextDocumentFilter for examples`."
+									"documentation": "A glob pattern, like **​/*.{ts,js}. See TextDocumentFilter for examples."
 								}
 							]
 						}
@@ -14623,7 +14623,7 @@
 										"name": "string"
 									},
 									"optional": true,
-									"documentation": "A glob pattern, like **​/*.{ts,js}. See TextDocumentFilter for examples`."
+									"documentation": "A glob pattern, like **​/*.{ts,js}. See TextDocumentFilter for examples."
 								}
 							]
 						}
@@ -14656,7 +14656,7 @@
 										"kind": "base",
 										"name": "string"
 									},
-									"documentation": "A glob pattern, like **​/*.{ts,js}. See TextDocumentFilter for examples`."
+									"documentation": "A glob pattern, like **​/*.{ts,js}. See TextDocumentFilter for examples."
 								}
 							]
 						}

--- a/protocol/src/common/protocol.ts
+++ b/protocol/src/common/protocol.ts
@@ -149,21 +149,21 @@ export type TextDocumentFilter = {
 	language: string;
 	/** A Uri {@link Uri.scheme scheme}, like `file` or `untitled`. */
 	scheme?: string;
-	/** A glob pattern, like **​/*.{ts,js}. See TextDocumentFilter for examples`. */
+	/** A glob pattern, like **​/*.{ts,js}. See TextDocumentFilter for examples. */
 	pattern?: string;
 } | {
 	/** A language id, like `typescript`. */
 	language?: string;
 	/** A Uri {@link Uri.scheme scheme}, like `file` or `untitled`. */
 	scheme: string;
-	/** A glob pattern, like **​/*.{ts,js}. See TextDocumentFilter for examples`. */
+	/** A glob pattern, like **​/*.{ts,js}. See TextDocumentFilter for examples. */
 	pattern?: string;
 } | {
 	/** A language id, like `typescript`. */
 	language?: string;
 	/** A Uri {@link Uri.scheme scheme}, like `file` or `untitled`. */
 	scheme?: string;
-	/** A glob pattern, like **​/*.{ts,js}. See TextDocumentFilter for examples`. */
+	/** A glob pattern, like **​/*.{ts,js}. See TextDocumentFilter for examples. */
 	pattern: string;
 };
 


### PR DESCRIPTION
Fixes #1293