### PR TITLE
Merge 3.18.1 release into main

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ After cloning the repository, run `npm install` to install dependencies and `npm
 
 ## History
 
+## 3.18.1 Protocol, 9.0.0 JSON-RPC, 10.0.1 Client and 10.0.1 Server.
+
+- [textDocumentContent capability/feature is still behind a proposed gate even though in 3.18 it's not flagged as proposed anymore](https://github.com/microsoft/vscode-languageserver-node/issues/1795)
+
 ## 3.18.0 Protocol, 9.0.0 JSON-RPC, 10.0.0 Client and 10.0.0 Server.
 
 ### Protocol - new requests / notifications

--- a/client-node-tests/package-lock.json
+++ b/client-node-tests/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "0.0.1",
 			"dependencies": {
 				"minimatch": "^10.2.5",
-				"vscode-languageserver": "10.0.0",
+				"vscode-languageserver": "10.0.1",
 				"vscode-uri": "3.1.0"
 			},
 			"devDependencies": {
@@ -825,21 +825,21 @@
 			}
 		},
 		"node_modules/vscode-languageserver": {
-			"version": "10.0.0",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-10.0.0.tgz",
-			"integrity": "sha512-KOdOVuBnNO5EZSejlEDdRPJWpJn/X87vR2TmOXneHsxSYY7mYjgc1SxeZPMoHICcBKTUnM0V19+WP4J92zDd1w==",
+			"version": "10.0.1",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-10.0.1.tgz",
+			"integrity": "sha512-hfERoZvpaHWzQa7t5mMIrHkEOhF7aTs1dpktem0TW/Xs4QZD7NtcHjIq/aE1CZJEj6Rb8LSGUkBhvTRDdpyGig==",
 			"license": "MIT",
 			"dependencies": {
-				"vscode-languageserver-protocol": "3.18.0"
+				"vscode-languageserver-protocol": "3.18.1"
 			},
 			"bin": {
 				"installServerIntoExtension": "bin/installServerIntoExtension"
 			}
 		},
 		"node_modules/vscode-languageserver-protocol": {
-			"version": "3.18.0",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.18.0.tgz",
-			"integrity": "sha512-Zdz+kJ12Iz6tc11xfZyEo501bBATHXrCjmMfnaR3pMnf1CoqZBKIynba3P+/bi9VEdrMbNtAVKYpKhbODvqy+Q==",
+			"version": "3.18.1",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.18.1.tgz",
+			"integrity": "sha512-RTiiVHdpxpYcJVI5sq6S5TLjQ4WDR/rBrIWru+kPXe6sGQ9PFQ3GamrTKLvPqbR4ylr1SoodhmcqbFII0WXVuw==",
 			"license": "MIT",
 			"dependencies": {
 				"vscode-jsonrpc": "9.0.0",

--- a/client-node-tests/package.json
+++ b/client-node-tests/package.json
@@ -30,7 +30,7 @@
 	},
 	"dependencies": {
 		"minimatch": "^10.2.5",
-		"vscode-languageserver": "10.0.0",
+		"vscode-languageserver": "10.0.1",
 		"vscode-uri": "3.1.0"
 	},
 	"devDependencies": {

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,17 +1,17 @@
 {
 	"name": "vscode-languageclient",
-	"version": "10.0.0",
+	"version": "10.0.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "vscode-languageclient",
-			"version": "10.0.0",
+			"version": "10.0.1",
 			"license": "MIT",
 			"dependencies": {
 				"minimatch": "^10.2.5",
 				"semver": "^7.8.1",
-				"vscode-languageserver-protocol": "3.18.0",
+				"vscode-languageserver-protocol": "3.18.1",
 				"vscode-languageserver-textdocument": "1.0.13"
 			},
 			"devDependencies": {
@@ -685,9 +685,9 @@
 			}
 		},
 		"node_modules/vscode-languageserver-protocol": {
-			"version": "3.18.0",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.18.0.tgz",
-			"integrity": "sha512-Zdz+kJ12Iz6tc11xfZyEo501bBATHXrCjmMfnaR3pMnf1CoqZBKIynba3P+/bi9VEdrMbNtAVKYpKhbODvqy+Q==",
+			"version": "3.18.1",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.18.1.tgz",
+			"integrity": "sha512-RTiiVHdpxpYcJVI5sq6S5TLjQ4WDR/rBrIWru+kPXe6sGQ9PFQ3GamrTKLvPqbR4ylr1SoodhmcqbFII0WXVuw==",
 			"license": "MIT",
 			"dependencies": {
 				"vscode-jsonrpc": "9.0.0",

--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "vscode-languageclient",
 	"description": "VSCode Language client implementation",
-	"version": "10.0.0",
+	"version": "10.0.1",
 	"author": "Microsoft Corporation",
 	"license": "MIT",
 	"engines": {
@@ -44,7 +44,7 @@
 		"minimatch": "^10.2.5",
 		"semver": "^7.8.1",
 		"vscode-languageserver-textdocument": "1.0.13",
-		"vscode-languageserver-protocol": "3.18.0"
+		"vscode-languageserver-protocol": "3.18.1"
 	},
 	"scripts": {
 		"prepublishOnly": "echo \"⛔ Can only publish from a secure pipeline ⛔\" && node ../build/npm/fail",

--- a/protocol/package-lock.json
+++ b/protocol/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "vscode-languageserver-protocol",
-	"version": "3.18.0",
+	"version": "3.18.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "vscode-languageserver-protocol",
-			"version": "3.18.0",
+			"version": "3.18.1",
 			"license": "MIT",
 			"dependencies": {
 				"vscode-jsonrpc": "9.0.0",

--- a/protocol/package.json
+++ b/protocol/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "vscode-languageserver-protocol",
 	"description": "VSCode Language Server Protocol implementation",
-	"version": "3.18.0",
+	"version": "3.18.1",
 	"author": "Microsoft Corporation",
 	"license": "MIT",
 	"repository": {

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,15 +1,15 @@
 {
 	"name": "vscode-languageserver",
-	"version": "10.0.0",
+	"version": "10.0.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "vscode-languageserver",
-			"version": "10.0.0",
+			"version": "10.0.1",
 			"license": "MIT",
 			"dependencies": {
-				"vscode-languageserver-protocol": "3.18.0"
+				"vscode-languageserver-protocol": "3.18.1"
 			},
 			"bin": {
 				"installServerIntoExtension": "bin/installServerIntoExtension"
@@ -28,9 +28,9 @@
 			}
 		},
 		"node_modules/vscode-languageserver-protocol": {
-			"version": "3.18.0",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.18.0.tgz",
-			"integrity": "sha512-Zdz+kJ12Iz6tc11xfZyEo501bBATHXrCjmMfnaR3pMnf1CoqZBKIynba3P+/bi9VEdrMbNtAVKYpKhbODvqy+Q==",
+			"version": "3.18.1",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.18.1.tgz",
+			"integrity": "sha512-RTiiVHdpxpYcJVI5sq6S5TLjQ4WDR/rBrIWru+kPXe6sGQ9PFQ3GamrTKLvPqbR4ylr1SoodhmcqbFII0WXVuw==",
 			"license": "MIT",
 			"dependencies": {
 				"vscode-jsonrpc": "9.0.0",

--- a/server/package.json
+++ b/server/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "vscode-languageserver",
 	"description": "Language server implementation for node",
-	"version": "10.0.0",
+	"version": "10.0.1",
 	"author": "Microsoft Corporation",
 	"license": "MIT",
 	"repository": {
@@ -33,7 +33,7 @@
 		"vscode-languageserver-textdocument": "1.0.13"
 	},
 	"dependencies": {
-		"vscode-languageserver-protocol": "3.18.0"
+		"vscode-languageserver-protocol": "3.18.1"
 	},
 	"scripts": {
 		"prepublishOnly": "echo \"⛔ Can only publish from a secure pipeline ⛔\" && node ../build/npm/fail",


### PR DESCRIPTION
Update the version of `vscode-languageserver` and `vscode-languageserver-protocol` to 10.0.1 and 3.18.1 respectively, ensuring compatibility with the latest features and fixes.