### PR TITLE
Show the error message from the LSP server

### DIFF
--- a/client/src/common/client.ts
+++ b/client/src/common/client.ts
@@ -1183,12 +1183,15 @@ export abstract class BaseLanguageClient implements FeatureClient<Middleware, La
 			this.outputChannel.appendLine(this.data2String(data));
 		}
 		if (showNotification === 'force' || (showNotification && this._clientOptions.revealOutputChannelOn <= reveal)) {
-			this.showNotificationMessage(type, message);
+			this.showNotificationMessage(type, message, data);
 		}
 	}
 
-	private showNotificationMessage(type: MessageType, message?: string) {
+	private showNotificationMessage(type: MessageType, message?: string, data? : any ) {
 		message = message ?? 'A request has failed. See the output for more information.';
+		if (data?.message) {
+			message += '\n' + data.message;
+		}
 		const messageFunc = type === MessageType.Error
 			? Window.showErrorMessage
 			: type === MessageType.Warning

--- a/client/src/common/client.ts
+++ b/client/src/common/client.ts
@@ -1189,8 +1189,8 @@ export abstract class BaseLanguageClient implements FeatureClient<Middleware, La
 
 	private showNotificationMessage(type: MessageType, message?: string, data? : any ) {
 		message = message ?? 'A request has failed. See the output for more information.';
-		if (data?.message) {
-			message += '\n' + data.message;
+		if (data) {
+			message += '\n' + this.data2String(data);
 		}
 		const messageFunc = type === MessageType.Error
 			? Window.showErrorMessage


### PR DESCRIPTION
I've noticed that if a LSP server reports an error via `ResponseError::message` field, it's a bit of a hit or miss if this is reported to the end user in a popup.

For example [rename reports the error in the dialog](https://github.com/SWAT-engineering/vscode-languageserver-node/blob/1f603f4f73552a30a649667262e5f83532cf223e/client/src/common/rename.ts#L112-L116) while errors in many others parts end up in the [generic handler](https://github.com/SWAT-engineering/vscode-languageserver-node/blob/12f4439aa73c31bfe2d4e44377426c23f2a55c01/client/src/common/client.ts#L2053-L2054)

I've changed this such that both the message from the library is kept, while also reporting the message from the LSP server.


