### PR TITLE
Fixes #1359: codeAction.resolveSupport does not have command field to detect support, but it supports it

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -51,7 +51,7 @@
 		"./tsconfig-gen"
 	],
 	"editor.codeActionsOnSave": {
-		"source.fixAll.eslint": true
+		"source.fixAll.eslint": "explicit"
 	},
 	"mochaExplorer.files": [
 		"textDocument/lib/umd/test/*.js",

--- a/client/src/common/codeAction.ts
+++ b/client/src/common/codeAction.ts
@@ -43,7 +43,7 @@ export class CodeActionFeature extends TextDocumentLanguageFeature<boolean | Cod
 		cap.dataSupport = true;
 		// We can only resolve the edit property.
 		cap.resolveSupport = {
-			properties: ['edit']
+			properties: ['edit', 'command']
 		};
 		cap.codeActionLiteralSupport = {
 			codeActionKind: {


### PR DESCRIPTION
Fixes #1359