### PR TITLE
Don't crash when unregistering a feature that doesn't exist

### DIFF
--- a/client/src/common/textSynchronization.ts
+++ b/client/src/common/textSynchronization.ts
@@ -157,7 +157,10 @@ export class DidCloseTextDocumentFeature extends TextDocumentEventFeature<DidClo
 	}
 
 	public unregister(id: string): void {
-		const selector = this._selectors.get(id)!;
+		const selector = this._selectors.get(id);
+		if (selector === undefined) {
+			return;
+		}
 		// The super call removed the selector from the map
 		// of selectors.
 		super.unregister(id);


### PR DESCRIPTION
Note: all other features follow the same practice in their `unregister()` methods -- if the features doesn't exist, do nothing and don't throw errors.