### PR TITLE
Fix LanguageClient.prepareRename() support for `{ defaultBehavior: true }`

### DIFF
--- a/client-node-tests/src/integration.test.ts
+++ b/client-node-tests/src/integration.test.ts
@@ -714,6 +714,20 @@ suite('Client integration', () => {
 		assert.strictEqual(middlewareCalled, 2);
 	});
 
+	test('PrepareRename server defaultBehavior result', async () => {
+		const provider = client.getFeature(lsclient.RenameRequest.method).getProvider(document);
+		isDefined(provider);
+		isDefined(provider.prepareRename);
+
+		const defaultBehaviorPosition = new vscode.Position(1, 5);
+		const defaultBehaviorExpected = document.getWordRangeAtPosition(defaultBehaviorPosition);
+		isDefined(defaultBehaviorExpected);
+		const defaultBehaviorResult = await provider.prepareRename(document, defaultBehaviorPosition, tokenSource.token) as vscode.Range;
+
+		isInstanceOf(defaultBehaviorResult, vscode.Range);
+		assert.deepStrictEqual(defaultBehaviorResult, defaultBehaviorExpected);
+	});
+
 	test('Document Link', async () => {
 		const provider = client.getFeature(lsclient.DocumentLinkRequest.method).getProvider(document);
 		isDefined(provider);

--- a/client-node-tests/src/servers/testServer.ts
+++ b/client-node-tests/src/servers/testServer.ts
@@ -283,7 +283,10 @@ connection.onDocumentOnTypeFormatting((_params) => {
 	];
 });
 
-connection.onPrepareRename((_params) => {
+connection.onPrepareRename((params) => {
+	if (params.position.line === 1 && params.position.character === 5) {
+		return { defaultBehavior: true };
+	}
 	return Range.create(1, 1, 1, 2);
 });
 

--- a/client/src/common/rename.ts
+++ b/client/src/common/rename.ts
@@ -98,7 +98,7 @@ export class RenameFeature extends TextDocumentLanguageFeature<boolean | RenameO
 								return client.protocol2CodeConverter.asRange(result);
 							} else if (this.isDefaultBehavior(result)) {
 								return result.defaultBehavior === true
-									? null
+									? document.getWordRangeAtPosition(position)
 									: Promise.reject(new Error(`The element can't be renamed.`));
 							} else if (result && Range.is(result.range)) {
 								return {


### PR DESCRIPTION
* /client behavior no longer converts `{ defaultBehavior: true }` to `null`, to now match >= 3.16.0 specification

  - converts `{ defaultBehavior: true }` into the editor's default word range, allowing `textDocument/rename` requests without widening the VS Code provider type
  - continues to reject `{ defaultBehavior: false }`, preventing `textDocument/rename` requests

* /client-node-tests new related `prepareRename` tests

  - adds test server coverage for a controlled `{ defaultBehavior: true }` prepareRename response
  - adds a dedicated integration test asserting the client converts that server result into a vscode.Range while keeping the existing Rename test focused on the standard flow