### PR TITLE
Use client ID as fallback for diagnostics collection

### DIFF
--- a/client/src/common/client.ts
+++ b/client/src/common/client.ts
@@ -1073,7 +1073,7 @@ export abstract class BaseLanguageClient implements FeatureClient<Middleware, La
 
 		// If we restart then the diagnostics collection is reused.
 		if (this._diagnostics === undefined) {
-			this._diagnostics = Languages.createDiagnosticCollection(this._clientOptions.diagnosticCollectionName || this._id);
+			this._diagnostics = Languages.createDiagnosticCollection(this._clientOptions.diagnosticCollectionName ?? this._id);
 		}
 
 		// When we start make all buffer handlers pending so that they

--- a/client/src/common/client.ts
+++ b/client/src/common/client.ts
@@ -1062,9 +1062,7 @@ export abstract class BaseLanguageClient implements FeatureClient<Middleware, La
 
 		// If we restart then the diagnostics collection is reused.
 		if (this._diagnostics === undefined) {
-			this._diagnostics = this._clientOptions.diagnosticCollectionName
-				? Languages.createDiagnosticCollection(this._clientOptions.diagnosticCollectionName)
-				: Languages.createDiagnosticCollection();
+			this._diagnostics = Languages.createDiagnosticCollection(this._clientOptions.diagnosticCollectionName || this._id);
 		}
 
 		// When we start make all buffer handlers pending so that they


### PR DESCRIPTION
This sets the language client ID as a fallback for the diagnostics collection name. If no collection name is provided, VSCode generates one. This name is visible in the diagnostics table view of the problems panel.

![Problems panel table view showing several diagnostics](https://github.com/microsoft/vscode-languageserver-node/assets/779047/036f1057-5ae4-42a1-9e13-0f6a4bb68d7b)

This can be solved for every language server integration separately, but IMO it’s nicer if this package provides a better default. An alternative is to use the name instead of the ID. I went with ID, because `typescript` in the screenshot is lower case.