### PR TITLE
Fix `workspace/textDocumentContent/refresh` request

### DIFF
--- a/client/src/common/textDocumentContent.ts
+++ b/client/src/common/textDocumentContent.ts
@@ -61,7 +61,7 @@ export class TextDocumentContentFeature implements DynamicFeature<TextDocumentCo
 			const uri = client.protocol2CodeConverter.asUri(params.uri);
 			for (const registrations of this._registrations.values()) {
 				for (const provider of registrations.providers) {
-					if (provider.scheme !== uri.scheme) {
+					if (provider.scheme === uri.scheme) {
 						provider.onDidChangeEmitter.fire(uri);
 					}
 				}


### PR DESCRIPTION
The request wasn't being forwarded to the provider, because it was guarded by an inequality check while the schemes are supposed to match.