### PR TITLE
fix(jsonrpc): cap Darwin pipe paths for OpenJDK

### DIFF
--- a/jsonrpc/src/node/main.ts
+++ b/jsonrpc/src/node/main.ts
@@ -170,7 +170,7 @@ export class StreamMessageWriter extends WriteableStreamMessageWriter {
 const XDG_RUNTIME_DIR = process.env['XDG_RUNTIME_DIR'];
 const safeIpcPathLengths: Map<NodeJS.Platform, number> = new Map([
 	['linux', 107],
-	['darwin', 103]
+	['darwin', 102]
 ]);
 
 export function generateRandomPipeName(): string {

--- a/jsonrpc/src/node/test/connection.test.ts
+++ b/jsonrpc/src/node/test/connection.test.ts
@@ -5,6 +5,8 @@
 
 import * as assert from 'assert';
 
+import * as path from 'path';
+import { execFileSync } from 'child_process';
 import { Duplex  } from 'stream';
 import { inherits } from 'util';
 import { AsyncLocalStorage } from 'async_hooks';
@@ -52,6 +54,26 @@ suite('Connection', () => {
 			done();
 		});
 		stream.write('Hello World');
+	});
+
+	test('Darwin pipe names fit OpenJDK Unix domain socket limit', () => {
+		const portableTmp = '/'.padEnd(65, 'a');
+		const main = path.join(__dirname, '..', 'main.js');
+		const script = `
+			process.env.XDG_RUNTIME_DIR = ${JSON.stringify(portableTmp)};
+			const connection = require(${JSON.stringify(main)});
+			const fs = require('fs');
+			fs.realpathSync = () => process.env.XDG_RUNTIME_DIR;
+			Object.defineProperty(process, 'platform', { value: 'darwin' });
+			const pipeName = connection.generateRandomPipeName();
+			if (Buffer.byteLength(pipeName) > 102) {
+				throw new Error(
+					\`Expected pipe name '\${pipeName}' to fit in 102 bytes\`
+				);
+			}
+		`;
+
+		execFileSync(process.execPath, ['-e', script], { stdio: 'pipe' });
 	});
 
 	test('Test Duplex Stream Connection', (done) => {


### PR DESCRIPTION
Fixes [#1802](https://github.com/microsoft/vscode-languageserver-node/issues/1802).

This lowers the Darwin pipe path budget from 103 to 102 bytes so generated Unix-domain socket paths fit OpenJDK's `sizeof(sun_path) - 2` limit on macOS. It also adds a regression test for the portable `tmp` boundary case described in [redhat-developer/vscode-java#4433](https://github.com/redhat-developer/vscode-java/issues/4433).

Validation:
- `npm run compile:jsonrpc`
- `cd jsonrpc && npm run test:node`
- `cd jsonrpc && npm run lint`
- `cd jsonrpc && npm test`