### PR TITLE
fix: ensure bundlers pick up esm version

### DIFF
--- a/textDocument/package.json
+++ b/textDocument/package.json
@@ -1,37 +1,38 @@
 {
-	"name": "vscode-languageserver-textdocument",
-	"description": "A simple text document implementation for Node LSP servers",
-	"version": "1.0.10",
-	"author": "Microsoft Corporation",
-	"license": "MIT",
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/Microsoft/vscode-languageserver-node.git",
-		"directory": "textDocument"
-	},
-	"bugs": {
-		"url": "https://github.com/Microsoft/vscode-languageserver-node/issues"
-	},
-	"main": "./lib/umd/main.js",
-	"typings": "./lib/umd/main",
-	"exports": {
-		".": {
-			"import": "./lib/esm/main.js",
-			"default": "./lib/umd/main.js"
-		}
-	},
-	"scripts": {
-		"prepublishOnly": "echo \"⛔ Can only publish from a secure pipeline ⛔\" && node ../build/npm/fail",
-		"prepack": "npm run all:publish",
-		"compile": "node ../build/bin/tsc -b ./tsconfig.json",
-		"clean": "node ../node_modules/.bin/rimraf lib",
-		"watch": "node ../build/bin/tsc -b ./tsconfig.watch.json -w",
-		"lint": "node ../node_modules/eslint/bin/eslint.js --ext ts src",
-		"test": "node ../node_modules/mocha/bin/_mocha",
-		"all": "npm run clean && npm run compile && npm run lint && npm run test",
-		"compile:esm": "node ../build/bin/tsc -b ./tsconfig.esm.publish.json && node ../build/bin/fix-esm",
-		"compile:umd": "node ../build/bin/tsc -b ./tsconfig.umd.publish.json",
-		"all:publish": "git clean -xfd . && npm install && npm run compile:esm && npm run compile:umd && npm run lint && npm run test",
-		"preversion": "npm test"
-	}
+  "name": "vscode-languageserver-textdocument",
+  "description": "A simple text document implementation for Node LSP servers",
+  "version": "1.0.10",
+  "author": "Microsoft Corporation",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Microsoft/vscode-languageserver-node.git",
+    "directory": "textDocument"
+  },
+  "bugs": {
+    "url": "https://github.com/Microsoft/vscode-languageserver-node/issues"
+  },
+  "main": "./lib/umd/main.js",
+  "typings": "./lib/umd/main",
+  "exports": {
+    ".": {
+      "browser": "./lib/esm/main.js",
+      "import": "./lib/esm/main.js",
+      "default": "./lib/umd/main.js"
+    }
+  },
+  "scripts": {
+    "prepublishOnly": "echo \"⛔ Can only publish from a secure pipeline ⛔\" && node ../build/npm/fail",
+    "prepack": "npm run all:publish",
+    "compile": "node ../build/bin/tsc -b ./tsconfig.json",
+    "clean": "node ../node_modules/.bin/rimraf lib",
+    "watch": "node ../build/bin/tsc -b ./tsconfig.watch.json -w",
+    "lint": "node ../node_modules/eslint/bin/eslint.js --ext ts src",
+    "test": "node ../node_modules/mocha/bin/_mocha",
+    "all": "npm run clean && npm run compile && npm run lint && npm run test",
+    "compile:esm": "node ../build/bin/tsc -b ./tsconfig.esm.publish.json && node ../build/bin/fix-esm",
+    "compile:umd": "node ../build/bin/tsc -b ./tsconfig.umd.publish.json",
+    "all:publish": "git clean -xfd . && npm install && npm run compile:esm && npm run compile:umd && npm run lint && npm run test",
+    "preversion": "npm test"
+  }
 }

--- a/textDocument/package.json
+++ b/textDocument/package.json
@@ -1,38 +1,38 @@
 {
-  "name": "vscode-languageserver-textdocument",
-  "description": "A simple text document implementation for Node LSP servers",
-  "version": "1.0.10",
-  "author": "Microsoft Corporation",
-  "license": "MIT",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/Microsoft/vscode-languageserver-node.git",
-    "directory": "textDocument"
-  },
-  "bugs": {
-    "url": "https://github.com/Microsoft/vscode-languageserver-node/issues"
-  },
-  "main": "./lib/umd/main.js",
-  "typings": "./lib/umd/main",
-  "exports": {
-    ".": {
-      "browser": "./lib/esm/main.js",
-      "import": "./lib/esm/main.js",
-      "default": "./lib/umd/main.js"
-    }
-  },
-  "scripts": {
-    "prepublishOnly": "echo \"⛔ Can only publish from a secure pipeline ⛔\" && node ../build/npm/fail",
-    "prepack": "npm run all:publish",
-    "compile": "node ../build/bin/tsc -b ./tsconfig.json",
-    "clean": "node ../node_modules/.bin/rimraf lib",
-    "watch": "node ../build/bin/tsc -b ./tsconfig.watch.json -w",
-    "lint": "node ../node_modules/eslint/bin/eslint.js --ext ts src",
-    "test": "node ../node_modules/mocha/bin/_mocha",
-    "all": "npm run clean && npm run compile && npm run lint && npm run test",
-    "compile:esm": "node ../build/bin/tsc -b ./tsconfig.esm.publish.json && node ../build/bin/fix-esm",
-    "compile:umd": "node ../build/bin/tsc -b ./tsconfig.umd.publish.json",
-    "all:publish": "git clean -xfd . && npm install && npm run compile:esm && npm run compile:umd && npm run lint && npm run test",
-    "preversion": "npm test"
-  }
+	"name": "vscode-languageserver-textdocument",
+	"description": "A simple text document implementation for Node LSP servers",
+	"version": "1.0.10",
+	"author": "Microsoft Corporation",
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/Microsoft/vscode-languageserver-node.git",
+		"directory": "textDocument"
+	},
+	"bugs": {
+		"url": "https://github.com/Microsoft/vscode-languageserver-node/issues"
+	},
+	"main": "./lib/umd/main.js",
+	"typings": "./lib/umd/main",
+	"exports": {
+		".": {
+			"browser": "./lib/esm/main.js",
+			"import": "./lib/esm/main.js",
+			"default": "./lib/umd/main.js"
+		}
+	},
+	"scripts": {
+		"prepublishOnly": "echo \"⛔ Can only publish from a secure pipeline ⛔\" && node ../build/npm/fail",
+		"prepack": "npm run all:publish",
+		"compile": "node ../build/bin/tsc -b ./tsconfig.json",
+		"clean": "node ../node_modules/.bin/rimraf lib",
+		"watch": "node ../build/bin/tsc -b ./tsconfig.watch.json -w",
+		"lint": "node ../node_modules/eslint/bin/eslint.js --ext ts src",
+		"test": "node ../node_modules/mocha/bin/_mocha",
+		"all": "npm run clean && npm run compile && npm run lint && npm run test",
+		"compile:esm": "node ../build/bin/tsc -b ./tsconfig.esm.publish.json && node ../build/bin/fix-esm",
+		"compile:umd": "node ../build/bin/tsc -b ./tsconfig.umd.publish.json",
+		"all:publish": "git clean -xfd . && npm install && npm run compile:esm && npm run compile:umd && npm run lint && npm run test",
+		"preversion": "npm test"
+	}
 }

--- a/types/package.json
+++ b/types/package.json
@@ -16,6 +16,7 @@
 	"typings": "./lib/umd/main",
 	"exports": {
 		".": {
+			"browser": "./lib/esm/main.js",
 			"import": "./lib/esm/main.js",
 			"default": "./lib/umd/main.js"
 		}


### PR DESCRIPTION
up until the addition of "exports", bundlers found the root "module" field and resolved the the esm version.

this change fixes a regression from https://github.com/microsoft/vscode-languageserver-node/pull/1297 where cjs browser consumers now get resolved to the umd, getting a warning about dynamic require.