### PR TITLE
Treat connection close during `stop()` as handled

### DIFF
--- a/client/src/common/client.ts
+++ b/client/src/common/client.ts
@@ -1832,8 +1832,11 @@ export abstract class BaseLanguageClient implements FeatureClient<Middleware, La
 			}
 		}
 		this._connection = undefined;
+		// `Stopping` counts as handled. The application asked for the close via `stop()`,
+		// and `closed()` was skipped above so the handler had no chance to set `handled`.
+		const handled = this.$state === ClientState.Stopping || handlerResult.handled === true;
 		if (handlerResult.action === CloseAction.DoNotRestart) {
-			this.error(handlerResult.message ?? 'Connection to server got closed. Server will not be restarted.', undefined, handlerResult.handled === true ? false : 'force');
+			this.error(handlerResult.message ?? 'Connection to server got closed. Server will not be restarted.', undefined, handled ? false : 'force');
 			this.cleanUp(ShutdownMode.Stop);
 			if (this.$state === ClientState.Starting) {
 				this.$state = ClientState.StartFailed;


### PR DESCRIPTION
We've hit a case where our `closed()` handler, meant to prevent user-visible toast notifications, was not invoked by languageclient. Our Linux users (likely due to some weird platform-specific race) consistently see a toast notification on restart due to this (https://github.com/posit-dev/positron/issues/7593).

I think this is because the `closed()` handler is not called when the client is already stopping: https://github.com/lionel-/vscode-languageserver-node/blob/f5e23e29b76c42fad882aa84933d46ba9b412183/client/src/common/client.ts#L1827-L1833. This prevents our handler from setting `handled` to `true`.

The fix proposed here is to treat a client that's already stopping as "handled", this way a toast notification isn't displayed.