### PR TITLE
Fix validation setting in TypeScript configuration

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -23,7 +23,6 @@
 	"js/ts.format.insertSpaceAfterOpeningAndBeforeClosingTemplateStringBraces": false,
 	"js/ts.format.placeOpenBraceOnNewLineForFunctions": false,
 	"js/ts.format.placeOpenBraceOnNewLineForControlBlocks": false,
-	"js/ts.validate.enabled": false,
 
 	"typescript.tsserver.trace": "off",
 	"typescript.tsserver.experimental.useVsCodeWatcher": true,


### PR DESCRIPTION
Remove the setting that disables TypeScript validation to ensure proper code validation during development.