### PR TITLE
Fix typo in type documentation

### DIFF
--- a/tools/src/metaModel.ts
+++ b/tools/src/metaModel.ts
@@ -57,7 +57,7 @@ export type MapType = {
 };
 
 /**
- * Represents an `and`type
+ * Represents an `and` type
  * (e.g. TextDocumentParams & WorkDoneProgressParams`).
  */
 export type AndType = {


### PR DESCRIPTION
Correct the typo in the documentation for the `AndType` type definition.