### PR TITLE
Use module export condition for types and textdocument

### DIFF
--- a/textDocument/package.json
+++ b/textDocument/package.json
@@ -16,7 +16,7 @@
 	"typings": "./lib/umd/main",
 	"exports": {
 		".": {
-			"browser": "./lib/esm/main.js",
+			"module": "./lib/esm/main.js",
 			"import": "./lib/esm/main.js",
 			"default": "./lib/umd/main.js"
 		}

--- a/textDocument/package.json
+++ b/textDocument/package.json
@@ -16,6 +16,7 @@
 	"typings": "./lib/umd/main",
 	"exports": {
 		".": {
+			"browser": "./lib/esm/main.js",
 			"module": "./lib/esm/main.js",
 			"import": "./lib/esm/main.js",
 			"default": "./lib/umd/main.js"

--- a/types/package.json
+++ b/types/package.json
@@ -16,7 +16,7 @@
 	"typings": "./lib/umd/main",
 	"exports": {
 		".": {
-			"browser": "./lib/esm/main.js",
+			"module": "./lib/esm/main.js",
 			"import": "./lib/esm/main.js",
 			"default": "./lib/umd/main.js"
 		}

--- a/types/package.json
+++ b/types/package.json
@@ -16,6 +16,7 @@
 	"typings": "./lib/umd/main",
 	"exports": {
 		".": {
+			"browser": "./lib/esm/main.js",
 			"module": "./lib/esm/main.js",
 			"import": "./lib/esm/main.js",
 			"default": "./lib/umd/main.js"


### PR DESCRIPTION
The `module` export condition is an unofficial export condition that’s respected by bundlers. It tells the bundler to resolve to an entrypoint, regardless of whether a module is imported or `require`d. This avoids the [dual package hazard](https://nodejs.org/api/packages.html#dual-package-hazard).

This was the original intent of the `browser` condition when it was added in https://github.com/microsoft/vscode-languageserver-node/pull/1326.

Thanks for telling me this @Andarist