### PR TITLE
Add 3.17 version check method for Diagnostic

### DIFF
--- a/types/src/main.ts
+++ b/types/src/main.ts
@@ -788,6 +788,13 @@ export namespace Diagnostic {
 			&& (Is.undefined(candidate.relatedInformation) || Is.typedArray<DiagnosticRelatedInformation>(candidate.relatedInformation, DiagnosticRelatedInformation.is));
 	}
 
+	/**
+	 * Checks whether the given diagnostic's message conforms to the 3.17.0
+	 * version of the protocol where the message is a string.
+	 *
+	 * @param value the diagnostic
+	 * @returns true if the diagnostic's message is a string, false otherwise.
+	 */
 	export function is3_17(value: Diagnostic): value is Omit<Diagnostic, 'message'> & { message: string } {
 		return Is.string(value.message);
 	}

--- a/types/src/main.ts
+++ b/types/src/main.ts
@@ -787,6 +787,10 @@ export namespace Diagnostic {
 			&& (Is.string(candidate.source) || Is.undefined(candidate.source))
 			&& (Is.undefined(candidate.relatedInformation) || Is.typedArray<DiagnosticRelatedInformation>(candidate.relatedInformation, DiagnosticRelatedInformation.is));
 	}
+
+	export function is3_17(value: Diagnostic): value is Omit<Diagnostic, 'message'> & { message: string } {
+		return Is.string(value.message);
+	}
 }
 
 /**


### PR DESCRIPTION
Introduce a method to verify if a diagnostic's message adheres to the 3.17.0 version of the protocol, ensuring the message is a string. A comment has been added for clarity.