### PR TITLE
Use `MapIterator` return types in `LinkedMap` methods.

### DIFF
--- a/jsonrpc/src/common/linkedMap.ts
+++ b/jsonrpc/src/common/linkedMap.ts
@@ -162,53 +162,51 @@ export class LinkedMap<K, V> implements Map<K, V> {
 		}
 	}
 
-	public keys(): IterableIterator<K> {
-		const state = this._state;
-		let current = this._head;
-		const iterator: IterableIterator<K> = {
-			[Symbol.iterator]: () => {
-				return iterator;
-			},
-			next: (): IteratorResult<K> => {
-				if (this._state !== state) {
-					throw new Error(`LinkedMap got modified during iteration.`);
-				}
-				if (current) {
-					const result = { value: current.key, done: false };
-					current = current.next;
-					return result;
-				} else {
-					return { value: undefined, done: true };
-				}
-			}
-		};
-		return iterator;
+	public keys(): MapIterator<K> {
+		return this._keys();
 	}
 
-	public values(): IterableIterator<V> {
+	private *_keys(): Generator<K, BuiltinIteratorReturn, unknown> {
 		const state = this._state;
 		let current = this._head;
-		const iterator: IterableIterator<V> = {
-			[Symbol.iterator]: () => {
-				return iterator;
-			},
-			next: (): IteratorResult<V> => {
-				if (this._state !== state) {
-					throw new Error(`LinkedMap got modified during iteration.`);
-				}
-				if (current) {
-					const result = { value: current.value, done: false };
-					current = current.next;
-					return result;
-				} else {
-					return { value: undefined, done: true };
-				}
+
+		while (true) {
+			if (this._state !== state) {
+				throw new Error(`LinkedMap got modified during iteration.`);
 			}
-		};
-		return iterator;
+			if (!current) {
+				return;
+			}
+
+			const yieldResult = current.key;
+			current = current.next;
+			yield yieldResult;
+		}
 	}
 
-	public entries(): IterableIterator<[K, V]> {
+	public values(): MapIterator<V> {
+		return this._values();
+	}
+
+	private *_values(): Generator<V, BuiltinIteratorReturn, unknown> {
+		const state = this._state;
+		let current = this._head;
+
+		while (true) {
+			if (this._state !== state) {
+				throw new Error(`LinkedMap got modified during iteration.`);
+			}
+			if (!current) {
+				return;
+			}
+
+			const yieldResult = current.value;
+			current = current.next;
+			yield yieldResult;
+		}
+	}
+
+	public entries(): MapIterator<[K, V]> {
 		const state = this._state;
 		let current = this._head;
 		const iterator: IterableIterator<[K, V]> = {
@@ -231,8 +229,26 @@ export class LinkedMap<K, V> implements Map<K, V> {
 		return iterator;
 	}
 
-	public [Symbol.iterator](): IterableIterator<[K, V]> {
-		return this.entries();
+	private *_entries(): Generator<[K, V], BuiltinIteratorReturn, unknown> {
+		const state = this._state;
+		let current = this._head;
+
+		while (true) {
+			if (this._state !== state) {
+				throw new Error(`LinkedMap got modified during iteration.`);
+			}
+			if (!current) {
+				return;
+			}
+
+			const yieldResult: [K, V] = [current.key, current.value];
+			current = current.next;
+			yield yieldResult;
+		}
+	}
+
+	public [Symbol.iterator](): MapIterator<[K, V]> {
+		return this._entries();
 	}
 
 	protected trimOld(newSize: number): void {


### PR DESCRIPTION
If you try to consume (or build) this library with the latest `lib`, you'll get the following error from TypeScript:

```
node_modules/.pnpm/vscode-jsonrpc@8.2.0/node_modules/vscode-jsonrpc/lib/common/linkedMap.d.ts:29:5 - error TS2416: Property 'keys' in type 'LinkedMap<K, V>' is not assignable to the same property in base type 'Map<K, V>'.
  Type '() => IterableIterator<K>' is not assignable to type '() => MapIterator<K>'.
    Type 'IterableIterator<K>' is missing the following properties from type 'MapIterator<K>': [Symbol.dispose], map, filter, take, and 9 more.

29     keys(): IterableIterator<K>;
       ~~~~
```

This is because `Map` now returns a ["richer" iterator object](https://github.com/tc39/proposal-iterator-helpers) with several methods, but `LinkedMap` just returns its own bespoke `IterableIterator`s.

The workaround I've made here is to just return an initialized generator (which currently has the same methods as any iterator from a `Map`). The declared type is a bit of a lie, but for most people this is ideal for future-proofing.

This does cause some divergences in behavior - namely, `next()` only throws once if the underlying collection has changed.