### PR TITLE
Update Node.js version to 18.18.2

### DIFF
--- a/build/azure-pipelines/pipeline.yml
+++ b/build/azure-pipelines/pipeline.yml
@@ -65,13 +65,13 @@ extends:
         testPlatforms:
           - name: Linux
             nodeVersions:
-              - 16.14.2
+              - 18.18.2
           - name: MacOS
             nodeVersions:
-              - 16.14.2
+              - 18.18.2
           - name: Windows
             nodeVersions:
-              - 16.14.2
+              - 18.18.2
         testSteps:
           - template: /build/azure-pipelines/templates/test-steps.yml@self
             parameters:
@@ -91,13 +91,13 @@ extends:
         testPlatforms:
           - name: Linux
             nodeVersions:
-              - 16.14.2
+              - 18.18.2
           - name: MacOS
             nodeVersions:
-              - 16.14.2
+              - 18.18.2
           - name: Windows
             nodeVersions:
-              - 16.14.2
+              - 18.18.2
         testSteps:
           - template: /build/azure-pipelines/templates/test-steps.yml@self
             parameters:
@@ -117,13 +117,13 @@ extends:
         testPlatforms:
           - name: Linux
             nodeVersions:
-              - 16.14.2
+              - 18.18.2
           - name: MacOS
             nodeVersions:
-              - 16.14.2
+              - 18.18.2
           - name: Windows
             nodeVersions:
-              - 16.14.2
+              - 18.18.2
         testSteps:
           - template: /build/azure-pipelines/templates/test-steps.yml@self
             parameters:
@@ -143,13 +143,13 @@ extends:
         testPlatforms:
           - name: Linux
             nodeVersions:
-              - 16.14.2
+              - 18.18.2
           - name: MacOS
             nodeVersions:
-              - 16.14.2
+              - 18.18.2
           - name: Windows
             nodeVersions:
-              - 16.14.2
+              - 18.18.2
         testSteps:
           - template: /build/azure-pipelines/templates/test-steps.yml@self
             parameters:
@@ -169,13 +169,13 @@ extends:
         testPlatforms:
           - name: Linux
             nodeVersions:
-              - 16.14.2
+              - 18.18.2
           - name: MacOS
             nodeVersions:
-              - 16.14.2
+              - 18.18.2
           - name: Windows
             nodeVersions:
-              - 16.14.2
+              - 18.18.2
         testSteps:
           - template: /build/azure-pipelines/templates/test-steps.yml@self
             parameters:
@@ -195,13 +195,13 @@ extends:
         testPlatforms:
           - name: Linux
             nodeVersions:
-              - 16.14.2
+              - 18.18.2
           - name: MacOS
             nodeVersions:
-              - 16.14.2
+              - 18.18.2
           - name: Windows
             nodeVersions:
-              - 16.14.2
+              - 18.18.2
         testSteps:
           - template: /build/azure-pipelines/templates/test-steps.yml@self
             parameters:
@@ -221,13 +221,13 @@ extends:
         testPlatforms:
           - name: Linux
             nodeVersions:
-              - 16.14.2
+              - 18.18.2
           - name: MacOS
             nodeVersions:
-              - 16.14.2
+              - 18.18.2
           - name: Windows
             nodeVersions:
-              - 16.14.2
+              - 18.18.2
         testSteps:
           - template: /build/azure-pipelines/templates/test-steps.yml@self
             parameters:


### PR DESCRIPTION
This pull request updates the Node.js version to 18.18.2 in order to support the --experimental-fetch feature.