### PR TITLE
Fix partial result type for textDocument/diagnostic request

### DIFF
--- a/protocol/metaModel.json
+++ b/protocol/metaModel.json
@@ -1027,17 +1027,8 @@
 				"name": "DocumentDiagnosticParams"
 			},
 			"partialResult": {
-				"kind": "or",
-				"items": [
-					{
-						"kind": "reference",
-						"name": "DocumentDiagnosticReport"
-					},
-					{
-						"kind": "reference",
-						"name": "DocumentDiagnosticReportPartialResult"
-					}
-				]
+				"kind": "reference",
+				"name": "DocumentDiagnosticReportProgress"
 			},
 			"errorData": {
 				"kind": "reference",
@@ -1047,7 +1038,7 @@
 				"kind": "reference",
 				"name": "DiagnosticRegistrationOptions"
 			},
-			"documentation": "The document diagnostic request definition.\n\n@since 3.17.0",
+			"documentation": "The document diagnostic request definition.\n\n\n@since 3.17.0",
 			"since": "3.17.0"
 		},
 		{
@@ -4173,36 +4164,6 @@
 				}
 			],
 			"documentation": "Parameters of the document diagnostic request.\n\n@since 3.17.0",
-			"since": "3.17.0"
-		},
-		{
-			"name": "DocumentDiagnosticReportPartialResult",
-			"properties": [
-				{
-					"name": "relatedDocuments",
-					"type": {
-						"kind": "map",
-						"key": {
-							"kind": "base",
-							"name": "DocumentUri"
-						},
-						"value": {
-							"kind": "or",
-							"items": [
-								{
-									"kind": "reference",
-									"name": "FullDocumentDiagnosticReport"
-								},
-								{
-									"kind": "reference",
-									"name": "UnchangedDocumentDiagnosticReport"
-								}
-							]
-						}
-					}
-				}
-			],
-			"documentation": "A partial result for a document diagnostic report.\n\n@since 3.17.0",
 			"since": "3.17.0"
 		},
 		{
@@ -7754,61 +7715,33 @@
 			"since": "3.17.0"
 		},
 		{
-			"name": "FullDocumentDiagnosticReport",
+			"name": "DocumentDiagnosticReportPartialResult",
 			"properties": [
 				{
-					"name": "kind",
+					"name": "relatedDocuments",
 					"type": {
-						"kind": "stringLiteral",
-						"value": "full"
-					},
-					"documentation": "A full document diagnostic report."
-				},
-				{
-					"name": "resultId",
-					"type": {
-						"kind": "base",
-						"name": "string"
-					},
-					"optional": true,
-					"documentation": "An optional result id. If provided it will\nbe sent on the next diagnostic request for the\nsame document."
-				},
-				{
-					"name": "items",
-					"type": {
-						"kind": "array",
-						"element": {
-							"kind": "reference",
-							"name": "Diagnostic"
+						"kind": "map",
+						"key": {
+							"kind": "base",
+							"name": "DocumentUri"
+						},
+						"value": {
+							"kind": "or",
+							"items": [
+								{
+									"kind": "reference",
+									"name": "FullDocumentDiagnosticReport"
+								},
+								{
+									"kind": "reference",
+									"name": "UnchangedDocumentDiagnosticReport"
+								}
+							]
 						}
-					},
-					"documentation": "The actual items."
+					}
 				}
 			],
-			"documentation": "A diagnostic report with a full set of problems.\n\n@since 3.17.0",
-			"since": "3.17.0"
-		},
-		{
-			"name": "UnchangedDocumentDiagnosticReport",
-			"properties": [
-				{
-					"name": "kind",
-					"type": {
-						"kind": "stringLiteral",
-						"value": "unchanged"
-					},
-					"documentation": "A document diagnostic report indicating\nno changes to the last result. A server can\nonly return `unchanged` if result ids are\nprovided."
-				},
-				{
-					"name": "resultId",
-					"type": {
-						"kind": "base",
-						"name": "string"
-					},
-					"documentation": "A result id which will be sent on the next\ndiagnostic request for the same document."
-				}
-			],
-			"documentation": "A diagnostic report indicating that the last returned\nreport is still accurate.\n\n@since 3.17.0",
+			"documentation": "A partial result for a document diagnostic report.\n\n@since 3.17.0",
 			"since": "3.17.0"
 		},
 		{
@@ -10319,6 +10252,64 @@
 			],
 			"documentation": "A pattern to describe in which file operation requests or notifications\nthe server is interested in receiving.\n\n@since 3.16.0",
 			"since": "3.16.0"
+		},
+		{
+			"name": "FullDocumentDiagnosticReport",
+			"properties": [
+				{
+					"name": "kind",
+					"type": {
+						"kind": "stringLiteral",
+						"value": "full"
+					},
+					"documentation": "A full document diagnostic report."
+				},
+				{
+					"name": "resultId",
+					"type": {
+						"kind": "base",
+						"name": "string"
+					},
+					"optional": true,
+					"documentation": "An optional result id. If provided it will\nbe sent on the next diagnostic request for the\nsame document."
+				},
+				{
+					"name": "items",
+					"type": {
+						"kind": "array",
+						"element": {
+							"kind": "reference",
+							"name": "Diagnostic"
+						}
+					},
+					"documentation": "The actual items."
+				}
+			],
+			"documentation": "A diagnostic report with a full set of problems.\n\n@since 3.17.0",
+			"since": "3.17.0"
+		},
+		{
+			"name": "UnchangedDocumentDiagnosticReport",
+			"properties": [
+				{
+					"name": "kind",
+					"type": {
+						"kind": "stringLiteral",
+						"value": "unchanged"
+					},
+					"documentation": "A document diagnostic report indicating\nno changes to the last result. A server can\nonly return `unchanged` if result ids are\nprovided."
+				},
+				{
+					"name": "resultId",
+					"type": {
+						"kind": "base",
+						"name": "string"
+					},
+					"documentation": "A result id which will be sent on the next\ndiagnostic request for the same document."
+				}
+			],
+			"documentation": "A diagnostic report indicating that the last returned\nreport is still accurate.\n\n@since 3.17.0",
+			"since": "3.17.0"
 		},
 		{
 			"name": "WorkspaceFullDocumentDiagnosticReport",
@@ -15838,6 +15829,24 @@
 			},
 			"documentation": "The result of a document diagnostic pull request. A report can\neither be a full report containing all diagnostics for the\nrequested document or an unchanged report indicating that nothing\nhas changed in terms of diagnostics in comparison to the last\npull request.\n\n@since 3.17.0",
 			"since": "3.17.0"
+		},
+		{
+			"name": "DocumentDiagnosticReportProgress",
+			"type": {
+				"kind": "or",
+				"items": [
+					{
+						"kind": "reference",
+						"name": "DocumentDiagnosticReport"
+					},
+					{
+						"kind": "reference",
+						"name": "DocumentDiagnosticReportPartialResult"
+					}
+				]
+			},
+			"documentation": "The document diagnostic report used when reporting partial result.\n\nWhen using partial results, the first literal sent needs to be a\nDocumentDiagnosticReport providing the diagnostics on the document\nfollowed by n DocumentDiagnosticReportPartialResult literals providing\nthe diagnostics for related documents.\n\n```\nDocumentDiagnosticReport\nDocumentDiagnosticReportPartialResult\nDocumentDiagnosticReportPartialResult\n...\n```\n\n@since 3.18.1",
+			"since": "3.18.1"
 		},
 		{
 			"name": "PrepareRenameResult",

--- a/protocol/metaModel.json
+++ b/protocol/metaModel.json
@@ -1027,8 +1027,17 @@
 				"name": "DocumentDiagnosticParams"
 			},
 			"partialResult": {
-				"kind": "reference",
-				"name": "DocumentDiagnosticReportPartialResult"
+				"kind": "or",
+				"items": [
+					{
+						"kind": "reference",
+						"name": "DocumentDiagnosticReport"
+					},
+					{
+						"kind": "reference",
+						"name": "DocumentDiagnosticReportPartialResult"
+					}
+				]
 			},
 			"errorData": {
 				"kind": "reference",

--- a/protocol/src/common/protocol.diagnostic.ts
+++ b/protocol/src/common/protocol.diagnostic.ts
@@ -265,11 +265,12 @@ export type DocumentDiagnosticReportPartialResult = {
 };
 
 /**
- * The document diagnostic request definition.
+ * The document diagnostic report used when reporting partial result.
  *
  * When using partial results, the first literal sent needs to be a
- * DocumentDiagnosticReport followed by n DocumentDiagnosticReportPartialResult
- * literals:
+ * DocumentDiagnosticReport providing the diagnostics on the document
+ * followed by n DocumentDiagnosticReportPartialResult literals providing
+ * the diagnostics for related documents.
  *
  * ```
  * DocumentDiagnosticReport
@@ -278,13 +279,21 @@ export type DocumentDiagnosticReportPartialResult = {
  * ...
  * ```
  *
+ * @since 3.18.1
+ */
+export type DocumentDiagnosticReportProgress = DocumentDiagnosticReport | DocumentDiagnosticReportPartialResult;
+
+/**
+ * The document diagnostic request definition.
+ *
+ *
  * @since 3.17.0
  */
 export namespace DocumentDiagnosticRequest {
 	export const method: 'textDocument/diagnostic' = 'textDocument/diagnostic';
 	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
-	export const type = new ProtocolRequestType<DocumentDiagnosticParams, DocumentDiagnosticReport, DocumentDiagnosticReport | DocumentDiagnosticReportPartialResult, DiagnosticServerCancellationData, DiagnosticRegistrationOptions>(method);
-	export const partialResult = new ProgressType<DocumentDiagnosticReport | DocumentDiagnosticReportPartialResult>();
+	export const type = new ProtocolRequestType<DocumentDiagnosticParams, DocumentDiagnosticReport, DocumentDiagnosticReportProgress, DiagnosticServerCancellationData, DiagnosticRegistrationOptions>(method);
+	export const partialResult = new ProgressType<DocumentDiagnosticReportProgress>();
 	export type HandlerSignature = RequestHandler<DocumentDiagnosticParams, DocumentDiagnosticReport, void>;
 	export const capabilities = CM.create('textDocument.diagnostic', 'diagnosticProvider');
 }

--- a/protocol/src/common/protocol.diagnostic.ts
+++ b/protocol/src/common/protocol.diagnostic.ts
@@ -267,13 +267,24 @@ export type DocumentDiagnosticReportPartialResult = {
 /**
  * The document diagnostic request definition.
  *
+ * When using partial results, the first literal sent needs to be a
+ * DocumentDiagnosticReport followed by n DocumentDiagnosticReportPartialResult
+ * literals:
+ *
+ * ```
+ * DocumentDiagnosticReport
+ * DocumentDiagnosticReportPartialResult
+ * DocumentDiagnosticReportPartialResult
+ * ...
+ * ```
+ *
  * @since 3.17.0
  */
 export namespace DocumentDiagnosticRequest {
 	export const method: 'textDocument/diagnostic' = 'textDocument/diagnostic';
 	export const messageDirection: MessageDirection = MessageDirection.clientToServer;
-	export const type = new ProtocolRequestType<DocumentDiagnosticParams, DocumentDiagnosticReport, DocumentDiagnosticReportPartialResult, DiagnosticServerCancellationData, DiagnosticRegistrationOptions>(method);
-	export const partialResult = new ProgressType<DocumentDiagnosticReportPartialResult>();
+	export const type = new ProtocolRequestType<DocumentDiagnosticParams, DocumentDiagnosticReport, DocumentDiagnosticReport | DocumentDiagnosticReportPartialResult, DiagnosticServerCancellationData, DiagnosticRegistrationOptions>(method);
+	export const partialResult = new ProgressType<DocumentDiagnosticReport | DocumentDiagnosticReportPartialResult>();
 	export type HandlerSignature = RequestHandler<DocumentDiagnosticParams, DocumentDiagnosticReport, void>;
 	export const capabilities = CM.create('textDocument.diagnostic', 'diagnosticProvider');
 }


### PR DESCRIPTION
Update the handling of partial results in the document diagnostic request to allow for both DocumentDiagnosticReport and DocumentDiagnosticReportPartialResult types. This change improves the flexibility of the diagnostic response structure.