### PR TITLE
Support `WorkspaceEditMetadata` in `workspace/applyEdit`

### DIFF
--- a/client/src/common/client.ts
+++ b/client/src/common/client.ts
@@ -1991,7 +1991,7 @@ export abstract class BaseLanguageClient implements FeatureClient<Middleware, La
 		if (versionMismatch) {
 			return Promise.resolve({ applied: false });
 		}
-		return Is.asPromise(Workspace.applyEdit(converted).then((value) => { return { applied: value }; }));
+		return Is.asPromise(Workspace.applyEdit(converted, { isRefactoring: params.metadata?.isRefactoring }).then((value) => { return { applied: value }; }));
 	}
 
 	private static RequestsToCancelOnContentModified: Set<string> = new Set([

--- a/client/src/common/client.ts
+++ b/client/src/common/client.ts
@@ -1836,6 +1836,7 @@ export abstract class BaseLanguageClient implements FeatureClient<Middleware, La
 		workspaceEdit.changeAnnotationSupport = {
 			groupsOnLabel: true
 		};
+		workspaceEdit.metadataSupport = true;
 
 		const diagnostics = ensure(ensure(result, 'textDocument')!, 'publishDiagnostics')!;
 		diagnostics.relatedInformation = true;

--- a/protocol/src/common/protocol.ts
+++ b/protocol/src/common/protocol.ts
@@ -4094,6 +4094,14 @@ export interface WorkspaceEditClientCapabilities {
 	 * @since 3.16.0
 	 */
 	changeAnnotationSupport?: ChangeAnnotationsSupportOptions;
+
+	/**
+	 * Whether the client supports `WorkspaceEditMetadata` in `WorkspaceEdit`s.
+	 *
+	 * @since 3.18.0
+	 * @proposed
+	 */
+	metadataSupport?: boolean;
 }
 
 /**
@@ -4114,6 +4122,9 @@ export interface ApplyWorkspaceEditParams {
 
 	/**
 	 * Additional data about the edit.
+	 *
+	 * @since 3.18.0
+	 * @proposed
 	 */
 	metadata?: WorkspaceEditMetadata;
 }

--- a/protocol/src/common/protocol.ts
+++ b/protocol/src/common/protocol.ts
@@ -8,7 +8,7 @@ import { ProgressToken, RequestHandler, TraceValues } from 'vscode-jsonrpc';
 import { MessageDirection, ProtocolRequestType, ProtocolRequestType0, ProtocolNotificationType, ProtocolNotificationType0 } from './messages';
 
 import {
-	Position, Range, Location, LocationLink, Diagnostic, Command, TextEdit, WorkspaceEdit, DocumentUri,
+	Position, Range, Location, LocationLink, Diagnostic, Command, TextEdit, WorkspaceEdit, WorkspaceEditMetadata, DocumentUri,
 	TextDocumentIdentifier, VersionedTextDocumentIdentifier, TextDocumentItem, CompletionItem, CompletionList,
 	Hover, SignatureHelp, Definition, DefinitionLink, ReferenceContext, DocumentHighlight, SymbolInformation,
 	CodeLens, CodeActionContext, FormattingOptions, DocumentLink, MarkupKind, SymbolKind, CompletionItemKind,
@@ -4111,6 +4111,11 @@ export interface ApplyWorkspaceEditParams {
 	 * The edits to apply.
 	 */
 	edit: WorkspaceEdit;
+
+	/**
+	 * Additional data about the edit.
+	 */
+	metadata?: WorkspaceEditMetadata;
 }
 
 /**

--- a/types/src/main.ts
+++ b/types/src/main.ts
@@ -1321,6 +1321,9 @@ export namespace WorkspaceEdit {
 
 /**
  * Additional data about a workspace edit.
+ *
+ * @since 3.18.0
+ * @proposed
  */
 export interface WorkspaceEditMetadata {
 	/**

--- a/types/src/main.ts
+++ b/types/src/main.ts
@@ -1320,6 +1320,16 @@ export namespace WorkspaceEdit {
 }
 
 /**
+ * Additional data about a workspace edit.
+ */
+export interface WorkspaceEditMetadata {
+	/**
+	 * Signal to the editor that this edit is a refactoring.
+	 */
+	isRefactoring?: boolean;
+}
+
+/**
  * A change to capture text edits for existing resources.
  */
 export interface TextEditChange {


### PR DESCRIPTION
To fix https://github.com/microsoft/pylance-release/issues/5217#issuecomment-1863469715 in Pylance, I'd need the `Workspace.applyEdit` call in `handleApplyWorkspaceEdit` to pass `{ isRefactoring: true }` as the second parameter.

Is it reasonable to add `WorkspaceEditMetadata` to `workspace/applyEdit`, so `isRefactoring` can be sent optionally via LSP?