### PR TITLE
Convert from UMD to CJS

### DIFF
--- a/.tsconfigrc.js
+++ b/.tsconfigrc.js
@@ -35,8 +35,7 @@ const general = {
 	 * rely on webpack to package everything correctly.
 	 */
 	compilerOptions: {
-		module: 'commonjs',
-		moduleResolution: 'node'
+		module: 'nodenext'
 	}
 };
 
@@ -115,7 +114,7 @@ const textDocument = {
 const textDocument_publish = {
 	name: 'textDocument_publish',
 	path: './textDocument',
-	references: [ './tsconfig.esm.publish.json', './tsconfig.umd.publish.json' ]
+	references: [ './tsconfig.esm.publish.json', './tsconfig.cjs.publish.json' ]
 };
 
 
@@ -149,7 +148,7 @@ const types = {
 const types_publish = {
 	name: 'types_publish',
 	path: './types',
-	references: [ './tsconfig.esm.publish.json', './tsconfig.umd.publish.json' ]
+	references: [ './tsconfig.esm.publish.json', './tsconfig.cjs.publish.json' ]
 };
 
 /** @type ProjectDescription */
@@ -414,49 +413,49 @@ const publishProjectOptions = {
 };
 
 /** @type CompilerOptions */
-const umdCompilerOptions = CompilerOptions.assign(defaultCompilerOptions, {
+const cjsCompilerOptions = CompilerOptions.assign(defaultCompilerOptions, {
 	sourceMap: true,
 	noUnusedLocals: true,
 	noUnusedParameters: true,
 	target: 'es5',
-	module: 'umd',
+	module: 'nodenext',
 	lib: [ 'es2015' ],
 });
 
 /** @type ProjectOptions */
-const umdProjectOptions = {
-	tags: ['umd', 'compile'],
+const cjsProjectOptions = {
+	tags: ['cjs', 'compile'],
 	tsconfig: 'tsconfig.json',
-	variables: new Map([['target', 'umd'], ['buildInfoFile', 'compile']]),
-	compilerOptions: umdCompilerOptions
+	variables: new Map([['target', 'cjs'], ['buildInfoFile', 'compile']]),
+	compilerOptions: cjsCompilerOptions
 };
 
 /** @type CompilerOptions */
-const umdWatchCompilerOptions = CompilerOptions.assign(umdCompilerOptions, {
+const cjsWatchCompilerOptions = CompilerOptions.assign(cjsCompilerOptions, {
 	noUnusedLocals: false,
 	noUnusedParameters: false,
 	assumeChangesOnlyAffectDirectDependencies: true,
 });
 
 /** @type ProjectOptions */
-const umdWatchProjectOptions = {
-	tags: ['umd', 'watch'],
+const cjsWatchProjectOptions = {
+	tags: ['cjs', 'watch'],
 	tsconfig: 'tsconfig.watch.json',
-	variables: new Map([['target', 'umd'], ['buildInfoFile', 'watch']]),
-	compilerOptions: umdCompilerOptions
+	variables: new Map([['target', 'cjs'], ['buildInfoFile', 'watch']]),
+	compilerOptions: cjsCompilerOptions
 };
 
 /** @type CompilerOptions */
-const umdPublishCompilerOptions = CompilerOptions.assign(umdCompilerOptions, {
+const cjsPublishCompilerOptions = CompilerOptions.assign(cjsCompilerOptions, {
 	sourceMap: false
 });
 
 /** @type ProjectOptions */
-const umdPublishProjectOptions = {
-	tags: ['umd', 'publish'],
-	tsconfig: 'tsconfig.umd.publish.json',
-	variables: new Map([['target', 'umd'], ['buildInfoFile', 'publish']]),
-	compilerOptions: umdPublishCompilerOptions
+const cjsPublishProjectOptions = {
+	tags: ['cjs', 'publish'],
+	tsconfig: 'tsconfig.cjs.publish.json',
+	variables: new Map([['target', 'cjs'], ['buildInfoFile', 'publish']]),
+	compilerOptions: cjsPublishCompilerOptions
 };
 
 
@@ -464,7 +463,7 @@ const umdPublishProjectOptions = {
 const esmPublishCompilerOptions = CompilerOptions.assign(defaultCompilerOptions, {
 	sourceMap: false,
 	target: 'es5',
-	module: 'es6',
+	module: 'esnext',
 	lib: [ 'es2015' ]
 });
 
@@ -478,9 +477,9 @@ const esmPublishProjectOptions = {
 
 /** @type Projects */
 const projects = [
-	[ textDocument, [ umdProjectOptions, umdWatchProjectOptions, esmPublishProjectOptions, umdPublishProjectOptions ] ],
+	[ textDocument, [ cjsProjectOptions, cjsWatchProjectOptions, esmPublishProjectOptions, cjsPublishProjectOptions ] ],
 	[ textDocument_publish, [ publishProjectOptions ] ],
-	[ types, [ umdProjectOptions, umdWatchProjectOptions, esmPublishProjectOptions, umdPublishProjectOptions ] ],
+	[ types, [ cjsProjectOptions, cjsWatchProjectOptions, esmPublishProjectOptions, cjsPublishProjectOptions ] ],
 	[ types_publish, [ publishProjectOptions ]],
 	[ jsonrpc, [ compileProjectOptions, watchProjectOptions ] ],
 	[ createPublishProjectDescription(jsonrpc), [ publishProjectOptions ] ],

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,7 +13,7 @@
 			"runtimeArgs": [],
 			"env": { },
 			"sourceMaps": true,
-			"outFiles": ["${workspaceRoot}/types/lib/umd/**/*.js"],
+			"outFiles": ["${workspaceRoot}/types/lib/cjs/**/*.js"],
 			"preLaunchTask": "npm: watch"
 		},
 		{
@@ -28,7 +28,7 @@
 			"runtimeArgs": [],
 			"env": { },
 			"sourceMaps": true,
-			"outFiles": ["${workspaceRoot}/textDocument/lib/umd/**/*.js"],
+			"outFiles": ["${workspaceRoot}/textDocument/lib/cjs/**/*.js"],
 			"preLaunchTask": "npm: watch"
 		},
 		{

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -54,8 +54,8 @@
 		"source.fixAll.eslint": true
 	},
 	"mochaExplorer.files": [
-		"textDocument/lib/umd/test/*.js",
-		"types/lib/umd/test/*.js",
+		"textDocument/lib/cjs/test/*.js",
+		"types/lib/cjs/test/*.js",
 		"jsonrpc/lib/common/test/*.js",
 		"jsonrpc/lib/node/test/*.js",
 		"protocol/lib/node/test/*.js",

--- a/client-node-tests/src/index.ts
+++ b/client-node-tests/src/index.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
-import * as Mocha from 'mocha';
-import * as glob from 'glob';
+import Mocha from 'mocha';
+import { glob } from 'glob';
 
 export function run(testsRoot: string, cb: (error: any, failures?: number) => void): void {
 	// Create the mocha test

--- a/client-node-tests/src/tsconfig.json
+++ b/client-node-tests/src/tsconfig.json
@@ -5,8 +5,7 @@
             "vscode",
             "mocha"
         ],
-        "module": "commonjs",
-        "moduleResolution": "node",
+        "module": "nodenext",
         "rootDir": ".",
         "strict": true,
         "noImplicitAny": true,

--- a/client-node-tests/src/tsconfig.publish.json
+++ b/client-node-tests/src/tsconfig.publish.json
@@ -5,8 +5,7 @@
             "vscode",
             "mocha"
         ],
-        "module": "commonjs",
-        "moduleResolution": "node",
+        "module": "nodenext",
         "rootDir": ".",
         "strict": true,
         "noImplicitAny": true,

--- a/client-node-tests/src/tsconfig.watch.json
+++ b/client-node-tests/src/tsconfig.watch.json
@@ -5,8 +5,7 @@
             "vscode",
             "mocha"
         ],
-        "module": "commonjs",
-        "moduleResolution": "node",
+        "module": "nodenext",
         "rootDir": ".",
         "strict": true,
         "noImplicitAny": true,

--- a/client/src/browser/tsconfig.json
+++ b/client/src/browser/tsconfig.json
@@ -3,8 +3,7 @@
         "types": [
             "vscode"
         ],
-        "module": "commonjs",
-        "moduleResolution": "node",
+        "module": "nodenext",
         "rootDir": ".",
         "lib": [
             "es2020",

--- a/client/src/browser/tsconfig.publish.json
+++ b/client/src/browser/tsconfig.publish.json
@@ -3,8 +3,7 @@
         "types": [
             "vscode"
         ],
-        "module": "commonjs",
-        "moduleResolution": "node",
+        "module": "nodenext",
         "rootDir": ".",
         "lib": [
             "es2020",

--- a/client/src/browser/tsconfig.watch.json
+++ b/client/src/browser/tsconfig.watch.json
@@ -3,8 +3,7 @@
         "types": [
             "vscode"
         ],
-        "module": "commonjs",
-        "moduleResolution": "node",
+        "module": "nodenext",
         "rootDir": ".",
         "lib": [
             "es2020",

--- a/client/src/common/tsconfig.json
+++ b/client/src/common/tsconfig.json
@@ -3,8 +3,7 @@
         "types": [
             "vscode"
         ],
-        "module": "commonjs",
-        "moduleResolution": "node",
+        "module": "nodenext",
         "rootDir": ".",
         "strict": true,
         "noImplicitAny": true,

--- a/client/src/common/tsconfig.publish.json
+++ b/client/src/common/tsconfig.publish.json
@@ -3,8 +3,7 @@
         "types": [
             "vscode"
         ],
-        "module": "commonjs",
-        "moduleResolution": "node",
+        "module": "nodenext",
         "rootDir": ".",
         "strict": true,
         "noImplicitAny": true,

--- a/client/src/common/tsconfig.watch.json
+++ b/client/src/common/tsconfig.watch.json
@@ -3,8 +3,7 @@
         "types": [
             "vscode"
         ],
-        "module": "commonjs",
-        "moduleResolution": "node",
+        "module": "nodenext",
         "rootDir": ".",
         "strict": true,
         "noImplicitAny": true,

--- a/client/src/node/tsconfig.json
+++ b/client/src/node/tsconfig.json
@@ -4,8 +4,7 @@
             "node",
             "vscode"
         ],
-        "module": "commonjs",
-        "moduleResolution": "node",
+        "module": "nodenext",
         "rootDir": ".",
         "strict": true,
         "noImplicitAny": true,

--- a/client/src/node/tsconfig.publish.json
+++ b/client/src/node/tsconfig.publish.json
@@ -4,8 +4,7 @@
             "node",
             "vscode"
         ],
-        "module": "commonjs",
-        "moduleResolution": "node",
+        "module": "nodenext",
         "rootDir": ".",
         "strict": true,
         "noImplicitAny": true,

--- a/client/src/node/tsconfig.watch.json
+++ b/client/src/node/tsconfig.watch.json
@@ -4,8 +4,7 @@
             "node",
             "vscode"
         ],
-        "module": "commonjs",
-        "moduleResolution": "node",
+        "module": "nodenext",
         "rootDir": ".",
         "strict": true,
         "noImplicitAny": true,

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -2,7 +2,7 @@
 	"compilerOptions": {
 		"strict": true,
 		"checkJs": true,
-		"module": "commonjs",
+		"module": "nodenext",
 		"target": "es2020",
 		"types": [
 			"node"

--- a/jsonrpc/src/browser/test/tsconfig.json
+++ b/jsonrpc/src/browser/test/tsconfig.json
@@ -3,8 +3,7 @@
         "types": [
             "mocha"
         ],
-        "module": "commonjs",
-        "moduleResolution": "node",
+        "module": "nodenext",
         "rootDir": ".",
         "lib": [
             "es2020",

--- a/jsonrpc/src/browser/test/tsconfig.publish.json
+++ b/jsonrpc/src/browser/test/tsconfig.publish.json
@@ -3,8 +3,7 @@
         "types": [
             "mocha"
         ],
-        "module": "commonjs",
-        "moduleResolution": "node",
+        "module": "nodenext",
         "rootDir": ".",
         "lib": [
             "es2020",

--- a/jsonrpc/src/browser/test/tsconfig.watch.json
+++ b/jsonrpc/src/browser/test/tsconfig.watch.json
@@ -3,8 +3,7 @@
         "types": [
             "mocha"
         ],
-        "module": "commonjs",
-        "moduleResolution": "node",
+        "module": "nodenext",
         "rootDir": ".",
         "lib": [
             "es2020",

--- a/jsonrpc/src/browser/tsconfig.json
+++ b/jsonrpc/src/browser/tsconfig.json
@@ -1,7 +1,6 @@
 {
     "compilerOptions": {
-        "module": "commonjs",
-        "moduleResolution": "node",
+        "module": "nodenext",
         "rootDir": ".",
         "types": [],
         "lib": [

--- a/jsonrpc/src/browser/tsconfig.publish.json
+++ b/jsonrpc/src/browser/tsconfig.publish.json
@@ -1,7 +1,6 @@
 {
     "compilerOptions": {
-        "module": "commonjs",
-        "moduleResolution": "node",
+        "module": "nodenext",
         "rootDir": ".",
         "types": [],
         "lib": [

--- a/jsonrpc/src/browser/tsconfig.watch.json
+++ b/jsonrpc/src/browser/tsconfig.watch.json
@@ -1,7 +1,6 @@
 {
     "compilerOptions": {
-        "module": "commonjs",
-        "moduleResolution": "node",
+        "module": "nodenext",
         "rootDir": ".",
         "types": [],
         "lib": [

--- a/jsonrpc/src/common/test/general.test.ts
+++ b/jsonrpc/src/common/test/general.test.ts
@@ -9,6 +9,6 @@ import { Trace } from '../api';
 
 suite('General Tests', () => {
 	test('Trace#fromString', () => {
-		assert(Trace.Off === Trace.fromString(10 as any));
+		assert.equal(Trace.Off, Trace.fromString(10 as any));
 	});
 });

--- a/jsonrpc/src/common/test/tsconfig.json
+++ b/jsonrpc/src/common/test/tsconfig.json
@@ -3,8 +3,7 @@
         "types": [
             "mocha"
         ],
-        "module": "commonjs",
-        "moduleResolution": "node",
+        "module": "nodenext",
         "rootDir": ".",
         "strict": true,
         "noImplicitAny": true,

--- a/jsonrpc/src/common/test/tsconfig.publish.json
+++ b/jsonrpc/src/common/test/tsconfig.publish.json
@@ -3,8 +3,7 @@
         "types": [
             "mocha"
         ],
-        "module": "commonjs",
-        "moduleResolution": "node",
+        "module": "nodenext",
         "rootDir": ".",
         "strict": true,
         "noImplicitAny": true,

--- a/jsonrpc/src/common/test/tsconfig.watch.json
+++ b/jsonrpc/src/common/test/tsconfig.watch.json
@@ -3,8 +3,7 @@
         "types": [
             "mocha"
         ],
-        "module": "commonjs",
-        "moduleResolution": "node",
+        "module": "nodenext",
         "rootDir": ".",
         "strict": true,
         "noImplicitAny": true,

--- a/jsonrpc/src/common/tsconfig.json
+++ b/jsonrpc/src/common/tsconfig.json
@@ -1,7 +1,6 @@
 {
     "compilerOptions": {
-        "module": "commonjs",
-        "moduleResolution": "node",
+        "module": "nodenext",
         "rootDir": ".",
         "types": [],
         "strict": true,

--- a/jsonrpc/src/common/tsconfig.publish.json
+++ b/jsonrpc/src/common/tsconfig.publish.json
@@ -1,7 +1,6 @@
 {
     "compilerOptions": {
-        "module": "commonjs",
-        "moduleResolution": "node",
+        "module": "nodenext",
         "rootDir": ".",
         "types": [],
         "strict": true,

--- a/jsonrpc/src/common/tsconfig.watch.json
+++ b/jsonrpc/src/common/tsconfig.watch.json
@@ -1,7 +1,6 @@
 {
     "compilerOptions": {
-        "module": "commonjs",
-        "moduleResolution": "node",
+        "module": "nodenext",
         "rootDir": ".",
         "types": [],
         "strict": true,

--- a/jsonrpc/src/node/test/connection.test.ts
+++ b/jsonrpc/src/node/test/connection.test.ts
@@ -320,7 +320,7 @@ suite('Connection', () => {
 
 		client.listen();
 		client.sendRequest(type, '').then(_result => {
-			assert(false);
+			assert.ok(false);
 		}, () => {
 			done();
 		});
@@ -335,7 +335,7 @@ suite('Connection', () => {
 		client.dispose();
 		try {
 			void client.sendNotification(testNotification);
-			assert(false);
+			assert.ok(false);
 		} catch (error) {
 			done();
 		}
@@ -349,7 +349,7 @@ suite('Connection', () => {
 		client.listen();
 		try {
 			client.listen();
-			assert(false);
+			assert.ok(false);
 		} catch (error) {
 			done();
 		}
@@ -405,7 +405,7 @@ suite('Connection', () => {
 			assert.strictEqual(result, 60);
 			done();
 		}, () => {
-			assert(false);
+			assert.ok(false);
 			done();
 		});
 	});
@@ -431,7 +431,7 @@ suite('Connection', () => {
 			assert.strictEqual(result, 60);
 			done();
 		}, () => {
-			assert(false);
+			assert.ok(false);
 			done();
 		});
 	});
@@ -443,7 +443,7 @@ suite('Connection', () => {
 
 		const server = hostConnection.createMessageConnection(duplexStream2, duplexStream1, hostConnection.NullLogger);
 		server.onRequest(type, (p1) => {
-			assert(Array.isArray(p1));
+			assert.ok(Array.isArray(p1));
 			assert.strictEqual(p1[0], 10);
 			assert.strictEqual(p1[1], 20);
 			assert.strictEqual(p1[2], 30);
@@ -458,7 +458,7 @@ suite('Connection', () => {
 			assert.strictEqual(result, 60);
 			done();
 		}, () => {
-			assert(false);
+			assert.ok(false);
 			done();
 		});
 	});
@@ -470,7 +470,7 @@ suite('Connection', () => {
 
 		const server = hostConnection.createMessageConnection(duplexStream2, duplexStream1, hostConnection.NullLogger);
 		server.onNotification(type, (p1) => {
-			assert(Array.isArray(p1));
+			assert.ok(Array.isArray(p1));
 			assert.strictEqual(p1[0], 10);
 			assert.strictEqual(p1[1], 20);
 			assert.strictEqual(p1[2], 30);
@@ -503,7 +503,7 @@ suite('Connection', () => {
 			assert.strictEqual(result, 60);
 			done();
 		}, () => {
-			assert(false);
+			assert.ok(false);
 			done();
 		});
 	});
@@ -526,7 +526,7 @@ suite('Connection', () => {
 			assert.strictEqual(result, 10);
 			done();
 		}, () => {
-			assert(false);
+			assert.ok(false);
 			done();
 		});
 	});
@@ -551,7 +551,7 @@ suite('Connection', () => {
 			assert.strictEqual(result, 60);
 			done();
 		}, () => {
-			assert(false);
+			assert.ok(false);
 			done();
 		});
 	});
@@ -576,7 +576,7 @@ suite('Connection', () => {
 			assert.strictEqual(result, 30);
 			done();
 		}, () => {
-			assert(false);
+			assert.ok(false);
 			done();
 		});
 	});

--- a/jsonrpc/src/node/test/tsconfig.json
+++ b/jsonrpc/src/node/test/tsconfig.json
@@ -4,8 +4,7 @@
             "node",
             "mocha"
         ],
-        "module": "commonjs",
-        "moduleResolution": "node",
+        "module": "nodenext",
         "rootDir": ".",
         "strict": true,
         "noImplicitAny": true,

--- a/jsonrpc/src/node/test/tsconfig.publish.json
+++ b/jsonrpc/src/node/test/tsconfig.publish.json
@@ -4,8 +4,7 @@
             "node",
             "mocha"
         ],
-        "module": "commonjs",
-        "moduleResolution": "node",
+        "module": "nodenext",
         "rootDir": ".",
         "strict": true,
         "noImplicitAny": true,

--- a/jsonrpc/src/node/test/tsconfig.watch.json
+++ b/jsonrpc/src/node/test/tsconfig.watch.json
@@ -4,8 +4,7 @@
             "node",
             "mocha"
         ],
-        "module": "commonjs",
-        "moduleResolution": "node",
+        "module": "nodenext",
         "rootDir": ".",
         "strict": true,
         "noImplicitAny": true,

--- a/jsonrpc/src/node/tsconfig.json
+++ b/jsonrpc/src/node/tsconfig.json
@@ -1,7 +1,6 @@
 {
     "compilerOptions": {
-        "module": "commonjs",
-        "moduleResolution": "node",
+        "module": "nodenext",
         "rootDir": ".",
         "types": [
             "node"

--- a/jsonrpc/src/node/tsconfig.publish.json
+++ b/jsonrpc/src/node/tsconfig.publish.json
@@ -1,7 +1,6 @@
 {
     "compilerOptions": {
-        "module": "commonjs",
-        "moduleResolution": "node",
+        "module": "nodenext",
         "rootDir": ".",
         "types": [
             "node"

--- a/jsonrpc/src/node/tsconfig.watch.json
+++ b/jsonrpc/src/node/tsconfig.watch.json
@@ -1,7 +1,6 @@
 {
     "compilerOptions": {
-        "module": "commonjs",
-        "moduleResolution": "node",
+        "module": "nodenext",
         "rootDir": ".",
         "types": [
             "node"

--- a/protocol/src/browser/test/tsconfig.json
+++ b/protocol/src/browser/test/tsconfig.json
@@ -3,8 +3,7 @@
         "types": [
             "mocha"
         ],
-        "module": "commonjs",
-        "moduleResolution": "node",
+        "module": "nodenext",
         "rootDir": ".",
         "lib": [
             "es2020",

--- a/protocol/src/browser/test/tsconfig.publish.json
+++ b/protocol/src/browser/test/tsconfig.publish.json
@@ -3,8 +3,7 @@
         "types": [
             "mocha"
         ],
-        "module": "commonjs",
-        "moduleResolution": "node",
+        "module": "nodenext",
         "rootDir": ".",
         "lib": [
             "es2020",

--- a/protocol/src/browser/test/tsconfig.watch.json
+++ b/protocol/src/browser/test/tsconfig.watch.json
@@ -3,8 +3,7 @@
         "types": [
             "mocha"
         ],
-        "module": "commonjs",
-        "moduleResolution": "node",
+        "module": "nodenext",
         "rootDir": ".",
         "lib": [
             "es2020",

--- a/protocol/src/browser/tsconfig.json
+++ b/protocol/src/browser/tsconfig.json
@@ -1,7 +1,6 @@
 {
     "compilerOptions": {
-        "module": "commonjs",
-        "moduleResolution": "node",
+        "module": "nodenext",
         "rootDir": ".",
         "types": [],
         "lib": [

--- a/protocol/src/browser/tsconfig.publish.json
+++ b/protocol/src/browser/tsconfig.publish.json
@@ -1,7 +1,6 @@
 {
     "compilerOptions": {
-        "module": "commonjs",
-        "moduleResolution": "node",
+        "module": "nodenext",
         "rootDir": ".",
         "types": [],
         "lib": [

--- a/protocol/src/browser/tsconfig.watch.json
+++ b/protocol/src/browser/tsconfig.watch.json
@@ -1,7 +1,6 @@
 {
     "compilerOptions": {
-        "module": "commonjs",
-        "moduleResolution": "node",
+        "module": "nodenext",
         "rootDir": ".",
         "types": [],
         "lib": [

--- a/protocol/src/common/tsconfig.json
+++ b/protocol/src/common/tsconfig.json
@@ -1,7 +1,6 @@
 {
     "compilerOptions": {
-        "module": "commonjs",
-        "moduleResolution": "node",
+        "module": "nodenext",
         "rootDir": ".",
         "types": [],
         "strict": true,

--- a/protocol/src/common/tsconfig.publish.json
+++ b/protocol/src/common/tsconfig.publish.json
@@ -1,7 +1,6 @@
 {
     "compilerOptions": {
-        "module": "commonjs",
-        "moduleResolution": "node",
+        "module": "nodenext",
         "rootDir": ".",
         "types": [],
         "strict": true,

--- a/protocol/src/common/tsconfig.watch.json
+++ b/protocol/src/common/tsconfig.watch.json
@@ -1,7 +1,6 @@
 {
     "compilerOptions": {
-        "module": "commonjs",
-        "moduleResolution": "node",
+        "module": "nodenext",
         "rootDir": ".",
         "types": [],
         "strict": true,

--- a/protocol/src/node/test/tsconfig.json
+++ b/protocol/src/node/test/tsconfig.json
@@ -4,8 +4,7 @@
             "node",
             "mocha"
         ],
-        "module": "commonjs",
-        "moduleResolution": "node",
+        "module": "nodenext",
         "rootDir": ".",
         "strict": true,
         "noImplicitAny": true,

--- a/protocol/src/node/test/tsconfig.publish.json
+++ b/protocol/src/node/test/tsconfig.publish.json
@@ -4,8 +4,7 @@
             "node",
             "mocha"
         ],
-        "module": "commonjs",
-        "moduleResolution": "node",
+        "module": "nodenext",
         "rootDir": ".",
         "strict": true,
         "noImplicitAny": true,

--- a/protocol/src/node/test/tsconfig.watch.json
+++ b/protocol/src/node/test/tsconfig.watch.json
@@ -4,8 +4,7 @@
             "node",
             "mocha"
         ],
-        "module": "commonjs",
-        "moduleResolution": "node",
+        "module": "nodenext",
         "rootDir": ".",
         "strict": true,
         "noImplicitAny": true,

--- a/protocol/src/node/tsconfig.json
+++ b/protocol/src/node/tsconfig.json
@@ -1,7 +1,6 @@
 {
     "compilerOptions": {
-        "module": "commonjs",
-        "moduleResolution": "node",
+        "module": "nodenext",
         "rootDir": ".",
         "types": [
             "node"

--- a/protocol/src/node/tsconfig.publish.json
+++ b/protocol/src/node/tsconfig.publish.json
@@ -1,7 +1,6 @@
 {
     "compilerOptions": {
-        "module": "commonjs",
-        "moduleResolution": "node",
+        "module": "nodenext",
         "rootDir": ".",
         "types": [
             "node"

--- a/protocol/src/node/tsconfig.watch.json
+++ b/protocol/src/node/tsconfig.watch.json
@@ -1,7 +1,6 @@
 {
     "compilerOptions": {
-        "module": "commonjs",
-        "moduleResolution": "node",
+        "module": "nodenext",
         "rootDir": ".",
         "types": [
             "node"

--- a/server/src/browser/tsconfig.json
+++ b/server/src/browser/tsconfig.json
@@ -1,7 +1,6 @@
 {
     "compilerOptions": {
-        "module": "commonjs",
-        "moduleResolution": "node",
+        "module": "nodenext",
         "rootDir": ".",
         "types": [],
         "lib": [

--- a/server/src/browser/tsconfig.publish.json
+++ b/server/src/browser/tsconfig.publish.json
@@ -1,7 +1,6 @@
 {
     "compilerOptions": {
-        "module": "commonjs",
-        "moduleResolution": "node",
+        "module": "nodenext",
         "rootDir": ".",
         "types": [],
         "lib": [

--- a/server/src/browser/tsconfig.watch.json
+++ b/server/src/browser/tsconfig.watch.json
@@ -1,7 +1,6 @@
 {
     "compilerOptions": {
-        "module": "commonjs",
-        "moduleResolution": "node",
+        "module": "nodenext",
         "rootDir": ".",
         "types": [],
         "lib": [

--- a/server/src/common/tsconfig.json
+++ b/server/src/common/tsconfig.json
@@ -1,7 +1,6 @@
 {
     "compilerOptions": {
-        "module": "commonjs",
-        "moduleResolution": "node",
+        "module": "nodenext",
         "rootDir": ".",
         "types": [],
         "strict": true,

--- a/server/src/common/tsconfig.publish.json
+++ b/server/src/common/tsconfig.publish.json
@@ -1,7 +1,6 @@
 {
     "compilerOptions": {
-        "module": "commonjs",
-        "moduleResolution": "node",
+        "module": "nodenext",
         "rootDir": ".",
         "types": [],
         "strict": true,

--- a/server/src/common/tsconfig.watch.json
+++ b/server/src/common/tsconfig.watch.json
@@ -1,7 +1,6 @@
 {
     "compilerOptions": {
-        "module": "commonjs",
-        "moduleResolution": "node",
+        "module": "nodenext",
         "rootDir": ".",
         "types": [],
         "strict": true,

--- a/server/src/node/test/tsconfig.json
+++ b/server/src/node/test/tsconfig.json
@@ -4,8 +4,7 @@
             "node",
             "mocha"
         ],
-        "module": "commonjs",
-        "moduleResolution": "node",
+        "module": "nodenext",
         "rootDir": ".",
         "strict": true,
         "noImplicitAny": true,

--- a/server/src/node/test/tsconfig.publish.json
+++ b/server/src/node/test/tsconfig.publish.json
@@ -4,8 +4,7 @@
             "node",
             "mocha"
         ],
-        "module": "commonjs",
-        "moduleResolution": "node",
+        "module": "nodenext",
         "rootDir": ".",
         "strict": true,
         "noImplicitAny": true,

--- a/server/src/node/test/tsconfig.watch.json
+++ b/server/src/node/test/tsconfig.watch.json
@@ -4,8 +4,7 @@
             "node",
             "mocha"
         ],
-        "module": "commonjs",
-        "moduleResolution": "node",
+        "module": "nodenext",
         "rootDir": ".",
         "strict": true,
         "noImplicitAny": true,

--- a/server/src/node/tsconfig.json
+++ b/server/src/node/tsconfig.json
@@ -1,7 +1,6 @@
 {
     "compilerOptions": {
-        "module": "commonjs",
-        "moduleResolution": "node",
+        "module": "nodenext",
         "rootDir": ".",
         "types": [
             "node"

--- a/server/src/node/tsconfig.publish.json
+++ b/server/src/node/tsconfig.publish.json
@@ -1,7 +1,6 @@
 {
     "compilerOptions": {
-        "module": "commonjs",
-        "moduleResolution": "node",
+        "module": "nodenext",
         "rootDir": ".",
         "types": [
             "node"

--- a/server/src/node/tsconfig.watch.json
+++ b/server/src/node/tsconfig.watch.json
@@ -1,7 +1,6 @@
 {
     "compilerOptions": {
-        "module": "commonjs",
-        "moduleResolution": "node",
+        "module": "nodenext",
         "rootDir": ".",
         "types": [
             "node"

--- a/testbed/client/tsconfig.json
+++ b/testbed/client/tsconfig.json
@@ -1,6 +1,6 @@
 {
 	"compilerOptions": {
-		"module": "commonjs",
+		"module": "nodenext",
 		"target": "es2017",
 		"outDir": "out",
 		"rootDir": "src",

--- a/testbed/server/tsconfig.json
+++ b/testbed/server/tsconfig.json
@@ -1,8 +1,7 @@
 {
 	"compilerOptions": {
 		"target": "es2017",
-		"module": "commonjs",
-		"moduleResolution": "node",
+		"module": "nodenext",
 		"sourceMap": true,
 		"outDir": "out",
 		"rootDir": "src",

--- a/testbed/tsconfig.json
+++ b/testbed/tsconfig.json
@@ -1,6 +1,6 @@
 {
 	"compilerOptions": {
-		"module": "commonjs",
+		"module": "nodenext",
 		"target": "es2017",
 		"outDir": "out",
 		"rootDir": "src",

--- a/textDocument/.mocharc.json
+++ b/textDocument/.mocharc.json
@@ -1,5 +1,5 @@
 {
-	"spec": "lib/umd/test",
+	"spec": "lib/cjs/test",
 	"extension": ["js"],
 	"recursive": true,
 	"ui": "tdd"

--- a/textDocument/package.json
+++ b/textDocument/package.json
@@ -12,12 +12,12 @@
 	"bugs": {
 		"url": "https://github.com/Microsoft/vscode-languageserver-node/issues"
 	},
-	"main": "./lib/umd/main.js",
-	"typings": "./lib/umd/main",
+	"main": "./lib/cjs/main.js",
+	"typings": "./lib/cjs/main",
 	"exports": {
 		".": {
 			"import": "./lib/esm/main.js",
-			"default": "./lib/umd/main.js"
+			"default": "./lib/cjs/main.js"
 		}
 	},
 	"scripts": {
@@ -30,8 +30,8 @@
 		"test": "node ../node_modules/mocha/bin/_mocha",
 		"all": "npm run clean && npm run compile && npm run lint && npm run test",
 		"compile:esm": "node ../build/bin/tsc -b ./tsconfig.esm.publish.json && node ../build/bin/fix-esm",
-		"compile:umd": "node ../build/bin/tsc -b ./tsconfig.umd.publish.json",
-		"all:publish": "git clean -xfd . && npm install && npm run compile:esm && npm run compile:umd && npm run lint && npm run test",
+		"compile:cjs": "node ../build/bin/tsc -b ./tsconfig.cjs.publish.json",
+		"all:publish": "git clean -xfd . && npm install && npm run compile:esm && npm run compile:cjs && npm run lint && npm run test",
 		"preversion": "npm test"
 	}
 }

--- a/textDocument/src/test/tsconfig.cjs.publish.json
+++ b/textDocument/src/test/tsconfig.cjs.publish.json
@@ -3,8 +3,7 @@
         "types": [
             "mocha"
         ],
-        "module": "umd",
-        "moduleResolution": "node",
+        "module": "nodenext",
         "rootDir": ".",
         "strict": true,
         "noImplicitAny": true,
@@ -19,8 +18,8 @@
         "lib": [
             "es2015"
         ],
-        "outDir": "../../lib/umd/test",
-        "tsBuildInfoFile": "../../lib/umd/test/publish.tsbuildInfo",
+        "outDir": "../../lib/cjs/test",
+        "tsBuildInfoFile": "../../lib/cjs/test/publish.tsbuildInfo",
         "incremental": true
     },
     "include": [
@@ -28,7 +27,7 @@
     ],
     "references": [
         {
-            "path": "../tsconfig.umd.publish.json"
+            "path": "../tsconfig.cjs.publish.json"
         }
     ]
 }

--- a/textDocument/src/test/tsconfig.esm.publish.json
+++ b/textDocument/src/test/tsconfig.esm.publish.json
@@ -3,8 +3,8 @@
         "types": [
             "mocha"
         ],
-        "module": "es6",
-        "moduleResolution": "node",
+        "module": "esnext",
+        "moduleResolution": "bundler",
         "rootDir": ".",
         "strict": true,
         "noImplicitAny": true,

--- a/textDocument/src/test/tsconfig.json
+++ b/textDocument/src/test/tsconfig.json
@@ -3,8 +3,7 @@
         "types": [
             "mocha"
         ],
-        "module": "umd",
-        "moduleResolution": "node",
+        "module": "nodenext",
         "rootDir": ".",
         "strict": true,
         "noImplicitAny": true,
@@ -19,8 +18,8 @@
         "lib": [
             "es2015"
         ],
-        "outDir": "../../lib/umd/test",
-        "tsBuildInfoFile": "../../lib/umd/test/compile.tsbuildInfo",
+        "outDir": "../../lib/cjs/test",
+        "tsBuildInfoFile": "../../lib/cjs/test/compile.tsbuildInfo",
         "incremental": true
     },
     "include": [

--- a/textDocument/src/test/tsconfig.watch.json
+++ b/textDocument/src/test/tsconfig.watch.json
@@ -3,8 +3,7 @@
         "types": [
             "mocha"
         ],
-        "module": "umd",
-        "moduleResolution": "node",
+        "module": "nodenext",
         "rootDir": ".",
         "strict": true,
         "noImplicitAny": true,
@@ -19,8 +18,8 @@
         "lib": [
             "es2015"
         ],
-        "outDir": "../../lib/umd/test",
-        "tsBuildInfoFile": "../../lib/umd/test/watch.tsbuildInfo",
+        "outDir": "../../lib/cjs/test",
+        "tsBuildInfoFile": "../../lib/cjs/test/watch.tsbuildInfo",
         "incremental": true
     },
     "include": [

--- a/textDocument/src/tsconfig.esm.publish.json
+++ b/textDocument/src/tsconfig.esm.publish.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
-        "module": "es6",
-        "moduleResolution": "node",
+        "module": "nodenext",
+        "moduleResolution": "bundler",
         "rootDir": ".",
         "types": [],
         "strict": true,

--- a/textDocument/src/tsconfig.json
+++ b/textDocument/src/tsconfig.json
@@ -1,7 +1,6 @@
 {
     "compilerOptions": {
-        "module": "umd",
-        "moduleResolution": "node",
+        "module": "nodenext",
         "rootDir": ".",
         "types": [],
         "strict": true,
@@ -17,8 +16,8 @@
         "lib": [
             "es2015"
         ],
-        "outDir": "../lib/umd",
-        "tsBuildInfoFile": "../lib/umd/compile.tsbuildInfo",
+        "outDir": "../lib/cjs",
+        "tsBuildInfoFile": "../lib/cjs/compile.tsbuildInfo",
         "incremental": true,
         "composite": true
     },

--- a/textDocument/src/tsconfig.umd.publish.json
+++ b/textDocument/src/tsconfig.umd.publish.json
@@ -1,7 +1,6 @@
 {
     "compilerOptions": {
-        "module": "umd",
-        "moduleResolution": "node",
+        "module": "nodenext",
         "rootDir": ".",
         "types": [],
         "strict": true,
@@ -17,8 +16,8 @@
         "lib": [
             "es2015"
         ],
-        "outDir": "../lib/umd",
-        "tsBuildInfoFile": "../lib/umd/publish.tsbuildInfo",
+        "outDir": "../lib/cjs",
+        "tsBuildInfoFile": "../lib/cjs/publish.tsbuildInfo",
         "incremental": true,
         "composite": true
     },

--- a/textDocument/src/tsconfig.watch.json
+++ b/textDocument/src/tsconfig.watch.json
@@ -1,7 +1,6 @@
 {
     "compilerOptions": {
-        "module": "umd",
-        "moduleResolution": "node",
+        "module": "nodenext",
         "rootDir": ".",
         "types": [],
         "strict": true,
@@ -17,8 +16,8 @@
         "lib": [
             "es2015"
         ],
-        "outDir": "../lib/umd",
-        "tsBuildInfoFile": "../lib/umd/watch.tsbuildInfo",
+        "outDir": "../lib/cjs",
+        "tsBuildInfoFile": "../lib/cjs/watch.tsbuildInfo",
         "incremental": true,
         "composite": true
     },

--- a/textDocument/tsconfig.cjs.publish.json
+++ b/textDocument/tsconfig.cjs.publish.json
@@ -6,10 +6,10 @@
     "files": [],
     "references": [
         {
-            "path": "./src/tsconfig.umd.publish.json"
+            "path": "./src/tsconfig.cjs.publish.json"
         },
         {
-            "path": "./src/test/tsconfig.umd.publish.json"
+            "path": "./src/test/tsconfig.cjs.publish.json"
         }
     ]
 }

--- a/textDocument/tsconfig.publish.json
+++ b/textDocument/tsconfig.publish.json
@@ -9,7 +9,7 @@
             "path": "./tsconfig.esm.publish.json"
         },
         {
-            "path": "./tsconfig.umd.publish.json"
+            "path": "./tsconfig.cjs.publish.json"
         }
     ]
 }

--- a/tools/tsconfig.json
+++ b/tools/tsconfig.json
@@ -1,7 +1,6 @@
 {
     "compilerOptions": {
-        "module": "commonjs",
-        "moduleResolution": "node",
+        "module": "nodenext",
         "rootDir": "./src",
         "types": [
             "node"

--- a/tools/tsconfig.watch.json
+++ b/tools/tsconfig.watch.json
@@ -1,7 +1,6 @@
 {
     "compilerOptions": {
-        "module": "commonjs",
-        "moduleResolution": "node",
+        "module": "nodenext",
         "rootDir": "./src",
         "types": [
             "node"

--- a/tsconfig-gen/tsconfig.json
+++ b/tsconfig-gen/tsconfig.json
@@ -1,7 +1,6 @@
 {
     "compilerOptions": {
-        "module": "commonjs",
-        "moduleResolution": "node",
+        "module": "nodenext",
         "rootDir": "./src",
         "types": [
             "node"

--- a/tsconfig-gen/tsconfig.publish.json
+++ b/tsconfig-gen/tsconfig.publish.json
@@ -1,7 +1,6 @@
 {
     "compilerOptions": {
-        "module": "commonjs",
-        "moduleResolution": "node",
+        "module": "nodenext",
         "rootDir": "./src",
         "types": [
             "node"

--- a/tsconfig-gen/tsconfig.watch.json
+++ b/tsconfig-gen/tsconfig.watch.json
@@ -1,7 +1,6 @@
 {
     "compilerOptions": {
-        "module": "commonjs",
-        "moduleResolution": "node",
+        "module": "nodenext",
         "rootDir": "./src",
         "types": [
             "node"

--- a/types/.mocharc.json
+++ b/types/.mocharc.json
@@ -1,5 +1,5 @@
 {
-	"spec": "lib/umd/test",
+	"spec": "lib/cjs/test",
 	"extension": ["js"],
 	"recursive": true,
 	"ui": "tdd"

--- a/types/package.json
+++ b/types/package.json
@@ -12,12 +12,12 @@
 	"bugs": {
 		"url": "https://github.com/Microsoft/vscode-languageserver-node/issues"
 	},
-	"main": "./lib/umd/main.js",
-	"typings": "./lib/umd/main",
+	"main": "./lib/cjs/main.js",
+	"typings": "./lib/cjs/main",
 	"exports": {
 		".": {
 			"import": "./lib/esm/main.js",
-			"default": "./lib/umd/main.js"
+			"default": "./lib/cjs/main.js"
 		}
 	},
 	"scripts": {
@@ -30,8 +30,8 @@
 		"test": "node ../node_modules/mocha/bin/_mocha",
 		"all": "npm run clean && npm run compile && npm run lint && npm run test",
 		"compile:esm": "node ../build/bin/tsc -b ./tsconfig.esm.publish.json && node ../build/bin/fix-esm",
-		"compile:umd": "node ../build/bin/tsc -b ./tsconfig.umd.publish.json",
-		"all:publish": "git clean -xfd . && npm install && npm run compile:esm && npm run compile:umd && npm run lint && npm run test",
+		"compile:cjs": "node ../build/bin/tsc -b ./tsconfig.cjs.publish.json",
+		"all:publish": "git clean -xfd . && npm install && npm run compile:esm && npm run compile:cjs && npm run lint && npm run test",
 		"preversion": "npm test"
 	}
 }

--- a/types/src/test/tsconfig.cjs.publish.json
+++ b/types/src/test/tsconfig.cjs.publish.json
@@ -3,8 +3,7 @@
         "types": [
             "mocha"
         ],
-        "module": "umd",
-        "moduleResolution": "node",
+        "module": "nodenext",
         "rootDir": ".",
         "strict": true,
         "noImplicitAny": true,
@@ -19,8 +18,8 @@
         "lib": [
             "es2015"
         ],
-        "outDir": "../../lib/umd/test",
-        "tsBuildInfoFile": "../../lib/umd/test/publish.tsbuildInfo",
+        "outDir": "../../lib/cjs/test",
+        "tsBuildInfoFile": "../../lib/cjs/test/publish.tsbuildInfo",
         "incremental": true
     },
     "include": [
@@ -28,7 +27,7 @@
     ],
     "references": [
         {
-            "path": "../tsconfig.umd.publish.json"
+            "path": "../tsconfig.cjs.publish.json"
         }
     ]
 }

--- a/types/src/test/tsconfig.esm.publish.json
+++ b/types/src/test/tsconfig.esm.publish.json
@@ -3,8 +3,8 @@
         "types": [
             "mocha"
         ],
-        "module": "es6",
-        "moduleResolution": "node",
+        "module": "esnext",
+        "moduleResolution": "bundler",
         "rootDir": ".",
         "strict": true,
         "noImplicitAny": true,

--- a/types/src/test/tsconfig.json
+++ b/types/src/test/tsconfig.json
@@ -3,8 +3,7 @@
         "types": [
             "mocha"
         ],
-        "module": "umd",
-        "moduleResolution": "node",
+        "module": "nodenext",
         "rootDir": ".",
         "strict": true,
         "noImplicitAny": true,
@@ -19,8 +18,8 @@
         "lib": [
             "es2015"
         ],
-        "outDir": "../../lib/umd/test",
-        "tsBuildInfoFile": "../../lib/umd/test/compile.tsbuildInfo",
+        "outDir": "../../lib/cjs/test",
+        "tsBuildInfoFile": "../../lib/cjs/test/compile.tsbuildInfo",
         "incremental": true
     },
     "include": [

--- a/types/src/test/tsconfig.watch.json
+++ b/types/src/test/tsconfig.watch.json
@@ -3,8 +3,7 @@
         "types": [
             "mocha"
         ],
-        "module": "umd",
-        "moduleResolution": "node",
+        "module": "nodenext",
         "rootDir": ".",
         "strict": true,
         "noImplicitAny": true,
@@ -19,8 +18,8 @@
         "lib": [
             "es2015"
         ],
-        "outDir": "../../lib/umd/test",
-        "tsBuildInfoFile": "../../lib/umd/test/watch.tsbuildInfo",
+        "outDir": "../../lib/cjs/test",
+        "tsBuildInfoFile": "../../lib/cjs/test/watch.tsbuildInfo",
         "incremental": true
     },
     "include": [

--- a/types/src/tsconfig.cjs.publish.json
+++ b/types/src/tsconfig.cjs.publish.json
@@ -1,7 +1,6 @@
 {
     "compilerOptions": {
-        "module": "umd",
-        "moduleResolution": "node",
+        "module": "nodenext",
         "rootDir": ".",
         "types": [],
         "strict": true,
@@ -17,8 +16,8 @@
         "lib": [
             "es2015"
         ],
-        "outDir": "../lib/umd",
-        "tsBuildInfoFile": "../lib/umd/publish.tsbuildInfo",
+        "outDir": "../lib/cjs",
+        "tsBuildInfoFile": "../lib/cjs/publish.tsbuildInfo",
         "incremental": true,
         "composite": true
     },

--- a/types/src/tsconfig.esm.publish.json
+++ b/types/src/tsconfig.esm.publish.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
-        "module": "es6",
-        "moduleResolution": "node",
+        "module": "esnext",
+        "moduleResolution": "bundler",
         "rootDir": ".",
         "types": [],
         "strict": true,

--- a/types/src/tsconfig.json
+++ b/types/src/tsconfig.json
@@ -1,7 +1,6 @@
 {
     "compilerOptions": {
-        "module": "umd",
-        "moduleResolution": "node",
+        "module": "nodenext",
         "rootDir": ".",
         "types": [],
         "strict": true,
@@ -17,8 +16,8 @@
         "lib": [
             "es2015"
         ],
-        "outDir": "../lib/umd",
-        "tsBuildInfoFile": "../lib/umd/compile.tsbuildInfo",
+        "outDir": "../lib/cjs",
+        "tsBuildInfoFile": "../lib/cjs/compile.tsbuildInfo",
         "incremental": true,
         "composite": true
     },

--- a/types/src/tsconfig.watch.json
+++ b/types/src/tsconfig.watch.json
@@ -1,7 +1,6 @@
 {
     "compilerOptions": {
-        "module": "umd",
-        "moduleResolution": "node",
+        "module": "nodenext",
         "rootDir": ".",
         "types": [],
         "strict": true,
@@ -17,8 +16,8 @@
         "lib": [
             "es2015"
         ],
-        "outDir": "../lib/umd",
-        "tsBuildInfoFile": "../lib/umd/watch.tsbuildInfo",
+        "outDir": "../lib/cjs",
+        "tsBuildInfoFile": "../lib/cjs/watch.tsbuildInfo",
         "incremental": true,
         "composite": true
     },

--- a/types/tsconfig.cjs.publish.json
+++ b/types/tsconfig.cjs.publish.json
@@ -6,10 +6,10 @@
     "files": [],
     "references": [
         {
-            "path": "./src/tsconfig.umd.publish.json"
+            "path": "./src/tsconfig.cjs.publish.json"
         },
         {
-            "path": "./src/test/tsconfig.umd.publish.json"
+            "path": "./src/test/tsconfig.cjs.publish.json"
         }
     ]
 }

--- a/types/tsconfig.publish.json
+++ b/types/tsconfig.publish.json
@@ -9,7 +9,7 @@
             "path": "./tsconfig.esm.publish.json"
         },
         {
-            "path": "./tsconfig.umd.publish.json"
+            "path": "./tsconfig.cjs.publish.json"
         }
     ]
 }


### PR DESCRIPTION
There are essentially 2 valid TypeScript module configurations.

The following is to build a code base using `tsc`. It detects whether it should emit CJS or ESM based on the parent `package.json` file. At the moment of writing `node16` is an alias of `nodenext`, but I’ve seen the TypeScript team promote `nodenext` more.

```jsonc
{
  "compilerOptions": {
    "module": "nodenext"
  }
}
```

The following is to build a code base using a bundler. It always outputs ESM.

```jsonc
{
  "compilerOptions": {
    "module": "esnext",
    "moduleResolution": "bundler."
  }
}
```

Other options are not yet officially deprecated, but are considered legacy. TypeScript on its own does not support dual publishing.

This change replaces all occurrences of `umd` with `cjs`. Next all TypeScript configurations were updated to use the `nodenext` module option, causing them to emit CJS.

The ESM configurations were changed to use the `esnext` module option. This tricks TypeScript to emit ESM, even though all workspaces are marked as a CJS project.

The main reason I’ve seen to emit UMD for some packages in the VSCode ecosystem, is because VSCode itself still uses AMD. However, this is only true for the VSCode core, which doesn’t use any of the packages in this repository.