### PR TITLE
Fix npm, azure pipeline links

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This repository contains the code for the following npm modules:
 
 All npm modules are built using one Azure Pipeline. Its status is:
 
-[![Build Status](https://dev.azure.com/vscode/vscode-languageserver-node/_apis/build/status%2Fvscode-languageserver-node?branchName=main)](https://dev.azure.com/vscode/vscode-languageserver-node/_build/latest?definitionId=49&branchName=main)
+[![Build Status](https://dev.azure.com/vscode/vscode-languageserver-node/_apis/build/status%2Fvscode-languageserver-node?branchName=main)](https://dev.azure.com/vscode/vscode-languageserver-node/_build/latest?definitionId=52&branchName=main)
 
 Click [here](https://code.visualstudio.com/docs/extensions/example-language-server) for a detailed document on how to use these npm modules to implement
 language servers for [VSCode](https://code.visualstudio.com/).

--- a/jsonrpc/README.md
+++ b/jsonrpc/README.md
@@ -2,7 +2,7 @@
 
 [![NPM Version](https://img.shields.io/npm/v/vscode-jsonrpc.svg)](https://npmjs.org/package/vscode-jsonrpc)
 [![NPM Downloads](https://img.shields.io/npm/dm/vscode-jsonrpc.svg)](https://npmjs.org/package/vscode-jsonrpc)
-[![Build Status](https://dev.azure.com/ms/vscode-languageserver-node/_apis/build/status/microsoft.vscode-languageserver-node?branchName=main)](https://dev.azure.com/ms/vscode-languageserver-node/_build/latest?definitionId=439&branchName=main)
+[![Build Status](https://dev.azure.com/vscode/vscode-languageserver-node/_apis/build/status%2Fvscode-languageserver-node?branchName=main)](https://dev.azure.com/vscode/vscode-languageserver-node/_build/latest?definitionId=52&branchName=main)
 
 This npm module implements the base messaging protocol spoken between a VSCode language server and a VSCode language client.
 

--- a/protocol/README.md
+++ b/protocol/README.md
@@ -1,7 +1,7 @@
 # VSCode Language Server - Protocol Module
 
-[![NPM Version](https://img.shields.io/npm/v/vscode-languageserver-protocol.svg)](https://npmjs.org/package/vscode-languageclient)
-[![NPM Downloads](https://img.shields.io/npm/dm/vscode-languageserver-protocol.svg)](https://npmjs.org/package/vscode-languageclient)
+[![NPM Version](https://img.shields.io/npm/v/vscode-languageserver-protocol.svg)](https://npmjs.org/package/vscode-languageserver-protocol)
+[![NPM Downloads](https://img.shields.io/npm/dm/vscode-languageserver-protocol.svg)](https://npmjs.org/package/vscode-languageserver-protocol)
 [![Build Status](https://dev.azure.com/ms/vscode-languageserver-node/_apis/build/status/microsoft.vscode-languageserver-node?branchName=main)](https://dev.azure.com/ms/vscode-languageserver-node/_build/latest?definitionId=439&branchName=main)
 
 This npm module is a tool independent implementation of the language server protocol and can be used in any type of node application. Please note that the protocol is versioned using the LSP specification version number. Since the protocol depends on the `vscode-jsonrpc` version a a breaking change on that dependencies might not be reflected in a major version change of this module. Changing the major version number in these cases was more confusing this it would result in a version mismatch between the protocol and the LSP specification.

--- a/protocol/README.md
+++ b/protocol/README.md
@@ -2,7 +2,7 @@
 
 [![NPM Version](https://img.shields.io/npm/v/vscode-languageserver-protocol.svg)](https://npmjs.org/package/vscode-languageserver-protocol)
 [![NPM Downloads](https://img.shields.io/npm/dm/vscode-languageserver-protocol.svg)](https://npmjs.org/package/vscode-languageserver-protocol)
-[![Build Status](https://dev.azure.com/ms/vscode-languageserver-node/_apis/build/status/microsoft.vscode-languageserver-node?branchName=main)](https://dev.azure.com/ms/vscode-languageserver-node/_build/latest?definitionId=439&branchName=main)
+[![Build Status](https://dev.azure.com/vscode/vscode-languageserver-node/_apis/build/status%2Fvscode-languageserver-node?branchName=main)](https://dev.azure.com/vscode/vscode-languageserver-node/_build/latest?definitionId=52&branchName=main)
 
 This npm module is a tool independent implementation of the language server protocol and can be used in any type of node application. Please note that the protocol is versioned using the LSP specification version number. Since the protocol depends on the `vscode-jsonrpc` version a a breaking change on that dependencies might not be reflected in a major version change of this module. Changing the major version number in these cases was more confusing this it would result in a version mismatch between the protocol and the LSP specification.
 

--- a/server/README.md
+++ b/server/README.md
@@ -2,7 +2,7 @@
 
 [![NPM Version](https://img.shields.io/npm/v/vscode-languageserver.svg)](https://npmjs.org/package/vscode-languageserver)
 [![NPM Downloads](https://img.shields.io/npm/dm/vscode-languageserver.svg)](https://npmjs.org/package/vscode-languageserver)
-[![Build Status](https://dev.azure.com/ms/vscode-languageserver-node/_apis/build/status/microsoft.vscode-languageserver-node?branchName=main)](https://dev.azure.com/ms/vscode-languageserver-node/_build/latest?definitionId=439&branchName=main)
+[![Build Status](https://dev.azure.com/vscode/vscode-languageserver-node/_apis/build/status%2Fvscode-languageserver-node?branchName=main)](https://dev.azure.com/vscode/vscode-languageserver-node/_build/latest?definitionId=52&branchName=main)
 
 Npm module to implement a VSCode language server using [Node.js](https://nodejs.org/) as a runtime.
 

--- a/types/README.md
+++ b/types/README.md
@@ -2,7 +2,7 @@
 
 [![NPM Version](https://img.shields.io/npm/v/vscode-languageserver-types.svg)](https://npmjs.org/package/vscode-languageserver-types)
 [![NPM Downloads](https://img.shields.io/npm/dm/vscode-languageserver-types.svg)](https://npmjs.org/package/vscode-languageserver-types)
-[![Build Status](https://dev.azure.com/ms/vscode-languageserver-node/_apis/build/status/microsoft.vscode-languageserver-node?branchName=main)](https://dev.azure.com/ms/vscode-languageserver-node/_build/latest?definitionId=439&branchName=main)
+[![Build Status](https://dev.azure.com/vscode/vscode-languageserver-node/_apis/build/status%2Fvscode-languageserver-node?branchName=main)](https://dev.azure.com/vscode/vscode-languageserver-node/_build/latest?definitionId=52&branchName=main)
 
 Npm module containing the types used by the VSCode language client and [Node.js](https://nodejs.org/) language server
 


### PR DESCRIPTION
- protocol module's NPM badge link leads to `vscode-languageclient`, not `vscode-languageserver-protocol`
- Current Azure pipeline definition id is 52 (I presume)
- Azure pipeline link in each modules leads to `ms/vscode-languageserver-node`, not `vscode/vscode-languageserver-node`