### PR TITLE
Log message when overriding client's document selector

### DIFF
--- a/client-node-tests/src/integration.test.ts
+++ b/client-node-tests/src/integration.test.ts
@@ -140,10 +140,16 @@ suite ('Client Features', () => {
 
 	test('Document Selector - Client and server', () => {
 		const client = createClient(documentSelector);
+		const capabilitySelector = { documentSelector: [{ scheme: 'file', language: 'test' }] } as any;
+
+		client.info = (message, data) => {
+			assert.strictEqual(message, `Overriding client document selector for ${lsclient.FoldingRangeRequest.method}`);
+			assert.deepStrictEqual(data, capabilitySelector);
+		};
 
 		const feature = client.getFeature(lsclient.FoldingRangeRequest.method) as unknown as FoldingRangeTestFeature;
 		{
-			const [, options] = feature.getRegistration(documentSelector, { documentSelector: [{ scheme: 'file', language: 'test' }] });
+			const [, options] = feature.getRegistration(documentSelector, capabilitySelector);
 			isDefined(options);
 			const filter = options.documentSelector[0] as lsclient.TextDocumentFilter;
 			assert.strictEqual(filter.scheme, 'file');
@@ -153,7 +159,7 @@ suite ('Client Features', () => {
 		{
 			// Note that the old registration spec has no support for providing a document selector.
 			// So ensure that even if we pass one in we will not honor it.
-			const options = feature.getRegistrationOptions(documentSelector, { documentSelector: [{ scheme: 'file', language: 'test' }] } as any);
+			const options = feature.getRegistrationOptions(documentSelector, capabilitySelector);
 			isDefined(options);
 			const filter = options.documentSelector[0] as lsclient.TextDocumentFilter;
 			assert.strictEqual(filter.scheme, 'lsptests');

--- a/client/src/common/features.ts
+++ b/client/src/common/features.ts
@@ -552,6 +552,12 @@ export abstract class TextDocumentLanguageFeature<PO, RO extends TextDocumentReg
 		if (!documentSelector || !capability) {
 			return undefined;
 		}
+
+		const capabilitySelector = capability ?? (capability as any).documentSelector;
+		if (documentSelector && capabilitySelector && JSON.stringify(documentSelector) !== JSON.stringify(capabilitySelector)) {
+			this._client.info(`Overriding client document selector for ${this._registrationType.method}`, capability);
+		}
+
 		return (Is.boolean(capability) && capability === true ? { documentSelector } : Object.assign({}, capability, { documentSelector })) as RO & { documentSelector: DocumentSelector };
 	}
 


### PR DESCRIPTION
Based on this discussion https://github.com/microsoft/vscode-languageserver-node/issues/1487#issuecomment-2601661175

This PR starts logging a message when the client's document selector gets overridden for a feature, in hopes to make this behaviour easier to trace when it occurs.

For the test, I redefined the `info` method so that I could assert that the log is being invoked as expected. Let me know if that pattern is okay.