### PR TITLE
Remove proposed tag references from documentation

### DIFF
--- a/protocol/metaModel.json
+++ b/protocol/metaModel.json
@@ -12862,8 +12862,8 @@
 						"name": "CodeActionTagOptions"
 					},
 					"optional": true,
-					"documentation": "Client supports the tag property on a code action. Clients\nsupporting tags have to handle unknown tags gracefully.\n\n@since 3.18.0 - proposed",
-					"since": "3.18.0 - proposed"
+					"documentation": "Client supports the tag property on a code action. Clients\nsupporting tags have to handle unknown tags gracefully.\n\n@since 3.18.0",
+					"since": "3.18.0"
 				}
 			],
 			"documentation": "The Client Capabilities of a {@link CodeActionRequest}."
@@ -13839,8 +13839,8 @@
 					"documentation": "The tags supported by the client."
 				}
 			],
-			"documentation": "@since 3.18.0 - proposed",
-			"since": "3.18.0 - proposed"
+			"documentation": "@since 3.18.0",
+			"since": "3.18.0"
 		},
 		{
 			"name": "ClientCodeLensResolveOptions",

--- a/protocol/src/common/protocol.ts
+++ b/protocol/src/common/protocol.ts
@@ -3357,13 +3357,13 @@ export interface CodeActionClientCapabilities {
 	 * Client supports the tag property on a code action. Clients
 	 * supporting tags have to handle unknown tags gracefully.
 	 *
-	 * @since 3.18.0 - proposed
+	 * @since 3.18.0
 	 */
 	tagSupport?: CodeActionTagOptions;
 }
 
 /**
- * @since 3.18.0 - proposed
+ * @since 3.18.0
  */
 export type CodeActionTagOptions = {
 	/**

--- a/types/src/main.ts
+++ b/types/src/main.ts
@@ -3524,7 +3524,7 @@ export type CodeActionDisabled = {
 /**
  * Code action tags are extra annotations that tweak the behavior of a code action.
  *
- * @since 3.18.0 - proposed
+ * @since 3.18.0
  */
 export namespace CodeActionTag {
 	/**
@@ -3619,7 +3619,7 @@ export interface CodeAction {
 	/**
  	 * Tags for this code action.
 	 *
-	 * @since 3.18.0 - proposed
+	 * @since 3.18.0
 	 */
 	tags?: CodeActionTag[];
 }


### PR DESCRIPTION
Eliminate the "proposed" label from the documentation and versioning comments related to code action tags to clarify the versioning status.