### PR TITLE
Allow returning null in SemanticTokensFeatureShape.on handler

### DIFF
--- a/server/src/common/semanticTokens.ts
+++ b/server/src/common/semanticTokens.ts
@@ -38,7 +38,7 @@ export const SemanticTokensFeature: Feature<_Languages, SemanticTokensFeatureSha
 						return handler(params, cancel, this.attachWorkDoneProgress(params), this.attachPartialResultProgress(type, params));
 					});
 				},
-				onDelta: (handler: ServerRequestHandler<SemanticTokensDeltaParams, SemanticTokensDelta | SemanticTokens | undefined | null, SemanticTokensDeltaPartialResult | SemanticTokensDeltaPartialResult, void>): Disposable => {
+				onDelta: (handler: ServerRequestHandler<SemanticTokensDeltaParams, SemanticTokensDelta | SemanticTokens | undefined | null, SemanticTokensDeltaPartialResult | SemanticTokensPartialResult, void>): Disposable => {
 					const type = SemanticTokensDeltaRequest.type;
 					return this.connection.onRequest(type, (params, cancel) => {
 						return handler(params, cancel, this.attachWorkDoneProgress(params), this.attachPartialResultProgress(type, params));

--- a/server/src/common/semanticTokens.ts
+++ b/server/src/common/semanticTokens.ts
@@ -19,9 +19,9 @@ import type { Feature, _Languages, ServerRequestHandler } from './server';
 export interface SemanticTokensFeatureShape {
 	semanticTokens: {
 		refresh(): Promise<void>;
-		on(handler: ServerRequestHandler<SemanticTokensParams, SemanticTokens, SemanticTokensPartialResult, void>): Disposable;
-		onDelta(handler: ServerRequestHandler<SemanticTokensDeltaParams, SemanticTokensDelta | SemanticTokens, SemanticTokensDeltaPartialResult | SemanticTokensPartialResult, void>): Disposable;
-		onRange(handler: ServerRequestHandler<SemanticTokensRangeParams, SemanticTokens, SemanticTokensPartialResult, void>): Disposable;
+		on(handler: ServerRequestHandler<SemanticTokensParams, SemanticTokens | undefined | null, SemanticTokensPartialResult, void>): Disposable;
+		onDelta(handler: ServerRequestHandler<SemanticTokensDeltaParams, SemanticTokensDelta | SemanticTokens | undefined | null, SemanticTokensDeltaPartialResult | SemanticTokensPartialResult, void>): Disposable;
+		onRange(handler: ServerRequestHandler<SemanticTokensRangeParams, SemanticTokens | undefined | null, SemanticTokensPartialResult, void>): Disposable;
 	};
 }
 
@@ -32,19 +32,19 @@ export const SemanticTokensFeature: Feature<_Languages, SemanticTokensFeatureSha
 				refresh: (): Promise<void> => {
 					return this.connection.sendRequest(SemanticTokensRefreshRequest.type);
 				},
-				on: (handler: ServerRequestHandler<SemanticTokensParams, SemanticTokens, SemanticTokensPartialResult, void>): Disposable => {
+				on: (handler: ServerRequestHandler<SemanticTokensParams, SemanticTokens | undefined | null, SemanticTokensPartialResult, void>): Disposable => {
 					const type = SemanticTokensRequest.type;
 					return this.connection.onRequest(type, (params, cancel) => {
 						return handler(params, cancel, this.attachWorkDoneProgress(params), this.attachPartialResultProgress(type, params));
 					});
 				},
-				onDelta: (handler: ServerRequestHandler<SemanticTokensDeltaParams, SemanticTokensDelta | SemanticTokens, SemanticTokensDeltaPartialResult | SemanticTokensDeltaPartialResult, void>): Disposable => {
+				onDelta: (handler: ServerRequestHandler<SemanticTokensDeltaParams, SemanticTokensDelta | SemanticTokens | undefined | null, SemanticTokensDeltaPartialResult | SemanticTokensDeltaPartialResult, void>): Disposable => {
 					const type = SemanticTokensDeltaRequest.type;
 					return this.connection.onRequest(type, (params, cancel) => {
 						return handler(params, cancel, this.attachWorkDoneProgress(params), this.attachPartialResultProgress(type, params));
 					});
 				},
-				onRange: (handler: ServerRequestHandler<SemanticTokensRangeParams, SemanticTokens, SemanticTokensPartialResult, void>): Disposable => {
+				onRange: (handler: ServerRequestHandler<SemanticTokensRangeParams, SemanticTokens | undefined | null, SemanticTokensPartialResult, void>): Disposable => {
 					const type = SemanticTokensRangeRequest.type;
 					return this.connection.onRequest(type, (params, cancel) => {
 						return handler(params, cancel, this.attachWorkDoneProgress(params), this.attachPartialResultProgress(type, params));

--- a/testbed/client/tsconfig.json
+++ b/testbed/client/tsconfig.json
@@ -5,6 +5,7 @@
 		"outDir": "out",
 		"rootDir": "src",
 		"lib": ["ES2023"],
+		"types": [ "node" ],
 		"sourceMap": true,
 		"incremental": true,
 		"tsBuildInfoFile":"./out/tsconfig.tsbuildInfo",

--- a/testbed/server/src/fullNotebookServer.ts
+++ b/testbed/server/src/fullNotebookServer.ts
@@ -22,9 +22,9 @@ const patterns = [
 
 function computeDiagnostics(content: string): Diagnostic[] {
 	const result: Diagnostic[] = [];
-	const lines: string[] = content.match(/^.*(\n|\r\n|\r|$)/gm);
+	const lines: RegExpMatchArray | null = content.match(/^.*(\n|\r\n|\r|$)/gm);
 	let lineNumber: number = 0;
-	for (const line of lines) {
+	for (const line of lines ?? []) {
 		const pattern = patterns[Math.floor(Math.random() * 3)];
 		let match: RegExpExecArray | null;
 		while (match = pattern.exec(line)) {
@@ -87,7 +87,7 @@ connection.onCompletion((params, token): CompletionItem[] => {
 const notebooks = new NotebookDocuments(TextDocument);
 
 function validate(cell: NotebookCell): void {
-	void connection.sendDiagnostics({ uri: cell.document, diagnostics: computeDiagnostics(notebooks.getCellTextDocument(cell).getText())});
+	void connection.sendDiagnostics({ uri: cell.document, diagnostics: computeDiagnostics(notebooks.getCellTextDocument(cell)?.getText() ?? '')});
 }
 
 function clear(cell: NotebookCell): void {

--- a/testbed/server/src/server.ts
+++ b/testbed/server/src/server.ts
@@ -668,10 +668,10 @@ function getTokenBuilder(document: TextDocument): SemanticTokensBuilder {
 function buildTokens(builder: SemanticTokensBuilder, document: TextDocument) {
 	const text = document.getText();
 	const regexp = /\w+/g;
-	let match: RegExpMatchArray | null;
+	let match: RegExpExecArray | null;
 	let tokenCounter: number = 0;
 	let modifierCounter: number = 0;
-	while ((match = regexp.exec(text)) !== null && match.index !== undefined) {
+	while ((match = regexp.exec(text)) !== null) {
 		const word = match[0];
 		const position = document.positionAt(match.index);
 		const tokenType = tokenCounter % TokenTypes._;

--- a/testbed/server/src/server.ts
+++ b/testbed/server/src/server.ts
@@ -114,7 +114,7 @@ connection.onInitialize((params, cancel, progress): Thenable<InitializeResult> |
 			connection.console.log(`${folder.name} ${folder.uri}`);
 		}
 		if (workspaceFolders.length > 0) {
-			folder = params.workspaceFolders[0].uri;
+			folder = params.workspaceFolders![0].uri;
 		}
 	}
 
@@ -197,13 +197,16 @@ connection.onInitialized((params) => {
 		connection.console.log('Workspace folder changed received');
 	});
 	void connection.workspace.getWorkspaceFolders().then(folders => {
+		if (folders === undefined || folders === null) {
+			return;
+		}
 		for (const folder of folders) {
 			connection.console.log(`Get workspace folders: ${folder.name} ${folder.uri}`);
 		}
 	});
 	const registrationOptions: SemanticTokensRegistrationOptions = {
 		documentSelector: ['bat'],
-		legend: semanticTokensLegend,
+		legend: semanticTokensLegend!,
 		range: false,
 		full: {
 			delta: true
@@ -312,9 +315,9 @@ const patterns = [
 
 function computeDiagnostics(content: string): Diagnostic[] {
 	const result: Diagnostic[] = [];
-	const lines: string[] = content.match(/^.*(\n|\r\n|\r|$)/gm);
+	const lines: RegExpMatchArray | null = content.match(/^.*(\n|\r\n|\r|$)/gm);
 	let lineNumber: number = 0;
-	for (const line of lines) {
+	for (const line of lines ?? []) {
 		const pattern = patterns[Math.floor(Math.random() * 3)];
 		let match: RegExpExecArray | null;
 		while (match = pattern.exec(line)) {
@@ -362,7 +365,7 @@ connection.languages.diagnostics.onWorkspace(async (params, token, _, resultProg
 			index = 0;
 		}
 		const diagnostics = computeDiagnostics(await fs.readFile(toValidate[index], { encoding: 'utf8'} ));
-		resultProgress.report({ items: [
+		resultProgress!.report({ items: [
 			{
 				kind: DocumentDiagnosticReportKind.Full,
 				uri: URI.file(toValidate[index]).toString(),
@@ -665,10 +668,10 @@ function getTokenBuilder(document: TextDocument): SemanticTokensBuilder {
 function buildTokens(builder: SemanticTokensBuilder, document: TextDocument) {
 	const text = document.getText();
 	const regexp = /\w+/g;
-	let match: RegExpMatchArray;
+	let match: RegExpMatchArray | null;
 	let tokenCounter: number = 0;
 	let modifierCounter: number = 0;
-	while ((match = regexp.exec(text)) !== null) {
+	while ((match = regexp.exec(text)) !== null && match.index !== undefined) {
 		const word = match[0];
 		const position = document.positionAt(match.index);
 		const tokenType = tokenCounter % TokenTypes._;

--- a/testbed/server/src/simpleNotebookServer.ts
+++ b/testbed/server/src/simpleNotebookServer.ts
@@ -22,9 +22,9 @@ const patterns = [
 
 function computeDiagnostics(content: string): Diagnostic[] {
 	const result: Diagnostic[] = [];
-	const lines: string[] = content.match(/^.*(\n|\r\n|\r|$)/gm);
+	const lines: RegExpMatchArray | null = content.match(/^.*(\n|\r\n|\r|$)/gm);
 	let lineNumber: number = 0;
-	for (const line of lines) {
+	for (const line of lines ?? []) {
 		const pattern = patterns[Math.floor(Math.random() * 3)];
 		let match: RegExpExecArray | null;
 		while (match = pattern.exec(line)) {

--- a/testbed/server/tsconfig.json
+++ b/testbed/server/tsconfig.json
@@ -7,6 +7,7 @@
 		"outDir": "out",
 		"rootDir": "src",
 		"lib": ["ES2023"],
+		"types": [ "node" ],
 		"incremental": true,
 		"tsBuildInfoFile":"./out/tsconfig.tsbuildInfo",
 	},


### PR DESCRIPTION
The changes modify the `SemanticTokensFeatureShape.on`, `onDelta`, and `onRange` handlers to accept `null` as a valid return value, aligning with the Language Server Protocol specification. This adjustment resolves an issue where returning an empty response was incorrectly handled, preventing the language server from overriding semantic tokens provided by other servers. Additional type safety improvements and null checks were also implemented throughout the codebase.

Fixes #1784