### PR TITLE
Always delete feature providers in `unregister()`

### DIFF
--- a/client/src/common/executeCommand.ts
+++ b/client/src/common/executeCommand.ts
@@ -88,6 +88,7 @@ export class ExecuteCommandFeature implements DynamicFeature<ExecuteCommandRegis
 	public unregister(id: string): void {
 		const disposables = this._commands.get(id);
 		if (disposables) {
+			this._commands.delete(id);
 			disposables.forEach(disposable => disposable.dispose());
 		}
 	}

--- a/client/src/common/features.ts
+++ b/client/src/common/features.ts
@@ -516,6 +516,7 @@ export abstract class TextDocumentLanguageFeature<PO, RO extends TextDocumentReg
 	public unregister(id: string): void {
 		const registration = this._registrations.get(id);
 		if (registration !== undefined) {
+			this._registrations.delete(id);
 			registration.disposable.dispose();
 		}
 	}
@@ -616,6 +617,7 @@ export abstract class WorkspaceFeature<RO, PR, M> implements DynamicFeature<RO> 
 	public unregister(id: string): void {
 		const registration = this._registrations.get(id);
 		if (registration !== undefined) {
+			this._registrations.delete(id);
 			registration.disposable.dispose();
 		}
 	}

--- a/client/src/common/fileSystemWatcher.ts
+++ b/client/src/common/fileSystemWatcher.ts
@@ -106,6 +106,7 @@ export class FileSystemWatcherFeature implements DynamicFeature<DidChangeWatched
 	public unregister(id: string): void {
 		const disposables = this._watchers.get(id);
 		if (disposables) {
+			this._watchers.delete(id);
 			for (const disposable of disposables) {
 				disposable.dispose();
 			}

--- a/client/src/common/notebook.ts
+++ b/client/src/common/notebook.ts
@@ -961,7 +961,10 @@ export class NotebookDocumentSyncFeature implements DynamicFeature<proto.Noteboo
 
 	public unregister(id: string): void {
 		const provider = this.registrations.get(id);
-		provider && provider.dispose();
+		if (provider !== undefined) {
+			this.registrations.delete(id);
+			provider.dispose();
+		}
 	}
 
 	public clear(): void {


### PR DESCRIPTION
The `DynamicFeature.unregister(id)` method is supposed to dispose the specified provider and delete it from the feature. In some implementations the provider is not actually deleted and stays in the storage forever. This PR fixes this.