### PR TITLE
Add SemanticTokenTypes.label

### DIFF
--- a/client/src/common/semanticTokens.ts
+++ b/client/src/common/semanticTokens.ts
@@ -74,7 +74,8 @@ export class SemanticTokensFeature extends TextDocumentLanguageFeature<boolean |
     		SemanticTokenTypes.number,
     		SemanticTokenTypes.regexp,
     		SemanticTokenTypes.operator,
-			SemanticTokenTypes.decorator
+			SemanticTokenTypes.decorator,
+			SemanticTokenTypes.label,
 		];
 		capability.tokenModifiers = [
     		SemanticTokenModifiers.declaration,

--- a/client/src/common/semanticTokens.ts
+++ b/client/src/common/semanticTokens.ts
@@ -75,7 +75,7 @@ export class SemanticTokensFeature extends TextDocumentLanguageFeature<boolean |
     		SemanticTokenTypes.regexp,
     		SemanticTokenTypes.operator,
 			SemanticTokenTypes.decorator,
-			SemanticTokenTypes.label,
+			SemanticTokenTypes.label
 		];
 		capability.tokenModifiers = [
     		SemanticTokenModifiers.declaration,

--- a/types/src/main.ts
+++ b/types/src/main.ts
@@ -3838,7 +3838,6 @@ export enum SemanticTokenTypes {
 	 * @since 3.18.0
 	 */
 	label = 'label'
-
 }
 
 /**

--- a/types/src/main.ts
+++ b/types/src/main.ts
@@ -3833,7 +3833,12 @@ export enum SemanticTokenTypes {
 	/**
 	 * @since 3.17.0
 	 */
-	decorator = 'decorator'
+	decorator = 'decorator',
+	/**
+	 * @since 3.18.0
+	 */
+	label = 'label'
+
 }
 
 /**


### PR DESCRIPTION
Visual Studio Code has 'label' in its standard token types list. https://code.visualstudio.com/api/language-extensions/semantic-highlight-guide#standard-token-types-and-modifiers

Fixes #1422