### PR TITLE
protocol: Fix typo in WorkspaceCapabilities.diagnostic field name

### DIFF
--- a/client/src/common/diagnostic.ts
+++ b/client/src/common/diagnostic.ts
@@ -1066,7 +1066,7 @@ export class DiagnosticFeature extends TextDocumentLanguageFeature<DiagnosticOpt
 		// the active editor.
 		capability.relatedDocumentSupport = false;
 
-		ensure(ensure(capabilities, 'workspace')!, 'diagnostics')!.refreshSupport = true;
+		ensure(ensure(capabilities, 'workspace')!, 'diagnostic')!.refreshSupport = true;
 	}
 
 	public initialize(capabilities: ServerCapabilities, documentSelector: DocumentSelector): void {

--- a/protocol/metaModel.json
+++ b/protocol/metaModel.json
@@ -11273,7 +11273,7 @@
 					"since": "3.17.0."
 				},
 				{
-					"name": "diagnostics",
+					"name": "diagnostic",
 					"type": {
 						"kind": "reference",
 						"name": "DiagnosticWorkspaceClientCapabilities"

--- a/protocol/src/common/protocol.ts
+++ b/protocol/src/common/protocol.ts
@@ -659,7 +659,7 @@ export interface WorkspaceClientCapabilities {
 	 *
 	 * @since 3.17.0.
 	 */
-	diagnostics?: DiagnosticWorkspaceClientCapabilities;
+	diagnostic?: DiagnosticWorkspaceClientCapabilities;
 
 	/**
 	 * Capabilities specific to the folding range requests scoped to the workspace.


### PR DESCRIPTION
This commit fixes a typo in the name of `diagnostic` field on client's workspace capabilities. Put another way, it removes the trailing `s` from the name of `diagnostic` field to align it with the LSP spec.

This turned out to be an issue with tsgo, which is generating it's JSON deserialization based on metaModel.json. This then led to it being incompatible with Zed, which is a non-VSC client.

I do not know the policy of this package with regards to breaking changes, but there's at least one language server (rust-analyzer) that is already expecting the name of this field to be `diagnostic`. 

Related:
- https://github.com/microsoft/typescript-go/issues/1396
- https://github.com/zed-extensions/tsgo/issues/6