### PR TITLE
Changed Successful Exit Notification for Node Client

### DIFF
--- a/client/src/node/main.ts
+++ b/client/src/node/main.ts
@@ -505,7 +505,9 @@ export class LanguageClient extends BaseLanguageClient {
 		}).finally(() => {
 			if (this._serverProcess !== undefined) {
 				this._serverProcess.on('exit', (code, signal) => {
-					if (code !== null) {
+					if (code === 0) {
+						this.info('Server process exited successfully', undefined, false);
+					} else if (code !== null) {
 						this.error(`Server process exited with code ${code}.`, undefined, false);
 					}
 					if (signal !== null) {


### PR DESCRIPTION
Previously any exit code (even 0), were logged as error messages. Now successful exits are instead logged as an information message.

For more information see:
- [Commit](https://github.com/microsoft/vscode-languageserver-node/commit/c6817d36ffbc9efb17330b19e5e73a2caaa197d9) where exit code capturing was added.