### PR TITLE
Add capability information to `textDocument/colorPresentation`

### DIFF
--- a/protocol/metaModel.json
+++ b/protocol/metaModel.json
@@ -196,6 +196,8 @@
 				}
 			},
 			"messageDirection": "clientToServer",
+			"clientCapability": "textDocument.colorProvider",
+			"serverCapability": "colorProvider",
 			"params": {
 				"kind": "reference",
 				"name": "ColorPresentationParams"

--- a/protocol/src/common/protocol.colorProvider.ts
+++ b/protocol/src/common/protocol.colorProvider.ts
@@ -85,4 +85,5 @@ export namespace ColorPresentationRequest {
 	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
 	export const type = new ProtocolRequestType<ColorPresentationParams, ColorPresentation[], ColorPresentation[], void, WorkDoneProgressOptions & TextDocumentRegistrationOptions>(method);
 	export type HandlerSignature = RequestHandler<ColorPresentationParams, ColorPresentation[], void>;
+	export const capabilities = CM.create('textDocument.colorProvider', 'colorProvider');
 }


### PR DESCRIPTION
Adding the same capability information as `textDocument/documentColor` as this is the corresponding resolve request.