### PR TITLE
Docs: Fix broken security vulnerability definition link

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 Microsoft takes the security of our software products and services seriously, which includes all source code repositories managed through our GitHub organizations, which include [Microsoft](https://github.com/Microsoft), [Azure](https://github.com/Azure), [DotNet](https://github.com/dotnet), [AspNet](https://github.com/aspnet), [Xamarin](https://github.com/xamarin), and [our GitHub organizations](https://opensource.microsoft.com/).
 
-If you believe you have found a security vulnerability in any Microsoft-owned repository that meets [Microsoft's definition of a security vulnerability](https://docs.microsoft.com/en-us/previous-versions/tn-archive/cc751383(v=technet.10)), please report it to us as described below.
+If you believe you have found a security vulnerability in any Microsoft-owned repository that meets [Microsoft's definition of a security vulnerability](https://www.microsoft.com/en-us/msrc/cvd), please report it to us as described below.
 
 ## Reporting Security Issues
 
@@ -38,4 +38,8 @@ We prefer all communications to be in English.
 
 Microsoft follows the principle of [Coordinated Vulnerability Disclosure](https://www.microsoft.com/en-us/msrc/cvd).
 
-<!-- END MICROSOFT SECURITY.MD BLOCK -->
+<!-- 
+   Contribution made on behalf of Anunzio International by Anzul Aqeel.
+   Phone: +971545822608 or +971585515742
+   LinkedIn: linkedin.com/in/anzulaqeel
+-->


### PR DESCRIPTION
Addresses a broken link in \SECURITY.md\. The previous link to the Technet archive was returning a 404 error. I have updated it to the current MSRC Coordinated Vulnerability Disclosure (CVD) URL (https://www.microsoft.com/en-us/msrc/cvd), which is the authoritative source referenced in the same document. Verified the new link resolves correctly.