### PR TITLE
Reuse diagnostic collections and introduce a provider

### DIFF
--- a/client/src/common/client.ts
+++ b/client/src/common/client.ts
@@ -396,7 +396,7 @@ export type LanguageClientOptions = {
 		 */
 		delayOpenNotifications?: boolean;
 	};
-} & $NotebookDocumentOptions & $DiagnosticPullOptions & $ConfigurationOptions;
+} & $NotebookDocumentOptions & Omit<$DiagnosticPullOptions, 'diagnosticCollectionName'> & $ConfigurationOptions;
 
 // type TestOptions = {
 // 	$testMode?: boolean;
@@ -432,7 +432,7 @@ type ResolvedClientOptions = {
 	textSynchronization: {
 		delayOpenNotifications: boolean;
 	};
-} & Required<$NotebookDocumentOptions> & Required<$DiagnosticPullOptions>;
+} & Required<$NotebookDocumentOptions> & Required<Omit<$DiagnosticPullOptions, 'diagnosticCollectionName'>>;
 namespace ResolvedClientOptions {
 	export function sanitizeIsTrusted(isTrusted?: boolean | { readonly enabledCommands: readonly string[] }): boolean | { readonly enabledCommands: readonly string[] } {
 		if (isTrusted === undefined || isTrusted === null) {

--- a/client/src/common/client.ts
+++ b/client/src/common/client.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 import {
-	workspace as Workspace, window as Window, languages as Languages, LogLevel, version as VSCodeVersion, TextDocument, Disposable,
+	workspace as Workspace, window as Window, LogLevel, version as VSCodeVersion, TextDocument, Disposable,
 	FileSystemWatcher as VFileSystemWatcher, DiagnosticCollection, Diagnostic as VDiagnostic, Uri, CancellationToken, WorkspaceEdit as VWorkspaceEdit,
 	MessageItem, WorkspaceFolder as VWorkspaceFolder, env as Env, TextDocumentShowOptions, CancellationError, CancellationTokenSource, FileCreateEvent,
 	FileRenameEvent, FileDeleteEvent, FileWillCreateEvent, FileWillRenameEvent, FileWillDeleteEvent, CompletionItemProvider, HoverProvider, SignatureHelpProvider,
@@ -49,7 +49,7 @@ import * as UUID from './utils/uuid';
 import { ProgressPart } from './progressPart';
 import {
 	DynamicFeature, ensure, FeatureClient, LSPCancellationError, TextDocumentSendFeature, RegistrationData, StaticFeature,
-	TextDocumentProviderFeature, WorkspaceProviderFeature, type VisibleDocuments
+	TextDocumentProviderFeature, WorkspaceProviderFeature, DefaultDiagnosticCollectionProvider, DiagnosticCollectionSource, type VisibleDocuments
 } from './features';
 
 import { DiagnosticFeature, DiagnosticProviderMiddleware, DiagnosticProviderShape, $DiagnosticPullOptions, DiagnosticFeatureShape } from './diagnostic';
@@ -396,7 +396,7 @@ export type LanguageClientOptions = {
 		 */
 		delayOpenNotifications?: boolean;
 	};
-} & $NotebookDocumentOptions & Omit<$DiagnosticPullOptions, 'diagnosticCollectionName'> & $ConfigurationOptions;
+} & $NotebookDocumentOptions & $DiagnosticPullOptions & $ConfigurationOptions;
 
 // type TestOptions = {
 // 	$testMode?: boolean;
@@ -432,7 +432,7 @@ type ResolvedClientOptions = {
 	textSynchronization: {
 		delayOpenNotifications: boolean;
 	};
-} & Required<$NotebookDocumentOptions> & Required<Omit<$DiagnosticPullOptions, 'diagnosticCollectionName'>>;
+} & Required<$NotebookDocumentOptions> & Required<$DiagnosticPullOptions>;
 namespace ResolvedClientOptions {
 	export function sanitizeIsTrusted(isTrusted?: boolean | { readonly enabledCommands: readonly string[] }): boolean | { readonly enabledCommands: readonly string[] } {
 		if (isTrusted === undefined || isTrusted === null) {
@@ -735,6 +735,7 @@ export abstract class BaseLanguageClient implements FeatureClient<Middleware, La
 			// 	interval: clientOptions.suspend?.interval ? Math.max(clientOptions.suspend.interval, defaultInterval) : defaultInterval
 			// },
 			diagnosticPullOptions: clientOptions.diagnosticPullOptions ?? { onChange: true, onSave: false },
+			diagnosticCollectionProvider: clientOptions.diagnosticCollectionProvider ?? new DefaultDiagnosticCollectionProvider(),
 			notebookDocumentOptions: clientOptions.notebookDocumentOptions ?? { },
 			textSynchronization: this.createTextSynchronizationOptions(clientOptions.textSynchronization)
 		};
@@ -866,7 +867,7 @@ export abstract class BaseLanguageClient implements FeatureClient<Middleware, La
 			return undefined;
 		}
 		if (this._diagnostics === undefined) {
-			this._diagnostics = Languages.createDiagnosticCollection(this._clientOptions.diagnosticCollectionName ?? this._id);
+			this._diagnostics = this._clientOptions.diagnosticCollectionProvider.create(this._clientOptions.diagnosticCollectionName ?? this._id, DiagnosticCollectionSource.push);
 		}
 		return this._diagnostics;
 	}
@@ -1672,7 +1673,7 @@ export abstract class BaseLanguageClient implements FeatureClient<Middleware, La
 				this._diagnostics = null;
 			}
 			if (this._diagnostics !== null) {
-				this._diagnostics.dispose();
+				this._clientOptions.diagnosticCollectionProvider.dispose(this._diagnostics, DiagnosticCollectionSource.push);
 				this._diagnostics = null;
 			}
 		}

--- a/client/src/common/diagnostic.ts
+++ b/client/src/common/diagnostic.ts
@@ -20,7 +20,7 @@ import { generateUuid } from './utils/uuid';
 import { matchGlobPattern } from './utils/globPattern';
 
 import {
-	TextDocumentLanguageFeature, FeatureClient, LSPCancellationError, type VisibleDocuments
+	TextDocumentLanguageFeature, FeatureClient, LSPCancellationError, DiagnosticCollectionSource, type DiagnosticCollectionProvider, type VisibleDocuments
 } from './features';
 
 function ensure<T, K extends keyof T>(target: T, key: K): T[K] {
@@ -166,8 +166,15 @@ export type DiagnosticPullOptions = {
 };
 
 export type $DiagnosticPullOptions = {
-	diagnosticCollectionName?: string;
 	diagnosticPullOptions?: DiagnosticPullOptions;
+
+	/**
+	 * The provider used to create and dispose the diagnostic collections for the
+	 * push (`textDocument/publishDiagnostics`) and the pull (`textDocument/diagnostic`)
+	 * model. If omitted a default provider is used that doesn't share a diagnostic
+	 * collection between the two models.
+	 */
+	diagnosticCollectionProvider?: DiagnosticCollectionProvider;
 };
 
 
@@ -298,7 +305,7 @@ class DiagnosticRequestor implements Disposable {
 
 	public readonly onDidChangeDiagnosticsEmitter: EventEmitter<void>;
 	public readonly provider: vsdiag.DiagnosticProvider;
-	private readonly diagnostics: DiagnosticCollection | undefined;
+	private readonly diagnostics: DiagnosticCollection;
 	private readonly openRequests: Map<string, RequestState>;
 	private readonly documentStates: DocumentPullStateTracker;
 
@@ -321,52 +328,13 @@ class DiagnosticRequestor implements Disposable {
 		this.workspaceErrorCounter = 0;
 	}
 
-	private createDiagnosticCollection(): DiagnosticCollection | undefined {
-		// We have no name. So create a unique diagnostic collection.
-		if (this.options.identifier === undefined) {
-			return Languages.createDiagnosticCollection();
-		}
-		const clientOptions = this.client.clientOptions;
-		// The name is different than the one used for push. So create a unique
-		// diagnostic collection.
-		if (this.options.identifier !== clientOptions.diagnosticCollectionName) {
+	private createDiagnosticCollection(): DiagnosticCollection {
+		if (this.client.clientOptions.diagnosticCollectionProvider === undefined) {
 			return Languages.createDiagnosticCollection(this.options.identifier);
-		}
-		// The name is the same. return undefined since we do want to reuse the
-		// same collection as the push model.
-		return undefined;
-	}
-
-	private deleteDiagnostics(document: TextDocument | Uri): void {
-		const uri = document instanceof Uri ? document : document.uri;
-		if (this.diagnostics !== undefined) {
-			this.diagnostics.delete(uri);
 		} else {
-			const diagnostics = this.client.diagnostics;
-			if (diagnostics !== undefined) {
-				diagnostics.delete(uri);
-			}
+			return this.client.clientOptions.diagnosticCollectionProvider.create(this.options.identifier, DiagnosticCollectionSource.pull);
 		}
 	}
-
-	private setDiagnostics(document: TextDocument | Uri, diagnostics: VDiagnostic[]): void {
-		const uri = document instanceof Uri ? document : document.uri;
-		if (this.diagnostics !== undefined) {
-			this.diagnostics.set(uri, diagnostics);
-		} else {
-			const clientDiagnostics = this.client.diagnostics;
-			if (clientDiagnostics !== undefined) {
-				clientDiagnostics.set(uri, diagnostics);
-			}
-		}
-	}
-
-	private disposeDiagnostics(): void {
-		if (this.diagnostics !== undefined) {
-			this.diagnostics.dispose();
-		}
-	}
-
 
 	public knows(kind: PullState, document: TextDocument | Uri): boolean {
 		const uri = document instanceof Uri ? document : document.uri;
@@ -440,7 +408,7 @@ class DiagnosticRequestor implements Disposable {
 			if (afterState === undefined) {
 				// This shouldn't happen. Log it
 				this.client.error(`Lost request state in diagnostic pull model. Clearing diagnostics for ${key}`);
-				this.deleteDiagnostics(uri);
+				this.diagnostics.delete(uri);
 				return;
 			}
 			this.openRequests.delete(key);
@@ -454,7 +422,7 @@ class DiagnosticRequestor implements Disposable {
 			// report is only undefined if the request has thrown.
 			if (report !== undefined) {
 				if (report.kind === vsdiag.DocumentDiagnosticReportKind.full) {
-					this.setDiagnostics(uri, report.items);
+					this.diagnostics.set(uri, report.items);
 				}
 				documentState.pulledVersion = version;
 				documentState.resultId = report.resultId;
@@ -505,7 +473,7 @@ class DiagnosticRequestor implements Disposable {
 				}
 				this.openRequests.set(key, { state: RequestStateKind.outDated, document: document });
 			}
-			this.deleteDiagnostics(uri);
+			this.diagnostics.delete(uri);
 			this.forget(PullState.document, document);
 		}
 	}
@@ -555,7 +523,7 @@ class DiagnosticRequestor implements Disposable {
 					// Favour document pull result over workspace results. So skip if it is tracked
 					// as a document result.
 					if (!this.documentStates.tracks(PullState.document, item.uri)) {
-						this.setDiagnostics(item.uri, item.items);
+						this.diagnostics.set(item.uri, item.items);
 					}
 				}
 				this.documentStates.update(PullState.workspace, item.uri, item.version ?? undefined, item.resultId);
@@ -698,7 +666,11 @@ class DiagnosticRequestor implements Disposable {
 		}
 
 		// cleanup old diagnostics
-		this.disposeDiagnostics();
+		if (this.client.clientOptions.diagnosticCollectionProvider !== undefined) {
+			this.client.clientOptions.diagnosticCollectionProvider.dispose(this.diagnostics, DiagnosticCollectionSource.pull);
+		} else {
+			this.diagnostics.dispose();
+		}
 	}
 }
 

--- a/client/src/common/diagnostic.ts
+++ b/client/src/common/diagnostic.ts
@@ -166,6 +166,7 @@ export type DiagnosticPullOptions = {
 };
 
 export type $DiagnosticPullOptions = {
+	diagnosticCollectionName?: string;
 	diagnosticPullOptions?: DiagnosticPullOptions;
 };
 
@@ -297,7 +298,7 @@ class DiagnosticRequestor implements Disposable {
 
 	public readonly onDidChangeDiagnosticsEmitter: EventEmitter<void>;
 	public readonly provider: vsdiag.DiagnosticProvider;
-	private readonly diagnostics: DiagnosticCollection;
+	private readonly diagnostics: DiagnosticCollection | undefined;
 	private readonly openRequests: Map<string, RequestState>;
 	private readonly documentStates: DocumentPullStateTracker;
 
@@ -314,11 +315,58 @@ class DiagnosticRequestor implements Disposable {
 		this.onDidChangeDiagnosticsEmitter = new EventEmitter<void>();
 		this.provider = this.createProvider();
 
-		this.diagnostics = Languages.createDiagnosticCollection(options.identifier);
+		this.diagnostics = this.createDiagnosticCollection();
 		this.openRequests = new Map();
 		this.documentStates = new DocumentPullStateTracker();
 		this.workspaceErrorCounter = 0;
 	}
+
+	private createDiagnosticCollection(): DiagnosticCollection | undefined {
+		// We have no name. So create a unique diagnostic collection.
+		if (this.options.identifier === undefined) {
+			return Languages.createDiagnosticCollection();
+		}
+		const clientOptions = this.client.clientOptions;
+		// The name is different than the one used for push. So create a unique
+		// diagnostic collection.
+		if (this.options.identifier !== clientOptions.diagnosticCollectionName) {
+			return Languages.createDiagnosticCollection(this.options.identifier);
+		}
+		// The name is the same. return undefined since we do want to reuse the
+		// same collection as the push model.
+		return undefined;
+	}
+
+	private deleteDiagnostics(document: TextDocument | Uri): void {
+		const uri = document instanceof Uri ? document : document.uri;
+		if (this.diagnostics !== undefined) {
+			this.diagnostics.delete(uri);
+		} else {
+			const diagnostics = this.client.diagnostics;
+			if (diagnostics !== undefined) {
+				diagnostics.delete(uri);
+			}
+		}
+	}
+
+	private setDiagnostics(document: TextDocument | Uri, diagnostics: VDiagnostic[]): void {
+		const uri = document instanceof Uri ? document : document.uri;
+		if (this.diagnostics !== undefined) {
+			this.diagnostics.set(uri, diagnostics);
+		} else {
+			const clientDiagnostics = this.client.diagnostics;
+			if (clientDiagnostics !== undefined) {
+				clientDiagnostics.set(uri, diagnostics);
+			}
+		}
+	}
+
+	private disposeDiagnostics(): void {
+		if (this.diagnostics !== undefined) {
+			this.diagnostics.dispose();
+		}
+	}
+
 
 	public knows(kind: PullState, document: TextDocument | Uri): boolean {
 		const uri = document instanceof Uri ? document : document.uri;
@@ -392,7 +440,7 @@ class DiagnosticRequestor implements Disposable {
 			if (afterState === undefined) {
 				// This shouldn't happen. Log it
 				this.client.error(`Lost request state in diagnostic pull model. Clearing diagnostics for ${key}`);
-				this.diagnostics.delete(uri);
+				this.deleteDiagnostics(uri);
 				return;
 			}
 			this.openRequests.delete(key);
@@ -406,7 +454,7 @@ class DiagnosticRequestor implements Disposable {
 			// report is only undefined if the request has thrown.
 			if (report !== undefined) {
 				if (report.kind === vsdiag.DocumentDiagnosticReportKind.full) {
-					this.diagnostics.set(uri, report.items);
+					this.setDiagnostics(uri, report.items);
 				}
 				documentState.pulledVersion = version;
 				documentState.resultId = report.resultId;
@@ -457,7 +505,7 @@ class DiagnosticRequestor implements Disposable {
 				}
 				this.openRequests.set(key, { state: RequestStateKind.outDated, document: document });
 			}
-			this.diagnostics.delete(uri);
+			this.deleteDiagnostics(uri);
 			this.forget(PullState.document, document);
 		}
 	}
@@ -507,7 +555,7 @@ class DiagnosticRequestor implements Disposable {
 					// Favour document pull result over workspace results. So skip if it is tracked
 					// as a document result.
 					if (!this.documentStates.tracks(PullState.document, item.uri)) {
-						this.diagnostics.set(item.uri, item.items);
+						this.setDiagnostics(item.uri, item.items);
 					}
 				}
 				this.documentStates.update(PullState.workspace, item.uri, item.version ?? undefined, item.resultId);
@@ -650,7 +698,7 @@ class DiagnosticRequestor implements Disposable {
 		}
 
 		// cleanup old diagnostics
-		this.diagnostics.dispose();
+		this.disposeDiagnostics();
 	}
 }
 

--- a/client/src/common/features.ts
+++ b/client/src/common/features.ts
@@ -689,6 +689,55 @@ import type { DiagnosticFeatureShape, DiagnosticProviderShape } from './diagnost
 import type { NotebookDocumentProviderShape } from './notebook';
 import { FoldingRangeProviderShape } from './foldingRange';
 
+export enum DiagnosticCollectionSource {
+	push = 'push',
+	pull = 'pull'
+}
+
+/**
+ * A provider that creates and disposes the diagnostic collections used by the
+ * push (`textDocument/publishDiagnostics`) and the pull (`textDocument/diagnostic`)
+ * model. The same provider instance is shared between the client and the
+ * diagnostic pull implementation so that an implementation can decide whether the
+ * two models share the same underlying collection.
+ */
+export interface DiagnosticCollectionProvider {
+	/**
+	 * Creates or returns a diagnostic collection for the given name and source.
+	 *
+	 * @param name the name of the diagnostic collection or `undefined` if no name
+	 * is available.
+	 * @param source whether the collection is requested by the `push` or the
+	 * `pull` model.
+	 */
+	create(name: string | undefined, source: DiagnosticCollectionSource): DiagnosticCollection;
+
+	/**
+	 * Disposes the given diagnostic collection on behalf of the given source.
+	 *
+	 * @param collection the collection to dispose.
+	 * @param source whether the `push` or the `pull` model releases the collection.
+	 */
+	dispose(collection: DiagnosticCollection, source: DiagnosticCollectionSource): void;
+}
+
+/**
+ * The default {@link DiagnosticCollectionProvider}. It never shares a diagnostic
+ * collection between the push and the pull model. Every call to {@link create}
+ * returns a new collection and {@link dispose} disposes it directly.
+ */
+export class DefaultDiagnosticCollectionProvider implements DiagnosticCollectionProvider {
+	public create(name: string | undefined, _source: DiagnosticCollectionSource): DiagnosticCollection {
+		return name !== undefined
+			? Languages.createDiagnosticCollection(name)
+			: Languages.createDiagnosticCollection();
+	}
+
+	public dispose(collection: DiagnosticCollection, _source: DiagnosticCollectionSource): void {
+		collection.dispose();
+	}
+}
+
 export interface FeatureClient<M, CO = object> {
 
 	protocol2CodeConverter: p2c.Converter;
@@ -697,7 +746,6 @@ export interface FeatureClient<M, CO = object> {
 	clientOptions: CO;
 	middleware: M;
 
-	diagnostics: DiagnosticCollection | undefined;
 	visibleDocuments: VisibleDocuments;
 
 	start(): Promise<void>;

--- a/client/src/common/features.ts
+++ b/client/src/common/features.ts
@@ -10,7 +10,7 @@ import {
 	DocumentRangeFormattingEditProvider, OnTypeFormattingEditProvider, RenameProvider, DocumentSymbolProvider, DocumentLinkProvider, DocumentColorProvider,
 	DeclarationProvider, ImplementationProvider, SelectionRangeProvider, TypeDefinitionProvider, CallHierarchyProvider,
 	LinkedEditingRangeProvider, TypeHierarchyProvider, FileCreateEvent, FileRenameEvent, FileDeleteEvent, FileWillCreateEvent, FileWillRenameEvent,
-	FileWillDeleteEvent, CancellationError, InlineCompletionItemProvider, type Uri
+	FileWillDeleteEvent, CancellationError, InlineCompletionItemProvider, type Uri, type DiagnosticCollection
 } from 'vscode';
 
 import {
@@ -697,6 +697,7 @@ export interface FeatureClient<M, CO = object> {
 	clientOptions: CO;
 	middleware: M;
 
+	diagnostics: DiagnosticCollection | undefined;
 	visibleDocuments: VisibleDocuments;
 
 	start(): Promise<void>;


### PR DESCRIPTION
Implement a mechanism to reuse diagnostic collections with the same name and introduce a `DiagnosticCollectionProvider` to manage the creation and disposal of these collections for both push and pull models.