### PR TITLE
Fixes double application of edits during renaming

### DIFF
--- a/client-node-tests/src/integration.test.ts
+++ b/client-node-tests/src/integration.test.ts
@@ -733,6 +733,18 @@ suite('Client integration', () => {
 		assert.strictEqual(middlewareCalled, 2);
 	});
 
+	test('Rename failed', async () => {
+		const provider = client.getFeature(lsclient.RenameRequest.method).getProvider(document);
+		isDefined(provider);
+
+		try {
+			const renameResult = await provider.provideRenameEdits(document, new vscode.Position(3333, 3333), 'newName', tokenSource.token);
+			assert.fail(`Expected rename to fail, but got result: ${JSON.stringify(renameResult)}`);
+		} catch (error) {
+			assert.ok(error instanceof Error);
+		}
+	});
+
 	test('Document Link', async () => {
 		const provider = client.getFeature(lsclient.DocumentLinkRequest.method).getProvider(document);
 		isDefined(provider);
@@ -2027,8 +2039,8 @@ suite('Server tests', () => {
 		await assert.rejects(async () => {
 			await client.stop(100);
 		}, /Stopping the server timed out/);
-		await waitForProcessExit(serverPid!, 10000);
-	});
+		await waitForProcessExit(serverPid!, 5000);
+	}).timeout(7500);
 
 	test('Server can\'t be stopped right after start', async() => {
 		const serverOptions: lsclient.ServerOptions = {

--- a/client-node-tests/src/servers/testServer.ts
+++ b/client-node-tests/src/servers/testServer.ts
@@ -287,7 +287,21 @@ connection.onPrepareRename((_params) => {
 	return Range.create(1, 1, 1, 2);
 });
 
-connection.onRenameRequest((_params) => {
+connection.onRenameRequest((params) => {
+	const pos = params.position;
+	if (pos.line === 3333 && pos.character === 3333) {
+		return { documentChanges: [
+			{
+				textDocument: {
+					uri: params.textDocument.uri,
+					version: 9999999
+				},
+				edits: [
+					TextEdit.insert(Position.create(0, 0), 'rename failed')
+				]
+			}
+		]};
+	}
 	return { documentChanges: [] };
 });
 

--- a/client/src/common/client.ts
+++ b/client/src/common/client.ts
@@ -2220,28 +2220,35 @@ export abstract class BaseLanguageClient implements FeatureClient<Middleware, La
 			return this._p2c.asWorkspaceEdit(workspaceEdit);
 		});
 
-		// This is some sort of workaround since the version check should be done by VS Code in the Workspace.applyEdit.
-		// However doing it here adds some safety since the server can lag more behind then an extension.
-		const openTextDocuments: Map<string, TextDocument> = new Map<string, TextDocument>();
-		Workspace.textDocuments.forEach((document) => openTextDocuments.set(document.uri.toString(), document));
-		let versionMismatch = false;
-		if (workspaceEdit.documentChanges) {
-			for (const change of workspaceEdit.documentChanges) {
-				if (TextDocumentEdit.is(change) && change.textDocument.version && change.textDocument.version >= 0) {
-					const changeUri = this._p2c.asUri(change.textDocument.uri).toString();
-					const textDocument = openTextDocuments.get(changeUri);
-					if (textDocument && textDocument.version !== change.textDocument.version) {
-						versionMismatch = true;
-						break;
-					}
-				}
-			}
-		}
-		if (versionMismatch) {
+		// Check whether the version provided in the workspace edit matches the version of the open text document.
+		// If not, we can't apply the workspace edit since it might be based on an old version of the document.
+		// CRITICAL: make sure that after this check has run no async operation happens which might cause that
+		// the version of the text document changes. Otherwise we might apply a workspace edit based on an old
+		// version of the document.
+		const valid = this.validateWorkspaceEdit(workspaceEdit);
+		if (!valid) {
 			return Promise.resolve({ applied: false });
 		}
 		return Is.asPromise(Workspace.applyEdit(converted, { isRefactoring: params.metadata?.isRefactoring }).then((value) => { return { applied: value }; }));
 	}
+
+	public validateWorkspaceEdit(workspaceEdit: WorkspaceEdit): boolean {
+		const openTextDocuments: Map<string, TextDocument> = new Map<string, TextDocument>();
+		Workspace.textDocuments.forEach((document) => openTextDocuments.set(document.uri.toString(), document));
+		if (workspaceEdit.documentChanges) {
+			for (const change of workspaceEdit.documentChanges) {
+				if (TextDocumentEdit.is(change) && change.textDocument.version !== null && change.textDocument.version >= 0) {
+					const changeUri = this._p2c.asUri(change.textDocument.uri).toString();
+					const textDocument = openTextDocuments.get(changeUri);
+					if (textDocument && textDocument.version !== change.textDocument.version) {
+						return false;
+					}
+				}
+			}
+		}
+		return true;
+	}
+
 
 	private static RequestsToCancelOnContentModified: Set<string> = new Set([
 		SemanticTokensRequest.method,

--- a/client/src/common/features.ts
+++ b/client/src/common/features.ts
@@ -23,7 +23,8 @@ import {
 	NotificationType, NotificationType0, ProgressType,  ProtocolNotificationType, ProtocolNotificationType0, ProtocolRequestType, ProtocolRequestType0, ReferencesRequest,
 	RegistrationType, RenameRequest, RequestHandler, RequestHandler0, RequestParam, RequestType, RequestType0, SelectionRangeRequest, SemanticTokensRegistrationType, ServerCapabilities,
 	SignatureHelpRequest, StaticRegistrationOptions, TextDocumentIdentifier, TextDocumentRegistrationOptions, TypeDefinitionRequest, TypeHierarchyPrepareRequest, WillCreateFilesRequest,
-	WillDeleteFilesRequest, WillRenameFilesRequest, WillSaveTextDocumentNotification, WillSaveTextDocumentWaitUntilRequest, WorkDoneProgressOptions, WorkspaceSymbolRequest
+	WillDeleteFilesRequest, WillRenameFilesRequest, WillSaveTextDocumentNotification, WillSaveTextDocumentWaitUntilRequest, WorkDoneProgressOptions, WorkspaceSymbolRequest,
+	type WorkspaceEdit
 } from 'vscode-languageserver-protocol';
 
 import * as Is from './utils/is';
@@ -756,4 +757,6 @@ export interface FeatureClient<M, CO = object> {
 	getFeature(request: typeof NotebookDocumentSyncRegistrationType.method): DynamicFeature<NotebookDocumentSyncRegistrationOptions> & NotebookDocumentProviderShape;
 	getFeature(request: typeof InlineCompletionRequest.method): (DynamicFeature<InlineCompletionRegistrationOptions> & TextDocumentProviderFeature<InlineCompletionItemProvider>) | undefined;
 	getFeature(request: typeof ExecuteCommandRequest.method): DynamicFeature<ExecuteCommandOptions>;
+
+	validateWorkspaceEdit(workspaceEdit: WorkspaceEdit): boolean;
 }

--- a/client/src/common/rename.ts
+++ b/client/src/common/rename.ts
@@ -8,7 +8,8 @@ import {
 } from 'vscode';
 
 import {
-	ClientCapabilities, CancellationToken, ServerCapabilities, DocumentSelector, RenameOptions, RenameRegistrationOptions, RenameRequest, PrepareSupportDefaultBehavior, RenameParams, ResponseError, TextDocumentPositionParams, PrepareRenameRequest, Range} from 'vscode-languageserver-protocol';
+	ClientCapabilities, CancellationToken, ServerCapabilities, DocumentSelector, RenameOptions, RenameRegistrationOptions, RenameRequest, PrepareSupportDefaultBehavior, RenameParams, ResponseError, TextDocumentPositionParams, PrepareRenameRequest, Range,
+	type WorkspaceEdit} from 'vscode-languageserver-protocol';
 
 import * as UUID from './utils/uuid';
 import * as Is from './utils/is';
@@ -62,20 +63,29 @@ export class RenameFeature extends TextDocumentLanguageFeature<boolean | RenameO
 		const provider: RenameProvider = {
 			provideRenameEdits: (document, position, newName, token) => {
 				const client = this._client;
-				const provideRenameEdits: ProvideRenameEditsSignature = (document, position, newName, token) => {
+				const provideRenameEdits: ProvideRenameEditsSignature = async (document, position, newName, token) => {
 					const params: RenameParams = {
 						textDocument: client.code2ProtocolConverter.asTextDocumentIdentifier(document),
 						position: client.code2ProtocolConverter.asPosition(position),
 						newName: newName
 					};
-					return client.sendRequest(RenameRequest.type, params, token).then((result) => {
-						if (token.isCancellationRequested) {
-							return null;
-						}
-						return client.protocol2CodeConverter.asWorkspaceEdit(result, token);
-					}, (error: ResponseError<void>) => {
+					let result: WorkspaceEdit | null = null;
+					try {
+						result = await client.sendRequest(RenameRequest.type, params, token);
+					} catch (error) {
 						return client.handleFailedRequest(RenameRequest.type, token, error, null, false);
-					});
+					}
+					if (token.isCancellationRequested || result === null) {
+						return null;
+					}
+					const converted = await client.protocol2CodeConverter.asWorkspaceEdit(result, token);
+					if (token.isCancellationRequested) {
+						return null;
+					}
+					if (!client.validateWorkspaceEdit(result)) {
+						throw new Error(`The rename edit returned from the server is not valid anymore and cannot be applied.`);
+					}
+					return converted;
 				};
 				const middleware = client.middleware;
 				return middleware.provideRenameEdits


### PR DESCRIPTION
The changes address an issue where renaming a module caused edits to be applied twice due to the interaction between the server and VSCode. The server now validates workspace edits to ensure they match the current document version before applying them, preventing duplicate edits. Additionally, a test has been added to confirm that renaming fails when expected.

Fixes #752