### PR TITLE
Fixes #1565: LanguageKind is marked as proposed and since 3.18, but is referenced from non-proposed TextDocumentItem.languageId

### DIFF
--- a/protocol/metaModel.json
+++ b/protocol/metaModel.json
@@ -15207,9 +15207,8 @@
 				}
 			],
 			"supportsCustomValues": true,
-			"documentation": "Predefined Language kinds\n@since 3.18.0\n@proposed",
-			"since": "3.18.0",
-			"proposed": true
+			"documentation": "Predefined Language kinds\n@since 3.18.0",
+			"since": "3.18.0"
 		},
 		{
 			"name": "InlineCompletionTriggerKind",

--- a/types/src/main.ts
+++ b/types/src/main.ts
@@ -1891,7 +1891,6 @@ export interface TextDocumentItem {
 /**
  * Predefined Language kinds
  * @since 3.18.0
- * @proposed
  */
 export namespace LanguageKind {
 	export const ABAP = 'abap' as const;


### PR DESCRIPTION
Fixes #1565