### PR TITLE
Update @vscode/test-electron to version 3.0.0

### DIFF
--- a/client-node-tests/package-lock.json
+++ b/client-node-tests/package-lock.json
@@ -17,7 +17,7 @@
 				"@types/minimatch": "^6.0.0",
 				"@types/sinon": "^21.0.1",
 				"@types/vscode": "1.106.0",
-				"@vscode/test-electron": "^2.5.2",
+				"@vscode/test-electron": "^3.0.0",
 				"find-process": "^2.1.1",
 				"glob": "^13.0.6",
 				"sinon": "^22.0.0"
@@ -113,9 +113,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@vscode/test-electron": {
-			"version": "2.5.2",
-			"resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.5.2.tgz",
-			"integrity": "sha512-8ukpxv4wYe0iWMRQU18jhzJOHkeGKbnw7xWRX3Zw1WJA4cEKbHcmmLPdPrPtL6rhDcrlCZN+xKRpv09n4gRHYg==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-3.0.0.tgz",
+			"integrity": "sha512-TY5mC7aAjxSLDXsyjhrG8cJHgc/HLdiE5lvtW7hABYQrY24Qwozzr5UoO3HiuAM4Hzz4b7K/eZlwrCILj94CcA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -126,7 +126,7 @@
 				"semver": "^7.6.2"
 			},
 			"engines": {
-				"node": ">=16"
+				"node": ">=22"
 			}
 		},
 		"node_modules/agent-base": {

--- a/client-node-tests/package.json
+++ b/client-node-tests/package.json
@@ -38,7 +38,7 @@
 		"@types/minimatch": "^6.0.0",
 		"@types/sinon": "^21.0.1",
 		"@types/vscode": "1.106.0",
-		"@vscode/test-electron": "^2.5.2",
+		"@vscode/test-electron": "^3.0.0",
 		"find-process": "^2.1.1",
 		"glob": "^13.0.6",
 		"sinon": "^22.0.0"

--- a/testbed/client/package-lock.json
+++ b/testbed/client/package-lock.json
@@ -11,35 +11,6 @@
 			"engines": {
 				"vscode": "^1.40.0"
 			}
-		},
-		"../../jsonrpc": {
-			"name": "vscode-jsonrpc",
-			"version": "8.2.0-next.2",
-			"extraneous": true,
-			"license": "MIT",
-			"devDependencies": {
-				"@types/msgpack-lite": "^0.1.7",
-				"msgpack-lite": "^0.1.26"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"../../protocol": {
-			"name": "vscode-languageserver-protocol",
-			"version": "3.17.4-next.3",
-			"extraneous": true,
-			"license": "MIT",
-			"dependencies": {
-				"vscode-jsonrpc": "8.2.0-next.2",
-				"vscode-languageserver-types": "3.17.4-next.2"
-			}
-		},
-		"../../types": {
-			"name": "vscode-languageserver-types",
-			"version": "3.17.4-next.2",
-			"extraneous": true,
-			"license": "MIT"
 		}
 	}
 }

--- a/testbed/server/package-lock.json
+++ b/testbed/server/package-lock.json
@@ -14,56 +14,6 @@
 				"node": "*"
 			}
 		},
-		"../../jsonrpc": {
-			"name": "vscode-jsonrpc",
-			"version": "8.2.0-next.2",
-			"extraneous": true,
-			"license": "MIT",
-			"devDependencies": {
-				"@types/msgpack-lite": "^0.1.7",
-				"msgpack-lite": "^0.1.26"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"../../protocol": {
-			"name": "vscode-languageserver-protocol",
-			"version": "3.17.4-next.3",
-			"extraneous": true,
-			"license": "MIT",
-			"dependencies": {
-				"vscode-jsonrpc": "8.2.0-next.2",
-				"vscode-languageserver-types": "3.17.4-next.2"
-			}
-		},
-		"../../server": {
-			"name": "vscode-languageserver",
-			"version": "8.2.0-next.3",
-			"extraneous": true,
-			"license": "MIT",
-			"dependencies": {
-				"vscode-languageserver-protocol": "3.17.4-next.3"
-			},
-			"bin": {
-				"installServerIntoExtension": "bin/installServerIntoExtension"
-			},
-			"devDependencies": {
-				"vscode-languageserver-textdocument": "1.0.10"
-			}
-		},
-		"../../textDocument": {
-			"name": "vscode-languageserver-textdocument",
-			"version": "1.0.10",
-			"extraneous": true,
-			"license": "MIT"
-		},
-		"../../types": {
-			"name": "vscode-languageserver-types",
-			"version": "3.17.4-next.2",
-			"extraneous": true,
-			"license": "MIT"
-		},
 		"node_modules/vscode-uri": {
 			"version": "3.0.8",
 			"resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.8.tgz",


### PR DESCRIPTION
Upgrade the @vscode/test-electron package to the latest version, ensuring compatibility with newer Node.js versions. Clean up extraneous dependencies in the process.