### PR TITLE
Fix ProtocolConverter#asWorkspaceEdit to correctly support workspace edits with snippets

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -101,5 +101,6 @@
 		"vsdiag",
 		"whitespaces",
 		"XCOPY"
-	]
+	],
+	"githubPullRequests.createDefaultBaseBranch": "repositoryDefault"
 }

--- a/client/src/common/client.ts
+++ b/client/src/common/client.ts
@@ -1837,7 +1837,7 @@ export abstract class BaseLanguageClient implements FeatureClient<Middleware, La
 			groupsOnLabel: true
 		};
 		workspaceEdit.metadataSupport = true;
-		workspaceEdit.snippetEditSupport = false;
+		workspaceEdit.snippetEditSupport = true;
 
 		const diagnostics = ensure(ensure(result, 'textDocument')!, 'publishDiagnostics')!;
 		diagnostics.relatedInformation = true;

--- a/client/src/common/protocolConverter.ts
+++ b/client/src/common/protocolConverter.ts
@@ -1085,15 +1085,17 @@ export function createConverter(uriConverter: URIConverter | undefined, trustMar
 					result.deleteFile(_uriConverter(change.uri), change.options, asMetadata(change.annotationId));
 				} else if (ls.TextDocumentEdit.is(change)) {
 					const uri = _uriConverter(change.textDocument.uri);
+					const edits: [code.TextEdit | code.SnippetTextEdit, code.WorkspaceEditEntryMetadata | undefined][] = [];
 					for (const edit of change.edits) {
 						if (ls.AnnotatedTextEdit.is(edit)) {
-							result.replace(uri, asRange(edit.range), edit.newText, asMetadata(edit.annotationId));
+							edits.push([new code.TextEdit(asRange(edit.range), edit.newText), asMetadata(edit.annotationId)]);
 						} else if (ls.SnippetTextEdit.is(edit)) {
-							result.replace(uri, asRange(edit.range), edit.snippet.value, asMetadata(edit.annotationId));
+							edits.push([new code.SnippetTextEdit(asRange(edit.range), new code.SnippetString(edit.snippet.value)), asMetadata(edit.annotationId)]);
 						} else {
-							result.replace(uri, asRange(edit.range), edit.newText);
+							edits.push([new code.TextEdit(asRange(edit.range), edit.newText), undefined]);
 						}
 					}
+					result.set(uri, edits);
 				} else {
 					throw new Error(`Unknown workspace edit change received:\n${JSON.stringify(change, undefined, 4)}`);
 				}


### PR DESCRIPTION
This pull request fixes the issue #1414 by updating the ProtocolConverter#asWorkspaceEdit method to correctly support workspace edits with snippets. The changes include updating the VS Code version to 1.86, adjusting the package.json file, and modifying the code in the protocol converter to construct VS Code text edits for SnippetTextEdit. The converted edits are maintained in an array and then set using the result.set method.