### PR TITLE
Add supportThemeIcons in MarkdownString

### DIFF
--- a/client-node-tests/src/converter.test.ts
+++ b/client-node-tests/src/converter.test.ts
@@ -17,7 +17,7 @@ import * as async from 'vscode-languageclient/$test/common/utils/async';
 import * as vscode from 'vscode';
 
 const c2p: codeConverter.Converter = codeConverter.createConverter();
-const p2c: protocolConverter.Converter = protocolConverter.createConverter(undefined, false, false);
+const p2c: protocolConverter.Converter = protocolConverter.createConverter(undefined, false, false, false);
 
 interface InsertReplaceRange {
 	inserting: vscode.Range;
@@ -1214,7 +1214,7 @@ suite('Protocol Converter', () => {
 	test('Uri Rewrite', () => {
 		const converter = protocolConverter.createConverter((value: string) => {
 			return vscode.Uri.parse(`${value}.vscode`);
-		}, false, false);
+		}, false, false, false);
 
 		const result = converter.asUri('file://localhost/folder/file');
 		strictEqual('file://localhost/folder/file.vscode', result.toString());

--- a/client/src/common/client.ts
+++ b/client/src/common/client.ts
@@ -371,6 +371,7 @@ export type LanguageClientOptions = {
 	markdown?: {
 		isTrusted?: boolean | { readonly enabledCommands: readonly string[] };
 		supportHtml?: boolean;
+		supportThemeIcons?: boolean;
 	};
 } & $NotebookDocumentOptions & $DiagnosticPullOptions & $ConfigurationOptions;
 
@@ -403,6 +404,7 @@ type ResolvedClientOptions = {
 	markdown: {
 		isTrusted: boolean | { readonly enabledCommands: readonly string[] };
 		supportHtml: boolean;
+		supportThemeIcons: boolean;
 	};
 } & Required<$NotebookDocumentOptions> & Required<$DiagnosticPullOptions>;
 namespace ResolvedClientOptions {
@@ -534,10 +536,15 @@ export abstract class BaseLanguageClient implements FeatureClient<Middleware, La
 
 		clientOptions = clientOptions || {};
 
-		const markdown: ResolvedClientOptions['markdown'] = { isTrusted: false, supportHtml: false };
+		const markdown: ResolvedClientOptions['markdown'] = {
+			isTrusted: false,
+			supportHtml: false,
+			supportThemeIcons: false
+		};
 		if (clientOptions.markdown !== undefined) {
 			markdown.isTrusted = ResolvedClientOptions.sanitizeIsTrusted(clientOptions.markdown.isTrusted);
 			markdown.supportHtml = clientOptions.markdown.supportHtml === true;
+			markdown.supportThemeIcons = clientOptions.markdown.supportThemeIcons === true;
 		}
 
 		// const defaultInterval = (clientOptions as TestOptions).$testMode ? 50 : 60000;
@@ -618,7 +625,8 @@ export abstract class BaseLanguageClient implements FeatureClient<Middleware, La
 		this._p2c = p2c.createConverter(
 			clientOptions.uriConverters ? clientOptions.uriConverters.protocol2Code : undefined,
 			this._clientOptions.markdown.isTrusted,
-			this._clientOptions.markdown.supportHtml);
+			this._clientOptions.markdown.supportHtml,
+			this._clientOptions.markdown.supportThemeIcons);
 		this._syncedDocuments = new Map<string, TextDocument>();
 		this.registerBuiltinFeatures();
 	}

--- a/client/src/common/protocolConverter.ts
+++ b/client/src/common/protocolConverter.ts
@@ -276,7 +276,11 @@ namespace CodeBlock {
 	}
 }
 
-export function createConverter(uriConverter: URIConverter | undefined, trustMarkdown: boolean | { readonly enabledCommands: readonly string[] }, supportHtml: boolean): Converter {
+export function createConverter(
+	uriConverter: URIConverter | undefined,
+	trustMarkdown: boolean | { readonly enabledCommands: readonly string[] },
+	supportHtml: boolean,
+	supportThemeIcons: boolean): Converter {
 
 	const nullConverter = (value: string) => code.Uri.parse(value);
 
@@ -481,6 +485,7 @@ export function createConverter(uriConverter: URIConverter | undefined, trustMar
 		}
 		result.isTrusted = trustMarkdown;
 		result.supportHtml = supportHtml;
+		result.supportThemeIcons = supportThemeIcons;
 		return result;
 	}
 


### PR DESCRIPTION
VS Code provides `supportThemeIcons` in `MarkdownString` to enable showing icons in contexts like hover, but there's no equivalent support in `LanguageClientOptions` from this library.

cc @lukka @spebl