### PR TITLE
fix: avoid dispose unmatched handlers

### DIFF
--- a/jsonrpc/src/common/connection.ts
+++ b/jsonrpc/src/common/connection.ts
@@ -1327,7 +1327,9 @@ export function createMessageConnection(messageReader: MessageReader, messageWri
 			return {
 				dispose: () => {
 					if (method !== undefined) {
-						notificationHandlers.delete(method);
+						if (notificationHandlers.get(method)?.handler === handler) {
+							notificationHandlers.delete(method);
+						}
 					} else {
 						starNotificationHandler = undefined;
 					}
@@ -1341,7 +1343,9 @@ export function createMessageConnection(messageReader: MessageReader, messageWri
 			progressHandlers.set(token, handler);
 			return {
 				dispose: () => {
-					progressHandlers.delete(token);
+					if (progressHandlers.get(token) === handler) {
+						progressHandlers.delete(token);
+					}
 				}
 			};
 		},
@@ -1487,7 +1491,9 @@ export function createMessageConnection(messageReader: MessageReader, messageWri
 						return;
 					}
 					if (method !== undefined) {
-						requestHandlers.delete(method);
+						if (requestHandlers.get(method)?.handler === handler) {
+							requestHandlers.delete(method);
+						}
 					} else {
 						starRequestHandler = undefined;
 					}


### PR DESCRIPTION
When multiple handlers with the same type is registered for json rpc request/notification/progress, only the last handler will be kept. However, calls of previous registration's returned disposable will unexpectedly remove the registered handler.