### PR TITLE
Fixes #1468: Missing 'export TypeHierarchyMiddleware' from api.ts

### DIFF
--- a/client/src/common/api.ts
+++ b/client/src/common/api.ts
@@ -42,5 +42,6 @@ export { TextDocumentSynchronizationMiddleware, DidOpenTextDocumentFeatureShape,
 export { ProvideTypeDefinitionSignature, TypeDefinitionMiddleware } from './typeDefinition';
 export { WorkspaceFolderMiddleware } from './workspaceFolder';
 export { ProvideWorkspaceSymbolsSignature, ResolveWorkspaceSymbolSignature, WorkspaceSymbolMiddleware } from './workspaceSymbol';
+export { PrepareTypeHierarchySignature, TypeHierarchySupertypesSignature, TypeHierarchySubtypesSignature, TypeHierarchyMiddleware } from './typeHierarchy';
 
 export * from './client';


### PR DESCRIPTION
Fixes #1468