### PR TITLE
Fixes #1698: RenameParams does not reference TextDocumentPositionParams interface in the JSON metamodel

### DIFF
--- a/protocol/metaModel.json
+++ b/protocol/metaModel.json
@@ -6402,28 +6402,18 @@
 			"name": "RenameParams",
 			"properties": [
 				{
-					"name": "textDocument",
-					"type": {
-						"kind": "reference",
-						"name": "TextDocumentIdentifier"
-					},
-					"documentation": "The document to rename."
-				},
-				{
-					"name": "position",
-					"type": {
-						"kind": "reference",
-						"name": "Position"
-					},
-					"documentation": "The position at which this request was sent."
-				},
-				{
 					"name": "newName",
 					"type": {
 						"kind": "base",
 						"name": "string"
 					},
 					"documentation": "The new name of the symbol. If the given name is not valid the\nrequest must return a {@link ResponseError} with an\nappropriate message set."
+				}
+			],
+			"extends": [
+				{
+					"kind": "reference",
+					"name": "TextDocumentPositionParams"
 				}
 			],
 			"mixins": [

--- a/protocol/src/common/protocol.ts
+++ b/protocol/src/common/protocol.ts
@@ -4076,17 +4076,7 @@ export interface RenameClientCapabilities {
 /**
  * The parameters of a {@link RenameRequest}.
  */
-export interface RenameParams extends WorkDoneProgressParams {
-	/**
-	 * The document to rename.
-	 */
-	textDocument: TextDocumentIdentifier;
-
-	/**
-	 * The position at which this request was sent.
-	 */
-	position: Position;
-
+export interface RenameParams extends TextDocumentPositionParams, WorkDoneProgressParams {
 	/**
 	 * The new name of the symbol. If the given name is not valid the
 	 * request must return a {@link ResponseError} with an


### PR DESCRIPTION
Fixes #1698