### PR TITLE
Move meta model to version 3.18

### DIFF
--- a/tools/src/visitor.ts
+++ b/tools/src/visitor.ts
@@ -223,7 +223,7 @@ export default class Visitor {
 
 	public getMetaModel(): MetaModel {
 		return {
-			metaData: { version: '3.17.0' },
+			metaData: { version: '3.18.0' },
 			requests: this.requests,
 			notifications: this.notifications,
 			structures: this.structures,


### PR DESCRIPTION
Update the meta model version from 3.17.0 to 3.18.0 to reflect the latest changes.