### PR TITLE
Remove uuid dependency and use crypto's randomUUID

### DIFF
--- a/client-node-tests/package-lock.json
+++ b/client-node-tests/package-lock.json
@@ -17,13 +17,11 @@
 				"@types/minimatch": "^5.1.2",
 				"@types/node": "20.17.9",
 				"@types/sinon": "^17.0.3",
-				"@types/uuid": "^10.0.0",
 				"@types/vscode": "1.106.0",
 				"@vscode/test-electron": "^2.4.1",
 				"find-process": "^1.4.7",
 				"glob": "^11.1.0",
-				"sinon": "^19.0.2",
-				"uuid": "^11.0.3"
+				"sinon": "^19.0.2"
 			},
 			"engines": {
 				"vscode": "^1.91.0"
@@ -137,13 +135,6 @@
 			"resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.2.tgz",
 			"integrity": "sha512-9GcLXF0/v3t80caGs5p2rRfkB+a8VBGLJZVih6CNFkx8IZ994wiKKLSRs9nuFwk1HevWs/1mnUmkApGrSGsShA==",
 			"dev": true
-		},
-		"node_modules/@types/uuid": {
-			"version": "10.0.0",
-			"resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
-			"integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/@types/vscode": {
 			"version": "1.106.0",
@@ -1173,20 +1164,6 @@
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
 			"dev": true
-		},
-		"node_modules/uuid": {
-			"version": "11.0.3",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.3.tgz",
-			"integrity": "sha512-d0z310fCWv5dJwnX1Y/MncBAqGMKEzlBb1AOf7z9K8ALnd0utBX/msg/fA0+sbyN1ihbMsLhrBlnl1ak7Wa0rg==",
-			"dev": true,
-			"funding": [
-				"https://github.com/sponsors/broofa",
-				"https://github.com/sponsors/ctavan"
-			],
-			"license": "MIT",
-			"bin": {
-				"uuid": "dist/esm/bin/uuid"
-			}
 		},
 		"node_modules/vscode-jsonrpc": {
 			"version": "9.0.0-next.11",

--- a/client-node-tests/package.json
+++ b/client-node-tests/package.json
@@ -37,14 +37,12 @@
 		"@types/glob": "^8.1.0",
 		"@types/minimatch": "^5.1.2",
 		"@types/sinon": "^17.0.3",
-		"@types/uuid": "^10.0.0",
 		"@types/vscode": "1.106.0",
 		"@types/node": "20.17.9",
 		"@vscode/test-electron": "^2.4.1",
 		"find-process": "^1.4.7",
 		"glob": "^11.1.0",
-		"sinon": "^19.0.2",
-		"uuid": "^11.0.3"
+		"sinon": "^19.0.2"
 	},
 	"enabledApiProposals": []
 }

--- a/client-node-tests/src/runTests.ts
+++ b/client-node-tests/src/runTests.ts
@@ -7,7 +7,7 @@
 import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';
-import * as uuid from 'uuid';
+import { randomUUID } from 'crypto';
 
 import find = require('find-process');
 import { runTests } from '@vscode/test-electron';
@@ -33,7 +33,7 @@ async function go() {
 		const extensionDevelopmentPath = path.resolve(__dirname, '..');
 		const extensionTestsPath = __dirname;
 
-		const testDir = path.join(os.tmpdir(), uuid.v4());
+		const testDir = path.join(os.tmpdir(), randomUUID());
 		fs.mkdirSync(testDir, { recursive: true });
 		const userDataDir = path.join(testDir, 'userData');
 		fs.mkdirSync(userDataDir);


### PR DESCRIPTION
Eliminate the uuid dependency by replacing it with crypto's randomUUID for generating test directories. This change simplifies the code and reduces external dependencies.