### PR TITLE
Add support for CompletionList "applyKind" to control how defaults and per-item commitCharacters/data are combined

### DIFF
--- a/client-node-tests/src/converter.test.ts
+++ b/client-node-tests/src/converter.test.ts
@@ -986,6 +986,18 @@ suite('Protocol Converter', () => {
 		deepStrictEqual(protoResult.data, {'d': 'd', 'i': 'i'}); // gets default for 'd'
 	});
 
+	test('Completion Result - applyKind:merge - data - both supplied, item has non-null falsy fields', async () => {
+		const completionResult: proto.CompletionList = {
+			isIncomplete: false,
+			itemDefaults: { data: { 'd1': 'd1', 'd2': 'd2' } },
+			applyKind: { data: 'merge' },
+			items: [{ label: 'item', data: { 'd1': 0, 'd2': ''} }] // Both falsy, but should be used.
+		};
+		const result = await p2c.asCompletionResult(completionResult);
+		const protoResult = await c2p.asCompletionItem(result.items[0]);
+		deepStrictEqual(protoResult.data, {'d1': 0, 'd2': ''});
+	});
+
 	test('Parameter Information', async () => {
 		const parameterInfo: proto.ParameterInformation = {
 			label: 'label'

--- a/client-node-tests/src/converter.test.ts
+++ b/client-node-tests/src/converter.test.ts
@@ -874,7 +874,7 @@ suite('Protocol Converter', () => {
 			isIncomplete: false,
 			itemDefaults: { commitCharacters: ['1'] },
 			// Set other fields to "merge" to ensure the correct field was used.
-			applyKind: { commitCharacters: 'replace', data: 'merge' },
+			applyKind: { commitCharacters: proto.ApplyKind.Replace, data: proto.ApplyKind.Merge },
 			items: [{ label: 'item', commitCharacters: ['2'] }]
 		};
 		const result = await p2c.asCompletionResult(completionResult);
@@ -886,7 +886,7 @@ suite('Protocol Converter', () => {
 			isIncomplete: false,
 			itemDefaults: { commitCharacters: ['1'] },
 			// Set other fields to "merge" to ensure the correct field was used.
-			applyKind: { commitCharacters: 'replace', data: 'merge' },
+			applyKind: { commitCharacters: proto.ApplyKind.Replace, data: proto.ApplyKind.Merge },
 			items: [{ label: 'item', commitCharacters: [] }]
 		};
 		const result = await p2c.asCompletionResult(completionResult);
@@ -897,7 +897,7 @@ suite('Protocol Converter', () => {
 		const completionResult: proto.CompletionList = {
 			isIncomplete: false,
 			itemDefaults: { commitCharacters: ['d', 'b'] },
-			applyKind: { commitCharacters: 'merge' },
+			applyKind: { commitCharacters: proto.ApplyKind.Merge },
 			items: [{ label: 'item', commitCharacters: ['b', 'i'] }]
 		};
 		const result = await p2c.asCompletionResult(completionResult);
@@ -908,7 +908,7 @@ suite('Protocol Converter', () => {
 		const completionResult: proto.CompletionList = {
 			isIncomplete: false,
 			itemDefaults: { commitCharacters: ['d'] },
-			applyKind: { commitCharacters: 'merge' },
+			applyKind: { commitCharacters: proto.ApplyKind.Merge },
 			items: [{ label: 'item' }]
 		};
 		const result = await p2c.asCompletionResult(completionResult);
@@ -919,7 +919,7 @@ suite('Protocol Converter', () => {
 		const completionResult: proto.CompletionList = {
 			isIncomplete: false,
 			itemDefaults: { },
-			applyKind: { commitCharacters: 'merge' },
+			applyKind: { commitCharacters: proto.ApplyKind.Merge },
 			items: [{ label: 'item', commitCharacters: ['i'] }]
 		};
 		const result = await p2c.asCompletionResult(completionResult);
@@ -942,7 +942,7 @@ suite('Protocol Converter', () => {
 			isIncomplete: false,
 			itemDefaults: { data: { 'd': 'd' } },
 			// Set other fields to "merge" to ensure the correct field was used.
-			applyKind: { data: 'replace', commitCharacters: 'merge' },
+			applyKind: { data: proto.ApplyKind.Replace, commitCharacters: proto.ApplyKind.Merge },
 			items: [{ label: 'item', data: { 'i': 'i' } }]
 		};
 		const result = await p2c.asCompletionResult(completionResult);
@@ -954,7 +954,7 @@ suite('Protocol Converter', () => {
 		const completionResult: proto.CompletionList = {
 			isIncomplete: false,
 			itemDefaults: { data: { 'd': 'd' } },
-			applyKind: { data: 'merge' },
+			applyKind: { data: proto.ApplyKind.Merge },
 			items: [{ label: 'item', data: { 'i': 'i' } }]
 		};
 		const result = await p2c.asCompletionResult(completionResult);
@@ -966,7 +966,7 @@ suite('Protocol Converter', () => {
 		const completionResult: proto.CompletionList = {
 			isIncomplete: false,
 			itemDefaults: { data: { 'd': 'd' } },
-			applyKind: { data: 'merge' },
+			applyKind: { data: proto.ApplyKind.Merge },
 			items: [{ label: 'item', data: null }] // null treated like undefined
 		};
 		const result = await p2c.asCompletionResult(completionResult);
@@ -978,7 +978,7 @@ suite('Protocol Converter', () => {
 		const completionResult: proto.CompletionList = {
 			isIncomplete: false,
 			itemDefaults: { data: { 'd': 'd' } },
-			applyKind: { data: 'merge' },
+			applyKind: { data: proto.ApplyKind.Merge },
 			items: [{ label: 'item', data: { 'd': null, 'i': 'i'} }] // null treated like undefined
 		};
 		const result = await p2c.asCompletionResult(completionResult);
@@ -990,7 +990,7 @@ suite('Protocol Converter', () => {
 		const completionResult: proto.CompletionList = {
 			isIncomplete: false,
 			itemDefaults: { data: { 'd1': 'd1', 'd2': 'd2' } },
-			applyKind: { data: 'merge' },
+			applyKind: { data: proto.ApplyKind.Merge },
 			items: [{ label: 'item', data: { 'd1': 0, 'd2': ''} }] // Both falsy, but should be used.
 		};
 		const result = await p2c.asCompletionResult(completionResult);

--- a/client/src/common/completion.ts
+++ b/client/src/common/completion.ts
@@ -92,7 +92,8 @@ export class CompletionItemFeature extends TextDocumentLanguageFeature<Completio
 		completion.completionList = {
 			itemDefaults: [
 				'commitCharacters', 'editRange', 'insertTextFormat', 'insertTextMode', 'data'
-			]
+			],
+			applyKindSupport: true,
 		};
 	}
 

--- a/protocol/metaModel.json
+++ b/protocol/metaModel.json
@@ -5168,8 +5168,18 @@
 						"name": "CompletionItemDefaults"
 					},
 					"optional": true,
-					"documentation": "In many cases the items of an actual completion result share the same\nvalue for properties like `commitCharacters` or the range of a text\nedit. A completion list can therefore define item defaults which will\nbe used if a completion item itself doesn't specify the value.\n\nIf a completion list specifies a default value and a completion item\nalso specifies a corresponding value the one from the item is used.\n\nServers are only allowed to return default values if the client\nsignals support for this via the `completionList.itemDefaults`\ncapability.\n\n@since 3.17.0",
+					"documentation": "In many cases the items of an actual completion result share the same\nvalue for properties like `commitCharacters` or the range of a text\nedit. A completion list can therefore define item defaults which will\nbe used if a completion item itself doesn't specify the value.\n\nIf a completion list specifies a default value and a completion item\nalso specifies a corresponding value, the rules for combining these are\ndefined by `applyKinds` (if the client supports it), defaulting to\n\"replace\".\n\nServers are only allowed to return default values if the client\nsignals support for this via the `completionList.itemDefaults`\ncapability.\n\n@since 3.17.0",
 					"since": "3.17.0"
+				},
+				{
+					"name": "applyKind",
+					"type": {
+						"kind": "reference",
+						"name": "CompletionItemApplyKinds"
+					},
+					"optional": true,
+					"documentation": "Specifies how fields from a completion item should be combined with those\nfrom `completionList.itemDefaults`.\n\nIn unspecified, all fields will be treated as \"replace\".\n\nIf a field's value is \"replace\", the value from a completion item (if\nprovided and not `null`) will always be used instead of the value from\n`completionItem.itemDefaults`.\n\nIf a field's value is \"merge\", the values will be merged using the rules\ndefined against each field below.\n\nServers are only allowed to return `applyKind` if the client\nsignals support for this via the `completionList.applyKindSupport`\ncapability.\n\n@since 3.18.0",
+					"since": "3.18.0"
 				},
 				{
 					"name": "items",
@@ -9182,8 +9192,35 @@
 					"since": "3.17.0"
 				}
 			],
-			"documentation": "In many cases the items of an actual completion result share the same\nvalue for properties like `commitCharacters` or the range of a text\nedit. A completion list can therefore define item defaults which will\nbe used if a completion item itself doesn't specify the value.\n\nIf a completion list specifies a default value and a completion item\nalso specifies a corresponding value the one from the item is used.\n\nServers are only allowed to return default values if the client\nsignals support for this via the `completionList.itemDefaults`\ncapability.\n\n@since 3.17.0",
+			"documentation": "In many cases the items of an actual completion result share the same\nvalue for properties like `commitCharacters` or the range of a text\nedit. A completion list can therefore define item defaults which will\nbe used if a completion item itself doesn't specify the value.\n\nIf a completion list specifies a default value and a completion item\nalso specifies a corresponding value, the rules for combining these are\ndefined by `applyKinds` (if the client supports it), defaulting to\n\"replace\".\n\nServers are only allowed to return default values if the client\nsignals support for this via the `completionList.itemDefaults`\ncapability.\n\n@since 3.17.0",
 			"since": "3.17.0"
+		},
+		{
+			"name": "CompletionItemApplyKinds",
+			"properties": [
+				{
+					"name": "commitCharacters",
+					"type": {
+						"kind": "reference",
+						"name": "ApplyKind"
+					},
+					"optional": true,
+					"documentation": "Specifies whether commitCharacters on a completion will replace or be\nmerged with those in `completionList.itemDefaults.commitCharacters`.\n\nIf \"replace\", the commit characters from the completion item will\nalways be used unless not provided, in which case those from\n`completionList.itemDefaults.commitCharacters` will be used. An\nempty list can be used if a completion item does not have any commit\ncharacters and also should not use those from\n`completionList.itemDefaults.commitCharacters`.\n\nIf \"merge\" the commitCharacters for the completion will be the union\nof all values in both `completionList.itemDefaults.commitCharacters`\nand the completion's own `commitCharacters`.\n\n@since 3.18.0",
+					"since": "3.18.0"
+				},
+				{
+					"name": "data",
+					"type": {
+						"kind": "reference",
+						"name": "ApplyKind"
+					},
+					"optional": true,
+					"documentation": "Specifies whether the `data` field on a completion will replace or\nbe merged with data from `completionList.itemDefaults.data`.\n\nIf \"replace\", the data from the completion item will be used if\nprovided (and not `null`), otherwise\n`completionList.itemDefaults.data` will be used. An empty object can\nbe used if a completion item does not have any data but also should\nnot use the value from `completionList.itemDefaults.data`.\n\nIf \"merge\", a shallow merge will be performed between\n`completionList.itemDefaults.data` and the completion's own data\nusing the following rules:\n\n- If a completion's `data` field is not provided (or `null`), the\n  entire `data` field from `completionList.itemDefaults.data` will be\n  used as-is.\n- If a completion's `data` field is provided, each field will\n  overwrite the field of the same name in\n  `completionList.itemDefaults.data` but no merging of nested fields\n  within that value will occur.\n\n@since 3.18.0",
+					"since": "3.18.0"
+				}
+			],
+			"documentation": "Specifies how fields from a completion item should be combined with those\nfrom `completionList.itemDefaults`.\n\nIn unspecified, all fields will be treated as \"replace\".\n\nIf a field's value is \"replace\", the value from a completion item (if\nprovided and not `null`) will always be used instead of the value from\n`completionItem.itemDefaults`.\n\nIf a field's value is \"merge\", the values will be merged using the rules\ndefined against each field below.\n\nServers are only allowed to return `applyKind` if the client\nsignals support for this via the `completionList.applyKindSupport`\ncapability.\n\n@since 3.18.0",
+			"since": "3.18.0"
 		},
 		{
 			"name": "CompletionOptions",
@@ -13537,6 +13574,16 @@
 					"optional": true,
 					"documentation": "The client supports the following itemDefaults on\na completion list.\n\nThe value lists the supported property names of the\n`CompletionList.itemDefaults` object. If omitted\nno properties are supported.\n\n@since 3.17.0",
 					"since": "3.17.0"
+				},
+				{
+					"name": "applyKindSupport",
+					"type": {
+						"kind": "base",
+						"name": "boolean"
+					},
+					"optional": true,
+					"documentation": "Specifies whether the client supports `CompletionList.applyKind` to\nindicate how supported values from `completionList.itemDefaults`\nand `completion` will be combined.\n\nIf a client supports `applyKind` it must support it for all fields\nthat it supports that are listed in `CompletionList.applyKind`. This\nmeans when clients add support for new/future fields in completion\nitems the MUST also support merge for them if those fields are\ndefined in `CompletionList.applyKind`.\n\n@since 3.18.0",
+					"since": "3.18.0"
 				}
 			],
 			"documentation": "The client supports the following `CompletionList` specific\ncapabilities.\n\n@since 3.17.0",
@@ -15256,6 +15303,27 @@
 				}
 			],
 			"documentation": "How a completion was triggered"
+		},
+		{
+			"name": "ApplyKind",
+			"type": {
+				"kind": "base",
+				"name": "string"
+			},
+			"values": [
+				{
+					"name": "Replace",
+					"value": "replace",
+					"documentation": "The value from the individual item (if provided and not `null`) will be\nused instead of the default."
+				},
+				{
+					"name": "Merge",
+					"value": "merge",
+					"documentation": "The value from the item will be merged with the default.\n\nThe specific rules for mergeing values are defined against each field\nthat supports merging."
+				}
+			],
+			"documentation": "Defines how values from a set of defaults and an individual item will be\nmerged.\n\n@since 3.18.0",
+			"since": "3.18.0"
 		},
 		{
 			"name": "SignatureHelpTriggerKind",

--- a/protocol/metaModel.json
+++ b/protocol/metaModel.json
@@ -5178,7 +5178,7 @@
 						"name": "CompletionItemApplyKinds"
 					},
 					"optional": true,
-					"documentation": "Specifies how fields from a completion item should be combined with those\nfrom `completionList.itemDefaults`.\n\nIn unspecified, all fields will be treated as \"replace\".\n\nIf a field's value is \"replace\", the value from a completion item (if\nprovided and not `null`) will always be used instead of the value from\n`completionItem.itemDefaults`.\n\nIf a field's value is \"merge\", the values will be merged using the rules\ndefined against each field below.\n\nServers are only allowed to return `applyKind` if the client\nsignals support for this via the `completionList.applyKindSupport`\ncapability.\n\n@since 3.18.0",
+					"documentation": "Specifies how fields from a completion item should be combined with those\nfrom `completionList.itemDefaults`.\n\nIf unspecified, all fields will be treated as \"replace\".\n\nIf a field's value is \"replace\", the value from a completion item (if\nprovided and not `null`) will always be used instead of the value from\n`completionItem.itemDefaults`.\n\nIf a field's value is \"merge\", the values will be merged using the rules\ndefined against each field below.\n\nServers are only allowed to return `applyKind` if the client\nsignals support for this via the `completionList.applyKindSupport`\ncapability.\n\n@since 3.18.0",
 					"since": "3.18.0"
 				},
 				{
@@ -9219,7 +9219,7 @@
 					"since": "3.18.0"
 				}
 			],
-			"documentation": "Specifies how fields from a completion item should be combined with those\nfrom `completionList.itemDefaults`.\n\nIn unspecified, all fields will be treated as \"replace\".\n\nIf a field's value is \"replace\", the value from a completion item (if\nprovided and not `null`) will always be used instead of the value from\n`completionItem.itemDefaults`.\n\nIf a field's value is \"merge\", the values will be merged using the rules\ndefined against each field below.\n\nServers are only allowed to return `applyKind` if the client\nsignals support for this via the `completionList.applyKindSupport`\ncapability.\n\n@since 3.18.0",
+			"documentation": "Specifies how fields from a completion item should be combined with those\nfrom `completionList.itemDefaults`.\n\nIf unspecified, all fields will be treated as \"replace\".\n\nIf a field's value is \"replace\", the value from a completion item (if\nprovided and not `null`) will always be used instead of the value from\n`completionItem.itemDefaults`.\n\nIf a field's value is \"merge\", the values will be merged using the rules\ndefined against each field below.\n\nServers are only allowed to return `applyKind` if the client\nsignals support for this via the `completionList.applyKindSupport`\ncapability.\n\n@since 3.18.0",
 			"since": "3.18.0"
 		},
 		{

--- a/protocol/src/common/protocol.ts
+++ b/protocol/src/common/protocol.ts
@@ -2450,6 +2450,21 @@ export interface CompletionListCapabilities {
 	 * @since 3.17.0
 	 */
 	itemDefaults?: string[];
+
+	/**
+	 * Specifies whether the client supports `CompletionList.applyKind` to
+	 * indicate how supported values from `completionList.itemDefaults`
+	 * and `completion` will be combined.
+	 *
+	 * If a client supports `applyKind` it must support it for all fields
+	 * that it supports that are listed in `CompletionList.applyKind`. This
+	 * means when clients add support for new/future fields in completion
+	 * items the MUST also support merge for them if those fields are
+	 * defined in `CompletionList.applyKind`.
+	 *
+	 * @since 3.18.0
+	 */
+	applyKindSupport?: boolean;
 }
 
 /**

--- a/types/src/main.ts
+++ b/types/src/main.ts
@@ -2491,7 +2491,7 @@ export type EditRangeWithInsertReplace = {
  * If a completion list specifies a default value and a completion item
  * also specifies a corresponding value, the rules for combining these are
  * defined by `applyKinds` (if the client supports it), defaulting to
- * "replace".
+ * ApplyKind.Replace.
  *
  * Servers are only allowed to return default values if the client
  * signals support for this via the `completionList.itemDefaults`
@@ -2540,13 +2540,13 @@ export interface CompletionItemDefaults {
  * Specifies how fields from a completion item should be combined with those
  * from `completionList.itemDefaults`.
  *
- * In unspecified, all fields will be treated as "replace".
+ * If unspecified, all fields will be treated as ApplyKind.Replace.
  *
- * If a field's value is "replace", the value from a completion item (if
+ * If a field's value is ApplyKind.Replace, the value from a completion item (if
  * provided and not `null`) will always be used instead of the value from
  * `completionItem.itemDefaults`.
  *
- * If a field's value is "merge", the values will be merged using the rules
+ * If a field's value is ApplyKind.Merge, the values will be merged using the rules
  * defined against each field below.
  *
  * Servers are only allowed to return `applyKind` if the client
@@ -2560,15 +2560,15 @@ export interface CompletionItemApplyKinds {
 	 * Specifies whether commitCharacters on a completion will replace or be
 	 * merged with those in `completionList.itemDefaults.commitCharacters`.
 	 *
-	 * If "replace", the commit characters from the completion item will
+	 * If ApplyKind.Replace, the commit characters from the completion item will
 	 * always be used unless not provided, in which case those from
 	 * `completionList.itemDefaults.commitCharacters` will be used. An
 	 * empty list can be used if a completion item does not have any commit
 	 * characters and also should not use those from
 	 * `completionList.itemDefaults.commitCharacters`.
 	 *
-	 * If "merge" the commitCharacters for the completion will be the union
-	 * of all values in both `completionList.itemDefaults.commitCharacters`
+	 * If ApplyKind.Merge the commitCharacters for the completion will be the
+	 * union of all values in both `completionList.itemDefaults.commitCharacters`
 	 * and the completion's own `commitCharacters`.
 	 *
 	 * @since 3.18.0
@@ -2579,13 +2579,13 @@ export interface CompletionItemApplyKinds {
 	 * Specifies whether the `data` field on a completion will replace or
 	 * be merged with data from `completionList.itemDefaults.data`.
 	 *
-	 * If "replace", the data from the completion item will be used if
+	 * If ApplyKind.Replace, the data from the completion item will be used if
 	 * provided (and not `null`), otherwise
 	 * `completionList.itemDefaults.data` will be used. An empty object can
 	 * be used if a completion item does not have any data but also should
 	 * not use the value from `completionList.itemDefaults.data`.
 	 *
-	 * If "merge", a shallow merge will be performed between
+	 * If ApplyKind.Merge, a shallow merge will be performed between
 	 * `completionList.itemDefaults.data` and the completion's own data
 	 * using the following rules:
 	 *
@@ -2624,7 +2624,7 @@ export interface CompletionList {
 	 * If a completion list specifies a default value and a completion item
 	 * also specifies a corresponding value, the rules for combining these are
 	 * defined by `applyKinds` (if the client supports it), defaulting to
-	 * "replace".
+	 * ApplyKind.Replace.
 	 *
 	 * Servers are only allowed to return default values if the client
 	 * signals support for this via the `completionList.itemDefaults`
@@ -2638,14 +2638,14 @@ export interface CompletionList {
 	 * Specifies how fields from a completion item should be combined with those
 	 * from `completionList.itemDefaults`.
 	 *
-	 * In unspecified, all fields will be treated as "replace".
+	 * If unspecified, all fields will be treated as ApplyKind.Replace.
 	 *
-	 * If a field's value is "replace", the value from a completion item (if
-	 * provided and not `null`) will always be used instead of the value from
-	 * `completionItem.itemDefaults`.
+	 * If a field's value is ApplyKind.Replace, the value from a completion item
+	 * (if provided and not `null`) will always be used instead of the value
+	 * from `completionItem.itemDefaults`.
 	 *
-	 * If a field's value is "merge", the values will be merged using the rules
-	 * defined against each field below.
+	 * If a field's value is ApplyKind.Merge, the values will be merged using
+	 * the rules defined against each field below.
 	 *
 	 * Servers are only allowed to return `applyKind` if the client
 	 * signals support for this via the `completionList.applyKindSupport`

--- a/types/src/main.ts
+++ b/types/src/main.ts
@@ -2221,6 +2221,36 @@ export namespace InsertTextMode {
 export type InsertTextMode = 1 | 2;
 
 /**
+ * Defines how values from a set of defaults and an individual item will be
+ * merged.
+ *
+ * @since 3.18.0
+ */
+export namespace ApplyKind {
+	/**
+	 * The value from the individual item (if provided and not `null`) will be
+	 * used instead of the default.
+	 */
+	export const Replace: 'replace' = 'replace';
+
+	/**
+	 * The value from the item will be merged with the default.
+	 *
+	 * The specific rules for mergeing values are defined against each field
+	 * that supports merging.
+	 */
+	export const Merge: 'merge' = 'merge';
+}
+
+/**
+ * Defines how values from a set of defaults and an individual item will be
+ * merged.
+ *
+ * @since 3.18.0
+ */
+export type ApplyKind = 'replace' | 'merge';
+
+/**
  * Additional details for a completion item label.
  *
  * @since 3.17.0
@@ -2459,7 +2489,9 @@ export type EditRangeWithInsertReplace = {
  * be used if a completion item itself doesn't specify the value.
  *
  * If a completion list specifies a default value and a completion item
- * also specifies a corresponding value the one from the item is used.
+ * also specifies a corresponding value, the rules for combining these are
+ * defined by `applyKinds` (if the client supports it), defaulting to
+ * "replace".
  *
  * Servers are only allowed to return default values if the client
  * signals support for this via the `completionList.itemDefaults`
@@ -2505,6 +2537,72 @@ export interface CompletionItemDefaults {
 }
 
 /**
+ * Specifies how fields from a completion item should be combined with those
+ * from `completionList.itemDefaults`.
+ *
+ * In unspecified, all fields will be treated as "replace".
+ *
+ * If a field's value is "replace", the value from a completion item (if
+ * provided and not `null`) will always be used instead of the value from
+ * `completionItem.itemDefaults`.
+ *
+ * If a field's value is "merge", the values will be merged using the rules
+ * defined against each field below.
+ *
+ * Servers are only allowed to return `applyKind` if the client
+ * signals support for this via the `completionList.applyKindSupport`
+ * capability.
+ *
+ * @since 3.18.0
+ */
+export interface CompletionItemApplyKinds {
+	/**
+	 * Specifies whether commitCharacters on a completion will replace or be
+	 * merged with those in `completionList.itemDefaults.commitCharacters`.
+	 *
+	 * If "replace", the commit characters from the completion item will
+	 * always be used unless not provided, in which case those from
+	 * `completionList.itemDefaults.commitCharacters` will be used. An
+	 * empty list can be used if a completion item does not have any commit
+	 * characters and also should not use those from
+	 * `completionList.itemDefaults.commitCharacters`.
+	 *
+	 * If "merge" the commitCharacters for the completion will be the union
+	 * of all values in both `completionList.itemDefaults.commitCharacters`
+	 * and the completion's own `commitCharacters`.
+	 *
+	 * @since 3.18.0
+	 */
+	commitCharacters?: ApplyKind;
+
+	/**
+	 * Specifies whether the `data` field on a completion will replace or
+	 * be merged with data from `completionList.itemDefaults.data`.
+	 *
+	 * If "replace", the data from the completion item will be used if
+	 * provided (and not `null`), otherwise
+	 * `completionList.itemDefaults.data` will be used. An empty object can
+	 * be used if a completion item does not have any data but also should
+	 * not use the value from `completionList.itemDefaults.data`.
+	 *
+	 * If "merge", a shallow merge will be performed between
+	 * `completionList.itemDefaults.data` and the completion's own data
+	 * using the following rules:
+	 *
+	 * - If a completion's `data` field is not provided (or `null`), the
+	 *   entire `data` field from `completionList.itemDefaults.data` will be
+	 *   used as-is.
+	 * - If a completion's `data` field is provided, each field will
+	 *   overwrite the field of the same name in
+	 *   `completionList.itemDefaults.data` but no merging of nested fields
+	 *   within that value will occur.
+	 *
+	 * @since 3.18.0
+	 */
+	data?: ApplyKind;
+}
+
+/**
  * Represents a collection of {@link CompletionItem completion items} to be presented
  * in the editor.
  */
@@ -2524,7 +2622,9 @@ export interface CompletionList {
 	 * be used if a completion item itself doesn't specify the value.
 	 *
 	 * If a completion list specifies a default value and a completion item
-	 * also specifies a corresponding value the one from the item is used.
+	 * also specifies a corresponding value, the rules for combining these are
+	 * defined by `applyKinds` (if the client supports it), defaulting to
+	 * "replace".
 	 *
 	 * Servers are only allowed to return default values if the client
 	 * signals support for this via the `completionList.itemDefaults`
@@ -2533,6 +2633,27 @@ export interface CompletionList {
 	 * @since 3.17.0
 	 */
 	itemDefaults?: CompletionItemDefaults;
+
+	/**
+	 * Specifies how fields from a completion item should be combined with those
+	 * from `completionList.itemDefaults`.
+	 *
+	 * In unspecified, all fields will be treated as "replace".
+	 *
+	 * If a field's value is "replace", the value from a completion item (if
+	 * provided and not `null`) will always be used instead of the value from
+	 * `completionItem.itemDefaults`.
+	 *
+	 * If a field's value is "merge", the values will be merged using the rules
+	 * defined against each field below.
+	 *
+	 * Servers are only allowed to return `applyKind` if the client
+	 * signals support for this via the `completionList.applyKindSupport`
+	 * capability.
+	 *
+	 * @since 3.18.0
+	 */
+	applyKind?: CompletionItemApplyKinds;
 
 	/**
 	 * The completion items.

--- a/types/src/main.ts
+++ b/types/src/main.ts
@@ -2231,7 +2231,7 @@ export namespace ApplyKind {
 	 * The value from the individual item (if provided and not `null`) will be
 	 * used instead of the default.
 	 */
-	export const Replace: 'replace' = 'replace';
+	export const Replace: 1 = 1;
 
 	/**
 	 * The value from the item will be merged with the default.
@@ -2239,7 +2239,7 @@ export namespace ApplyKind {
 	 * The specific rules for mergeing values are defined against each field
 	 * that supports merging.
 	 */
-	export const Merge: 'merge' = 'merge';
+	export const Merge: 2 = 2;
 }
 
 /**
@@ -2248,7 +2248,7 @@ export namespace ApplyKind {
  *
  * @since 3.18.0
  */
-export type ApplyKind = 'replace' | 'merge';
+export type ApplyKind = 1 | 2;
 
 /**
  * Additional details for a completion item label.


### PR DESCRIPTION
Implements the changes in the LSP spec PR at https://github.com/microsoft/language-server-protocol/pull/2018 (see also https://github.com/microsoft/language-server-protocol/issues/1802).

Please let me know if you think there are any additional test cases that need covering.