### PR TITLE
Add the workspace/foldingRange/refresh method

### DIFF
--- a/client/src/common/foldingRange.ts
+++ b/client/src/common/foldingRange.ts
@@ -40,7 +40,7 @@ export class FoldingRangeFeature extends TextDocumentLanguageFeature<boolean | F
 		capability.lineFoldingOnly = true;
 		capability.foldingRangeKind = { valueSet: [ FoldingRangeKind.Comment, FoldingRangeKind.Imports, FoldingRangeKind.Region ] };
 		capability.foldingRange = { collapsedText: false };
-		capability.refreshSupport = true;
+		ensure(ensure(capabilities, 'workspace')!, 'foldingRange')!.refreshSupport = true;
 	}
 
 	public initialize(capabilities: ServerCapabilities, documentSelector: DocumentSelector): void {

--- a/client/src/common/foldingRange.ts
+++ b/client/src/common/foldingRange.ts
@@ -4,12 +4,12 @@
  * ------------------------------------------------------------------------------------------ */
 
 import {
-	languages as Languages, Disposable, TextDocument, ProviderResult, FoldingRange as VFoldingRange, FoldingContext, FoldingRangeProvider
+	languages as Languages, Disposable, TextDocument, ProviderResult, FoldingRange as VFoldingRange, FoldingContext, FoldingRangeProvider, EventEmitter
 } from 'vscode';
 
 import {
 	ClientCapabilities, CancellationToken, ServerCapabilities, DocumentSelector, FoldingRangeRequest, FoldingRangeParams,
-	FoldingRangeRegistrationOptions, FoldingRangeOptions, FoldingRangeKind
+	FoldingRangeRegistrationOptions, FoldingRangeOptions, FoldingRangeKind, FoldingRangeRefreshRequest
 } from 'vscode-languageserver-protocol';
 
 import { TextDocumentLanguageFeature, FeatureClient, ensure } from './features';
@@ -22,7 +22,12 @@ export interface FoldingRangeProviderMiddleware {
 	provideFoldingRanges?: (this: void, document: TextDocument, context: FoldingContext, token: CancellationToken, next: ProvideFoldingRangeSignature) => ProviderResult<VFoldingRange[]>;
 }
 
-export class FoldingRangeFeature extends TextDocumentLanguageFeature<boolean | FoldingRangeOptions, FoldingRangeRegistrationOptions, FoldingRangeProvider, FoldingRangeProviderMiddleware> {
+export type FoldingRangeProviderShape = {
+	provider: FoldingRangeProvider;
+	onDidChangeFoldingRange: EventEmitter<void>;
+};
+
+export class FoldingRangeFeature extends TextDocumentLanguageFeature<boolean | FoldingRangeOptions, FoldingRangeRegistrationOptions, FoldingRangeProviderShape, FoldingRangeProviderMiddleware> {
 
 	constructor(client: FeatureClient<FoldingRangeProviderMiddleware>) {
 		super(client, FoldingRangeRequest.type);
@@ -35,9 +40,16 @@ export class FoldingRangeFeature extends TextDocumentLanguageFeature<boolean | F
 		capability.lineFoldingOnly = true;
 		capability.foldingRangeKind = { valueSet: [ FoldingRangeKind.Comment, FoldingRangeKind.Imports, FoldingRangeKind.Region ] };
 		capability.foldingRange = { collapsedText: false };
+		capability.refreshSupport = true;
 	}
 
 	public initialize(capabilities: ServerCapabilities, documentSelector: DocumentSelector): void {
+		this._client.onRequest(FoldingRangeRefreshRequest.type, async () => {
+			for (const provider of this.getAllProviders()) {
+				provider.onDidChangeFoldingRange.fire();
+			}
+		});
+
 		let [id, options] = this.getRegistration(documentSelector, capabilities.foldingRangeProvider);
 		if (!id || !options) {
 			return;
@@ -45,9 +57,11 @@ export class FoldingRangeFeature extends TextDocumentLanguageFeature<boolean | F
 		this.register({ id: id, registerOptions: options });
 	}
 
-	protected registerLanguageProvider(options: FoldingRangeRegistrationOptions): [Disposable, FoldingRangeProvider] {
+	protected registerLanguageProvider(options: FoldingRangeRegistrationOptions): [Disposable, FoldingRangeProviderShape] {
 		const selector = options.documentSelector!;
+		const eventEmitter: EventEmitter<void> = new EventEmitter<void>();
 		const provider: FoldingRangeProvider = {
+			onDidChangeFoldingRanges: eventEmitter.event,
 			provideFoldingRanges: (document, context, token) => {
 				const client = this._client;
 				const provideFoldingRanges: ProvideFoldingRangeSignature = (document, _, token) => {
@@ -69,6 +83,6 @@ export class FoldingRangeFeature extends TextDocumentLanguageFeature<boolean | F
 					: provideFoldingRanges(document, context, token);
 			}
 		};
-		return [Languages.registerFoldingRangeProvider(this._client.protocol2CodeConverter.asDocumentSelector(selector), provider), provider];
+		return [Languages.registerFoldingRangeProvider(this._client.protocol2CodeConverter.asDocumentSelector(selector), provider), { provider: provider, onDidChangeFoldingRange: eventEmitter }];
 	}
 }

--- a/protocol/metaModel.json
+++ b/protocol/metaModel.json
@@ -10681,6 +10681,17 @@
 					"optional": true,
 					"documentation": "Capabilities specific to the diagnostic requests scoped to the\nworkspace.\n\n@since 3.17.0.",
 					"since": "3.17.0."
+				},
+				{
+					"name": "foldingRange",
+					"type": {
+						"kind": "reference",
+						"name": "FoldingRangeWorkspaceClientCapabilities"
+					},
+					"optional": true,
+					"documentation": "Capabilities specific to the folding range requests scoped to the workspace.\n\n@since 3.18.0\n@proposed",
+					"since": "3.18.0",
+					"proposed": true
 				}
 			],
 			"documentation": "Workspace specific client capabilities."
@@ -11499,6 +11510,25 @@
 			],
 			"documentation": "Workspace client capabilities specific to diagnostic pull requests.\n\n@since 3.17.0",
 			"since": "3.17.0"
+		},
+		{
+			"name": "FoldingRangeWorkspaceClientCapabilities",
+			"properties": [
+				{
+					"name": "refreshSupport",
+					"type": {
+						"kind": "base",
+						"name": "boolean"
+					},
+					"optional": true,
+					"documentation": "Whether the client implementation supports a refresh request sent from the\nserver to the client.\n\nNote that this event is global and will force the client to refresh all\nfolding ranges currently shown. It should be used with absolute care and is\nuseful for situation where a server for example detects a project wide\nchange that requires such a calculation.\n\n@since 3.18.0\n@proposed",
+					"since": "3.18.0",
+					"proposed": true
+				}
+			],
+			"documentation": "Client workspace capabilities specific to folding ranges\n\n@since 3.18.0\n@proposed",
+			"since": "3.18.0",
+			"proposed": true
 		},
 		{
 			"name": "TextDocumentSyncClientCapabilities",
@@ -12439,17 +12469,6 @@
 					"optional": true,
 					"documentation": "Specific options for the folding range.\n\n@since 3.17.0",
 					"since": "3.17.0"
-				},
-				{
-					"name": "refreshSupport",
-					"type": {
-						"kind": "base",
-						"name": "boolean"
-					},
-					"optional": true,
-					"documentation": "Whether the client implementation supports a refresh request sent from the\nserver to the client.\n\nNote that this event is global and will force the client to refresh all\nfolding ranges currently shown. It should be used with absolute care and is\nuseful for situation where a server for example detects a project wide\nchange that requires such a calculation.\n\n@since 3.18.0\n@proposed",
-					"since": "3.18.0",
-					"proposed": true
 				}
 			]
 		},

--- a/protocol/metaModel.json
+++ b/protocol/metaModel.json
@@ -244,6 +244,16 @@
 			"documentation": "A request to provide folding ranges in a document. The request's\nparameter is of type {@link FoldingRangeParams}, the\nresponse is of type {@link FoldingRangeList} or a Thenable\nthat resolves to such."
 		},
 		{
+			"method": "workspace/foldingRange/refresh",
+			"result": {
+				"kind": "base",
+				"name": "null"
+			},
+			"messageDirection": "serverToClient",
+			"documentation": "@since 3.18.0",
+			"since": "3.18.0"
+		},
+		{
 			"method": "textDocument/declaration",
 			"result": {
 				"kind": "or",
@@ -12428,6 +12438,16 @@
 					"optional": true,
 					"documentation": "Specific options for the folding range.\n\n@since 3.17.0",
 					"since": "3.17.0"
+				},
+				{
+					"name": "refreshSupport",
+					"type": {
+						"kind": "base",
+						"name": "boolean"
+					},
+					"optional": true,
+					"documentation": "Whether the client implementation supports a refresh request sent from the\nserver to the client.\n\nNote that this event is global and will force the client to refresh all\nfolding ranges currently shown. It should be used with absolute care and is\nuseful for situation where a server for example detects a project wide\nchange that requires such a calculation.\n\n@since 3.18.0",
+					"since": "3.18.0"
 				}
 			]
 		},

--- a/protocol/metaModel.json
+++ b/protocol/metaModel.json
@@ -250,8 +250,9 @@
 				"name": "null"
 			},
 			"messageDirection": "serverToClient",
-			"documentation": "@since 3.18.0",
-			"since": "3.18.0"
+			"documentation": "@since 3.18.0\n@proposed",
+			"since": "3.18.0",
+			"proposed": true
 		},
 		{
 			"method": "textDocument/declaration",
@@ -12446,8 +12447,9 @@
 						"name": "boolean"
 					},
 					"optional": true,
-					"documentation": "Whether the client implementation supports a refresh request sent from the\nserver to the client.\n\nNote that this event is global and will force the client to refresh all\nfolding ranges currently shown. It should be used with absolute care and is\nuseful for situation where a server for example detects a project wide\nchange that requires such a calculation.\n\n@since 3.18.0",
-					"since": "3.18.0"
+					"documentation": "Whether the client implementation supports a refresh request sent from the\nserver to the client.\n\nNote that this event is global and will force the client to refresh all\nfolding ranges currently shown. It should be used with absolute care and is\nuseful for situation where a server for example detects a project wide\nchange that requires such a calculation.\n\n@since 3.18.0\n@proposed",
+					"since": "3.18.0",
+					"proposed": true
 				}
 			]
 		},

--- a/protocol/src/common/protocol.foldingRange.ts
+++ b/protocol/src/common/protocol.foldingRange.ts
@@ -77,6 +77,7 @@ export interface FoldingRangeClientCapabilities {
 	 * change that requires such a calculation.
 	 *
 	 * @since 3.18.0
+	 * @proposed
 	 */
 	refreshSupport?: boolean;
 }
@@ -112,6 +113,7 @@ export namespace FoldingRangeRequest {
 
 /**
  * @since 3.18.0
+ * @proposed
  */
 export namespace FoldingRangeRefreshRequest {
 	export const method: `workspace/foldingRange/refresh` = `workspace/foldingRange/refresh`;

--- a/protocol/src/common/protocol.foldingRange.ts
+++ b/protocol/src/common/protocol.foldingRange.ts
@@ -66,6 +66,15 @@ export interface FoldingRangeClientCapabilities {
 		*/
 		collapsedText?: boolean;
 	};
+}
+
+/**
+ * Client workspace capabilities specific to folding ranges
+ *
+ * @since 3.18.0
+ * @proposed
+ */
+export interface FoldingRangeWorkspaceClientCapabilities {
 
 	/**
 	 * Whether the client implementation supports a refresh request sent from the

--- a/protocol/src/common/protocol.foldingRange.ts
+++ b/protocol/src/common/protocol.foldingRange.ts
@@ -3,10 +3,10 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { RequestHandler } from 'vscode-jsonrpc';
+import { RequestHandler, RequestHandler0 } from 'vscode-jsonrpc';
 import { TextDocumentIdentifier, uinteger, FoldingRange, FoldingRangeKind } from 'vscode-languageserver-types';
 
-import { MessageDirection, ProtocolRequestType } from './messages';
+import { MessageDirection, ProtocolRequestType, ProtocolRequestType0 } from './messages';
 import type {
 	TextDocumentRegistrationOptions, StaticRegistrationOptions, PartialResultParams, WorkDoneProgressParams, WorkDoneProgressOptions
 } from './protocol';
@@ -66,6 +66,19 @@ export interface FoldingRangeClientCapabilities {
 		*/
 		collapsedText?: boolean;
 	};
+
+	/**
+	 * Whether the client implementation supports a refresh request sent from the
+	 * server to the client.
+	 *
+	 * Note that this event is global and will force the client to refresh all
+	 * folding ranges currently shown. It should be used with absolute care and is
+	 * useful for situation where a server for example detects a project wide
+	 * change that requires such a calculation.
+	 *
+	 * @since 3.18.0
+	 */
+	refreshSupport?: boolean;
 }
 
 export interface FoldingRangeOptions extends WorkDoneProgressOptions {
@@ -95,4 +108,14 @@ export namespace FoldingRangeRequest {
 	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
 	export const type = new ProtocolRequestType<FoldingRangeParams, FoldingRange[] | null, FoldingRange[], void, FoldingRangeRegistrationOptions>(method);
 	export type HandlerSignature = RequestHandler<FoldingRangeParams, FoldingRange[] | null, void>;
+}
+
+/**
+ * @since 3.18.0
+ */
+export namespace FoldingRangeRefreshRequest {
+	export const method: `workspace/foldingRange/refresh` = `workspace/foldingRange/refresh`;
+	export const messageDirection: MessageDirection = MessageDirection.serverToClient;
+	export const type = new ProtocolRequestType0<void, void, void, void>(method);
+	export type HandlerSignature = RequestHandler0<void, void>;
 }

--- a/protocol/src/common/protocol.ts
+++ b/protocol/src/common/protocol.ts
@@ -43,7 +43,7 @@ import {
 } from './protocol.colorProvider';
 
 import {
-	FoldingRangeClientCapabilities, FoldingRangeOptions, FoldingRangeRequest, FoldingRangeParams, FoldingRangeRegistrationOptions, FoldingRangeRefreshRequest
+	FoldingRangeClientCapabilities, FoldingRangeOptions, FoldingRangeRequest, FoldingRangeParams, FoldingRangeRegistrationOptions, FoldingRangeRefreshRequest, FoldingRangeWorkspaceClientCapabilities
 } from './protocol.foldingRange';
 
 import {
@@ -556,6 +556,14 @@ export interface WorkspaceClientCapabilities {
 	 * @since 3.17.0.
 	 */
 	diagnostics?: DiagnosticWorkspaceClientCapabilities;
+
+	/**
+	 * Capabilities specific to the folding range requests scoped to the workspace.
+	 *
+	 * @since 3.18.0
+	 * @proposed
+	 */
+	foldingRange?: FoldingRangeWorkspaceClientCapabilities;
 }
 
 /**

--- a/protocol/src/common/protocol.ts
+++ b/protocol/src/common/protocol.ts
@@ -43,7 +43,7 @@ import {
 } from './protocol.colorProvider';
 
 import {
-	FoldingRangeClientCapabilities, FoldingRangeOptions, FoldingRangeRequest, FoldingRangeParams, FoldingRangeRegistrationOptions
+	FoldingRangeClientCapabilities, FoldingRangeOptions, FoldingRangeRequest, FoldingRangeParams, FoldingRangeRegistrationOptions, FoldingRangeRefreshRequest
 } from './protocol.foldingRange';
 
 import {
@@ -3874,7 +3874,7 @@ export {
 	WorkspaceFoldersRequest, DidChangeWorkspaceFoldersNotification, DidChangeWorkspaceFoldersParams, WorkspaceFoldersChangeEvent,
 	ConfigurationRequest, ConfigurationParams, ConfigurationItem,
 	DocumentColorRequest, ColorPresentationRequest, DocumentColorOptions, DocumentColorParams, ColorPresentationParams, DocumentColorRegistrationOptions,
-	FoldingRangeClientCapabilities, FoldingRangeOptions, FoldingRangeRequest, FoldingRangeParams, FoldingRangeRegistrationOptions,
+	FoldingRangeClientCapabilities, FoldingRangeOptions, FoldingRangeRequest, FoldingRangeParams, FoldingRangeRegistrationOptions, FoldingRangeRefreshRequest,
 	DeclarationClientCapabilities, DeclarationRequest, DeclarationParams, DeclarationRegistrationOptions, DeclarationOptions,
 	SelectionRangeClientCapabilities, SelectionRangeOptions, SelectionRangeParams, SelectionRangeRequest, SelectionRangeRegistrationOptions,
 	WorkDoneProgressBegin, WorkDoneProgressReport, WorkDoneProgressEnd, WorkDoneProgress, WorkDoneProgressCreateParams,

--- a/server/src/common/foldingRange.ts
+++ b/server/src/common/foldingRange.ts
@@ -17,6 +17,7 @@ export interface FoldingRangeFeatureShape {
 		 * Ask the client to refresh all folding ranges
 		 *
 		 * @since 3.18.0.
+		 * @proposed
 		 */
 		refresh(): Promise<void>;
 

--- a/server/src/common/foldingRange.ts
+++ b/server/src/common/foldingRange.ts
@@ -1,0 +1,48 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+'use strict';
+
+import { FoldingRange, Disposable, FoldingRangeParams, FoldingRangeRefreshRequest, FoldingRangeRequest } from 'vscode-languageserver-protocol';
+
+import type { Feature, _Languages, ServerRequestHandler } from './server';
+
+/**
+ * Shape of the folding range feature
+ */
+export interface FoldingRangeFeatureShape {
+	foldingRange: {
+		/**
+		 * Ask the client to refresh all folding ranges
+		 *
+		 * @since 3.18.0.
+		 */
+		refresh(): Promise<void>;
+
+		/**
+		 * Installs a handler for the folding range request.
+		 *
+		 * @param handler The corresponding handler.
+		 */
+		on(handler: ServerRequestHandler<FoldingRangeParams, FoldingRange[] | undefined | null, FoldingRange[], void>): Disposable;
+	};
+}
+
+export const FoldingRangeFeature: Feature<_Languages, FoldingRangeFeatureShape> = (Base) => {
+	return class extends Base implements FoldingRangeFeatureShape {
+		public get foldingRange() {
+			return {
+				refresh: (): Promise<void> => {
+					return this.connection.sendRequest(FoldingRangeRefreshRequest.type);
+				},
+				on: (handler: ServerRequestHandler<FoldingRangeParams, FoldingRange[] | undefined | null, FoldingRange[], void>): Disposable => {
+					const type = FoldingRangeRequest.type;
+					return this.connection.onRequest(type, (params, cancel) => {
+						return handler(params, cancel, this.attachWorkDoneProgress(params), this.attachPartialResultProgress(type, params));
+					});
+				}
+			};
+		}
+	};
+};

--- a/server/src/common/server.ts
+++ b/server/src/common/server.ts
@@ -39,6 +39,7 @@ import { FileOperationsFeature, FileOperationsFeatureShape } from './fileOperati
 import { LinkedEditingRangeFeature, LinkedEditingRangeFeatureShape } from './linkedEditingRange';
 import { TypeHierarchyFeatureShape, TypeHierarchyFeature } from './typeHierarchy';
 import { InlineValueFeatureShape, InlineValueFeature } from './inlineValue';
+import { FoldingRangeFeatureShape, FoldingRangeFeature } from './foldingRange';
 // import { InlineCompletionFeatureShape, InlineCompletionFeature } from './inlineCompletion.proposed';
 import { InlayHintFeatureShape, InlayHintFeature } from './inlayHint';
 import { DiagnosticFeatureShape, DiagnosticFeature } from './diagnostic';
@@ -828,8 +829,8 @@ export class _LanguagesImpl implements Remote, _Languages {
 	}
 }
 
-export type Languages = _Languages & CallHierarchy & SemanticTokensFeatureShape & LinkedEditingRangeFeatureShape & TypeHierarchyFeatureShape & InlineValueFeatureShape & InlayHintFeatureShape & DiagnosticFeatureShape & MonikerFeatureShape;
-const LanguagesImpl: new () => Languages = MonikerFeature(DiagnosticFeature(InlayHintFeature(InlineValueFeature(TypeHierarchyFeature(LinkedEditingRangeFeature(SemanticTokensFeature(CallHierarchyFeature(_LanguagesImpl)))))))) as (new () => Languages);
+export type Languages = _Languages & CallHierarchy & SemanticTokensFeatureShape & LinkedEditingRangeFeatureShape & TypeHierarchyFeatureShape & InlineValueFeatureShape & InlayHintFeatureShape & DiagnosticFeatureShape & MonikerFeatureShape & FoldingRangeFeatureShape;
+const LanguagesImpl: new () => Languages = FoldingRangeFeature(MonikerFeature(DiagnosticFeature(InlayHintFeature(InlineValueFeature(TypeHierarchyFeature(LinkedEditingRangeFeature(SemanticTokensFeature(CallHierarchyFeature(_LanguagesImpl))))))))) as (new () => Languages);
 
 export interface _Notebooks extends FeatureBase {
 	connection: Connection;


### PR DESCRIPTION
Relating to #1306

server.ts has `onFoldingRanges` already which I've left alone for backwards compatibility but this PR also adds `languages.foldingRange.on` which should be identical.