### PR TITLE
Allow resultReporter to be substituted in provideWorkspaceDiagnostics middleware.

### DIFF
--- a/client-node-tests/src/integration.test.ts
+++ b/client-node-tests/src/integration.test.ts
@@ -1387,13 +1387,18 @@ suite('Client integration', () => {
 		});
 
 		let middlewareCalled: boolean = false;
+		let reporterCalled: boolean = false;
 		(middleware as DiagnosticProviderMiddleware).provideWorkspaceDiagnostics = (resultIds, token, reporter, next) => {
 			middlewareCalled = true;
-			return next(resultIds, token, reporter);
+			return next(resultIds, token, (chunk) => {
+				reporterCalled = true;
+				reporter(chunk);
+			});
 		};
 		await provider.diagnostics.provideWorkspaceDiagnostics([], tokenSource.token, () => {});
 		(middleware as DiagnosticProviderMiddleware).provideWorkspaceDiagnostics = undefined;
 		assert.strictEqual(middlewareCalled, true);
+		assert.strictEqual(reporterCalled, true);
 	});
 
 	test('Type Hierarchy', async () => {

--- a/client/src/common/diagnostic.ts
+++ b/client/src/common/diagnostic.ts
@@ -543,7 +543,7 @@ class DiagnosticRequestor implements Disposable {
 					}
 					return converted;
 				};
-				const provideDiagnostics: ProvideWorkspaceDiagnosticSignature = (resultIds, token): ProviderResult<vsdiag.WorkspaceDiagnosticReport> => {
+				const provideDiagnostics: ProvideWorkspaceDiagnosticSignature = (resultIds, token, resultReporter): ProviderResult<vsdiag.WorkspaceDiagnosticReport> => {
 					const partialResultToken: string = generateUuid();
 					const disposable = this.client.onProgress(WorkspaceDiagnosticRequest.partialResult, partialResultToken, async (partialResult) => {
 						if (partialResult === undefined || partialResult === null) {


### PR DESCRIPTION
By not accepting a `resultReporter` parameter in `provideDiagnostics` the `provideWorkspaceDiagnostics` middleware always used the reporter it was initially passed. This means that diagnostics are always reported without the ability to manipulate them first.