### PR TITLE
add support for VS Code's LogOutputChannel API

### DIFF
--- a/client/src/node/main.ts
+++ b/client/src/node/main.ts
@@ -7,8 +7,10 @@ import * as cp from 'child_process';
 import ChildProcess = cp.ChildProcess;
 import * as fs from 'fs';
 import * as path from 'path';
+import * as stream from 'stream';
+import * as readline from 'readline';
 
-import { workspace as Workspace, Disposable, version as VSCodeVersion } from 'vscode';
+import { workspace as Workspace, Disposable, version as VSCodeVersion, OutputChannel, LogOutputChannel } from 'vscode';
 
 import * as Is from '../common/utils/is';
 import { BaseLanguageClient, LanguageClientOptions, MessageTransports, ShutdownMode } from '../common/client';
@@ -280,6 +282,24 @@ export class LanguageClient extends BaseLanguageClient {
 			}
 		}
 
+		function isLogOutputChannel(channel: OutputChannel): channel is LogOutputChannel {
+			const candidate = channel as LogOutputChannel;
+			return candidate.trace !== undefined && candidate.debug !== undefined && candidate.info !== undefined && candidate.warn !== undefined && candidate.error !== undefined;
+		}
+
+		function pipeReadableToOutputChannel(input: stream.Readable, outputChannel: OutputChannel) {
+			if (isLogOutputChannel(outputChannel)) {
+				readline.createInterface({
+					input: input,
+					crlfDelay: Infinity,
+					terminal: false,
+					historySize: 0,
+				}).on('line', data => outputChannel.appendLine(data));
+			} else {
+				input.on('data', data => outputChannel.append(Is.string(data) ? data : data.toString(encoding)));
+			}
+		}
+
 		const server = this._serverOptions;
 		// We got a function.
 		if (Is.func(server)) {
@@ -299,7 +319,7 @@ export class LanguageClient extends BaseLanguageClient {
 						cp = result;
 						this._isDetached = false;
 					}
-					cp.stderr!.on('data', data => this.outputChannel.append(Is.string(data) ? data : data.toString(encoding)));
+					pipeReadableToOutputChannel(cp.stderr!, this.outputChannel);
 					return { reader: new StreamMessageReader(cp.stdout!), writer: new StreamMessageWriter(cp.stdin!) };
 				}
 			});
@@ -355,9 +375,9 @@ export class LanguageClient extends BaseLanguageClient {
 							return handleChildProcessStartError(serverProcess, `Launching server using runtime ${runtime} failed.`);
 						}
 						this._serverProcess = serverProcess;
-						serverProcess.stderr.on('data', data => this.outputChannel.append(Is.string(data) ? data : data.toString(encoding)));
+						pipeReadableToOutputChannel(serverProcess.stderr, this.outputChannel);
 						if (transport === TransportKind.ipc) {
-							serverProcess.stdout.on('data', data => this.outputChannel.append(Is.string(data) ? data : data.toString(encoding)));
+							pipeReadableToOutputChannel(serverProcess.stdout, this.outputChannel);
 							return Promise.resolve({ reader: new IPCMessageReader(serverProcess), writer: new IPCMessageWriter(serverProcess) });
 						} else {
 							return Promise.resolve({ reader: new StreamMessageReader(serverProcess.stdout), writer: new StreamMessageWriter(serverProcess.stdin) });
@@ -369,8 +389,8 @@ export class LanguageClient extends BaseLanguageClient {
 								return handleChildProcessStartError(process, `Launching server using runtime ${runtime} failed.`);
 							}
 							this._serverProcess = process;
-							process.stderr.on('data', data => this.outputChannel.append(Is.string(data) ? data : data.toString(encoding)));
-							process.stdout.on('data', data => this.outputChannel.append(Is.string(data) ? data : data.toString(encoding)));
+							pipeReadableToOutputChannel(process.stderr, this.outputChannel);
+							pipeReadableToOutputChannel(process.stdout, this.outputChannel);
 							return transport.onConnected().then((protocol) => {
 								return { reader: protocol[0], writer: protocol[1] };
 							});
@@ -382,8 +402,8 @@ export class LanguageClient extends BaseLanguageClient {
 								return handleChildProcessStartError(process, `Launching server using runtime ${runtime} failed.`);
 							}
 							this._serverProcess = process;
-							process.stderr.on('data', data => this.outputChannel.append(Is.string(data) ? data : data.toString(encoding)));
-							process.stdout.on('data', data => this.outputChannel.append(Is.string(data) ? data : data.toString(encoding)));
+							pipeReadableToOutputChannel(process.stderr, this.outputChannel);
+							pipeReadableToOutputChannel(process.stdout, this.outputChannel);
 							return transport.onConnected().then((protocol) => {
 								return { reader: protocol[0], writer: protocol[1] };
 							});
@@ -413,9 +433,9 @@ export class LanguageClient extends BaseLanguageClient {
 							const sp = cp.fork(node.module, args || [], options);
 							assertStdio(sp);
 							this._serverProcess = sp;
-							sp.stderr.on('data', data => this.outputChannel.append(Is.string(data) ? data : data.toString(encoding)));
+							pipeReadableToOutputChannel(sp.stderr, this.outputChannel);
 							if (transport === TransportKind.ipc) {
-								sp.stdout.on('data', data => this.outputChannel.append(Is.string(data) ? data : data.toString(encoding)));
+								pipeReadableToOutputChannel(sp.stdout, this.outputChannel);
 								resolve({ reader: new IPCMessageReader(this._serverProcess), writer: new IPCMessageWriter(this._serverProcess) });
 							} else {
 								resolve({ reader: new StreamMessageReader(sp.stdout), writer: new StreamMessageWriter(sp.stdin) });
@@ -425,8 +445,8 @@ export class LanguageClient extends BaseLanguageClient {
 								const sp = cp.fork(node.module, args || [], options);
 								assertStdio(sp);
 								this._serverProcess = sp;
-								sp.stderr.on('data', data => this.outputChannel.append(Is.string(data) ? data : data.toString(encoding)));
-								sp.stdout.on('data', data => this.outputChannel.append(Is.string(data) ? data : data.toString(encoding)));
+								pipeReadableToOutputChannel(sp.stderr, this.outputChannel);
+								pipeReadableToOutputChannel(sp.stdout, this.outputChannel);
 								transport.onConnected().then((protocol) => {
 									resolve({ reader: protocol[0], writer: protocol[1] });
 								}, reject);
@@ -436,8 +456,8 @@ export class LanguageClient extends BaseLanguageClient {
 								const sp = cp.fork(node.module, args || [], options);
 								assertStdio(sp);
 								this._serverProcess = sp;
-								sp.stderr.on('data', data => this.outputChannel.append(Is.string(data) ? data : data.toString(encoding)));
-								sp.stdout.on('data', data => this.outputChannel.append(Is.string(data) ? data : data.toString(encoding)));
+								pipeReadableToOutputChannel(sp.stderr, this.outputChannel);
+								pipeReadableToOutputChannel(sp.stdout, this.outputChannel);
 								transport.onConnected().then((protocol) => {
 									resolve({ reader: protocol[0], writer: protocol[1] });
 								}, reject);
@@ -467,7 +487,7 @@ export class LanguageClient extends BaseLanguageClient {
 					if (!serverProcess || !serverProcess.pid) {
 						return handleChildProcessStartError(serverProcess, `Launching server using command ${command.command} failed.`);
 					}
-					serverProcess.stderr.on('data', data => this.outputChannel.append(Is.string(data) ? data : data.toString(encoding)));
+					pipeReadableToOutputChannel(serverProcess.stderr, this.outputChannel);
 					this._serverProcess = serverProcess;
 					this._isDetached = !!options.detached;
 					return Promise.resolve({ reader: new StreamMessageReader(serverProcess.stdout), writer: new StreamMessageWriter(serverProcess.stdin) });
@@ -479,8 +499,8 @@ export class LanguageClient extends BaseLanguageClient {
 						}
 						this._serverProcess = serverProcess;
 						this._isDetached = !!options.detached;
-						serverProcess.stderr.on('data', data => this.outputChannel.append(Is.string(data) ? data : data.toString(encoding)));
-						serverProcess.stdout.on('data', data => this.outputChannel.append(Is.string(data) ? data : data.toString(encoding)));
+						pipeReadableToOutputChannel(serverProcess.stderr, this.outputChannel);
+						pipeReadableToOutputChannel(serverProcess.stdout, this.outputChannel);
 						return transport.onConnected().then((protocol) => {
 							return { reader: protocol[0], writer: protocol[1] };
 						});
@@ -493,8 +513,8 @@ export class LanguageClient extends BaseLanguageClient {
 						}
 						this._serverProcess = serverProcess;
 						this._isDetached = !!options.detached;
-						serverProcess.stderr.on('data', data => this.outputChannel.append(Is.string(data) ? data : data.toString(encoding)));
-						serverProcess.stdout.on('data', data => this.outputChannel.append(Is.string(data) ? data : data.toString(encoding)));
+						pipeReadableToOutputChannel(serverProcess.stderr, this.outputChannel);
+						pipeReadableToOutputChannel(serverProcess.stdout, this.outputChannel);
 						return transport.onConnected().then((protocol) => {
 							return { reader: protocol[0], writer: protocol[1] };
 						});


### PR DESCRIPTION
fixes #1116

This will improve the language client's support for using [LogOutputChannel](https://code.visualstudio.com/api/references/vscode-api#LogOutputChannel) instead of [OutputChannel](https://code.visualstudio.com/api/references/vscode-api#OutputChannel).

I tested these changes with the [ZLS language server](https://github.com/zigtools/zls/) which supports logging with [window/logMessage](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#window_logMessage) or optionally through stderr. To avoid making the PR description too long, I included only images of the final output. If text output or reproducible steps are wanted, I’d be happy to add them as well.

## `window/logMessage`

<details>
<summary>Before, OutputChannel</summary>

![old_client-old_channel-lsp_logs](https://github.com/user-attachments/assets/2d764b25-daaf-4140-9e07-bcef8ab52720)

</details>

<details>
<summary>After, OutputChannel</summary>

![new_client-old_channel-lsp_logs](https://github.com/user-attachments/assets/1b615872-72be-40db-8e83-53e2c637a36f)

</details>

<details>
<summary>Before, LogOutputChannel</summary>

![old_client-log_channel-lsp_logs](https://github.com/user-attachments/assets/8688f235-efc5-4b9e-93b7-00a57cc766e7)

</details>

<details>
<summary>After, LogOutputChannel</summary>

![new_client-log_channel-lsp_logs](https://github.com/user-attachments/assets/92fd9702-0f69-40e3-ac63-3af6b7939dc5)

</details>

## stderr logging

<details>
<summary>Before, OutputChannel</summary>

The `info  ( main )` part is added by the server when logging to stderr.

![old_client-old_channel-stderr_logs](https://github.com/user-attachments/assets/8a1718ba-a60f-4e61-a54e-2ff653040f76)

</details>

<details>
<summary>After, OutputChannel</summary>

![new_client-old_channel-stderr_logs](https://github.com/user-attachments/assets/7853b462-7e2f-4728-a7c1-ff6c15653555)

</details>

<details>
<summary>Before, LogOutputChannel</summary>

![old_client-log_channel-stderr_logs](https://github.com/user-attachments/assets/86680c6b-ffe4-4ef8-8de0-683ef79d5377)

</details>

<details>
<summary>After, LogOutputChannel</summary>

![new_client-log_channel-stderr_logs](https://github.com/user-attachments/assets/db56ed79-bbdf-4dd8-b3c9-b04cf2b44144)

This has since been changed to use `[INFO]` instead of `[ERROR]`.

</details>

I personally don’t have a strong preference between `LogOutputChannel` and `OutputChannel`, which is why I chose to retain support for `OutputChannel` so that extension authors to decide which one better suits the output of their language server. However, if maintaining support for `OutputChannel` is not desirable, I’m open to removing it.

---

In the following example, I modified the server to intentionally crash so that it writes a stack trace to stderr. This is meant to highlight that mixing `window/logMessage` and stderr is possible and produces readable output.

<details>
<summary>After, LogOutputChannel, <code>window/logMessage</code> + stderr</summary>

![new_client-log_channel-lsp_logs-stderr_logs](https://github.com/user-attachments/assets/19439c46-e578-4c5c-b911-12f384936595)

</details>

