### PR TITLE
Clear workspace pull state on document close to prevent stale diagnostics

### DIFF
--- a/client/src/common/diagnostic.ts
+++ b/client/src/common/diagnostic.ts
@@ -419,7 +419,7 @@ class DiagnosticRequestor implements Disposable {
 
 			// The previous resultId from the workspace pull state can map to diagnostics we no longer have
 			// (e.g. they came from a workspace report but were overwritten by a later document pull request).
-			//Clear the workspace pull state for this document as well to ensure we get fresh diagnostics.
+			// Clear the workspace pull state for this document as well to ensure we get fresh diagnostics.
 			this.forget(PullState.workspace, document);
 		} else {
 			// We have normal pull or inter file dependencies. In this case we


### PR DESCRIPTION
Took a stab at fixing https://github.com/microsoft/vscode-languageserver-node/issues/1673

Not completely sure if this is the right solution, but doesn't seem unreasonable.  When forgetting a document, also forget the workspace pull state for it to ensure new workspace diagnostics are sent from the server.  The document pull may have changed the set of diagnostics, meaning the client no longer has the same set of diagnostics that map to the previous workspace pull.

![workspace_stale_fix](https://github.com/user-attachments/assets/67549793-6f97-4319-ac2a-12e0dfc0a0d5)
