### PR TITLE
Port metamodel generator to TypeScript 7 API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,28 +26,11 @@
 				"shx": "^0.4.0",
 				"source-map-support": "^0.5.21",
 				"ts-json-schema-generator": "^2.9.0",
-				"typescript": "npm:@typescript/typescript6@^6.0.1",
-				"typescript-7": "file:../typescript-go/_packages/native-preview",
+				"typescript": "npm:@typescript/typescript6@^6.0.2",
+				"typescript-7": "npm:typescript@7.0.2",
 				"typescript-eslint": "^8.60.0",
 				"webpack": "^5.107.2",
 				"webpack-cli": "^7.0.2"
-			}
-		},
-		"../typescript-go/_packages/native-preview": {
-			"name": "@typescript/native-preview",
-			"version": "0.0.0",
-			"dev": true,
-			"license": "Apache-2.0",
-			"bin": {
-				"tsgo": "bin/tsgo"
-			},
-			"devDependencies": {
-				"@types/node": "^25.9.4",
-				"tinybench": "^6.0.2",
-				"vscode-jsonrpc": "^9.0.0"
-			},
-			"engines": {
-				"node": ">=16.20.0"
 			}
 		},
 		"node_modules/@discoveryjs/json-ext": {
@@ -478,6 +461,346 @@
 			},
 			"engines": {
 				"node": ">=14.17"
+			}
+		},
+		"node_modules/@typescript/typescript-aix-ppc64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
+			"integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"aix"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-darwin-arm64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
+			"integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-darwin-x64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
+			"integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-freebsd-arm64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
+			"integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-freebsd-x64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
+			"integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-linux-arm": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
+			"integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-linux-arm64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
+			"integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-linux-loong64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
+			"integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-linux-mips64el": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
+			"integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
+			"cpu": [
+				"mips64el"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-linux-ppc64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
+			"integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-linux-riscv64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
+			"integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-linux-s390x": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
+			"integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-linux-x64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
+			"integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-netbsd-arm64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
+			"integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-netbsd-x64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
+			"integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-openbsd-arm64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
+			"integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-openbsd-x64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
+			"integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-sunos-x64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
+			"integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"sunos"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-win32-arm64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
+			"integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/@typescript/typescript-win32-x64": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
+			"integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=16.20.0"
 			}
 		},
 		"node_modules/@webassemblyjs/ast": {
@@ -5694,9 +6017,9 @@
 		},
 		"node_modules/typescript": {
 			"name": "@typescript/typescript6",
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/@typescript/typescript6/-/typescript6-6.0.1.tgz",
-			"integrity": "sha512-JbesA1Y3wSOYpcw4b4XvG8KCk9AaStATxk1Vmc1qY0Y30fjovvcuRXX2fJ8eC2JRycKQi7V1VYKUljSVBJUzZA==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript6/-/typescript6-6.0.2.tgz",
+			"integrity": "sha512-mbCddXd+jm7hfx7w2YU64/Av4/NqqeG3GoRZgxPcgoTxYjhrcfJRw9ULch71SS4G+Q3bOXFhRvPqjguN0Hyp5w==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -5707,8 +6030,40 @@
 			}
 		},
 		"node_modules/typescript-7": {
-			"resolved": "../typescript-go/_packages/native-preview",
-			"link": true
+			"name": "typescript",
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
+			"integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"tsc": "bin/tsc"
+			},
+			"engines": {
+				"node": ">=16.20.0"
+			},
+			"optionalDependencies": {
+				"@typescript/typescript-aix-ppc64": "7.0.2",
+				"@typescript/typescript-darwin-arm64": "7.0.2",
+				"@typescript/typescript-darwin-x64": "7.0.2",
+				"@typescript/typescript-freebsd-arm64": "7.0.2",
+				"@typescript/typescript-freebsd-x64": "7.0.2",
+				"@typescript/typescript-linux-arm": "7.0.2",
+				"@typescript/typescript-linux-arm64": "7.0.2",
+				"@typescript/typescript-linux-loong64": "7.0.2",
+				"@typescript/typescript-linux-mips64el": "7.0.2",
+				"@typescript/typescript-linux-ppc64": "7.0.2",
+				"@typescript/typescript-linux-riscv64": "7.0.2",
+				"@typescript/typescript-linux-s390x": "7.0.2",
+				"@typescript/typescript-linux-x64": "7.0.2",
+				"@typescript/typescript-netbsd-arm64": "7.0.2",
+				"@typescript/typescript-netbsd-x64": "7.0.2",
+				"@typescript/typescript-openbsd-arm64": "7.0.2",
+				"@typescript/typescript-openbsd-x64": "7.0.2",
+				"@typescript/typescript-sunos-x64": "7.0.2",
+				"@typescript/typescript-win32-arm64": "7.0.2",
+				"@typescript/typescript-win32-x64": "7.0.2"
+			}
 		},
 		"node_modules/typescript-eslint": {
 			"version": "8.60.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,10 +26,28 @@
 				"shx": "^0.4.0",
 				"source-map-support": "^0.5.21",
 				"ts-json-schema-generator": "^2.9.0",
-				"typescript": "^6.0.3",
+				"typescript": "npm:@typescript/typescript6@^6.0.1",
+				"typescript-7": "file:../typescript-go/_packages/native-preview",
 				"typescript-eslint": "^8.60.0",
 				"webpack": "^5.107.2",
 				"webpack-cli": "^7.0.2"
+			}
+		},
+		"../typescript-go/_packages/native-preview": {
+			"name": "@typescript/native-preview",
+			"version": "0.0.0",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"tsgo": "bin/tsgo"
+			},
+			"devDependencies": {
+				"@types/node": "^25.9.4",
+				"tinybench": "^6.0.2",
+				"vscode-jsonrpc": "^9.0.0"
+			},
+			"engines": {
+				"node": ">=16.20.0"
 			}
 		},
 		"node_modules/@discoveryjs/json-ext": {
@@ -384,92 +402,6 @@
 				"undici-types": "~6.20.0"
 			}
 		},
-		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "8.60.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.60.0.tgz",
-			"integrity": "sha512-QYb/sa74/s7OKMbACMjrYnGspj9Hs5YI5aaffSL65UfeBUzVzBJfVo3oWSpbzPurvm7yaCCo2Lk7lVj610HqKw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@eslint-community/regexpp": "^4.12.2",
-				"@typescript-eslint/scope-manager": "8.60.0",
-				"@typescript-eslint/type-utils": "8.60.0",
-				"@typescript-eslint/utils": "8.60.0",
-				"@typescript-eslint/visitor-keys": "8.60.0",
-				"ignore": "^7.0.5",
-				"natural-compare": "^1.4.0",
-				"ts-api-utils": "^2.5.0"
-			},
-			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			},
-			"peerDependencies": {
-				"@typescript-eslint/parser": "^8.60.0",
-				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-				"typescript": ">=4.8.4 <6.1.0"
-			}
-		},
-		"node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
-			"version": "7.0.5",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-			"integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 4"
-			}
-		},
-		"node_modules/@typescript-eslint/parser": {
-			"version": "8.60.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.60.0.tgz",
-			"integrity": "sha512-fcqpj/MyK4sxDPcbe7STNPbpQL4RLZOPWuaTmwZYuc+hJKzRf58yRxfhqGpc6PIq9ZyfSBpfHgmUHmHs0KwHwg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@typescript-eslint/scope-manager": "8.60.0",
-				"@typescript-eslint/types": "8.60.0",
-				"@typescript-eslint/typescript-estree": "8.60.0",
-				"@typescript-eslint/visitor-keys": "8.60.0",
-				"debug": "^4.4.3"
-			},
-			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			},
-			"peerDependencies": {
-				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-				"typescript": ">=4.8.4 <6.1.0"
-			}
-		},
-		"node_modules/@typescript-eslint/project-service": {
-			"version": "8.60.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.60.0.tgz",
-			"integrity": "sha512-aZu74NNKJeUWqCjDddzdiKaS82dgYgV/vmf+Ui3ZdZejmgfXR/q+pRumgobnQ2cCJTgGTWp4ypiwsuofFubavg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@typescript-eslint/tsconfig-utils": "^8.60.0",
-				"@typescript-eslint/types": "^8.60.0",
-				"debug": "^4.4.3"
-			},
-			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			},
-			"peerDependencies": {
-				"typescript": ">=4.8.4 <6.1.0"
-			}
-		},
 		"node_modules/@typescript-eslint/scope-manager": {
 			"version": "8.60.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.60.0.tgz",
@@ -488,48 +420,6 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			}
 		},
-		"node_modules/@typescript-eslint/tsconfig-utils": {
-			"version": "8.60.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.60.0.tgz",
-			"integrity": "sha512-BZPR3RGYlAXnly6ymAxfkVn5rCbZzQNou0rxv3GfWZ8cTQp+hhVd73khbGLAd8k1TlAPLISH337M+tAgAnaJDQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			},
-			"peerDependencies": {
-				"typescript": ">=4.8.4 <6.1.0"
-			}
-		},
-		"node_modules/@typescript-eslint/type-utils": {
-			"version": "8.60.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.60.0.tgz",
-			"integrity": "sha512-SX46wEUtitCpq7AN38HkUU/+zvUpdKf7ephtWAFgckH8O7PQIyL5gvrhQgBLuEYgLfuKWOVvWVskMbuFHAz5xg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@typescript-eslint/types": "8.60.0",
-				"@typescript-eslint/typescript-estree": "8.60.0",
-				"@typescript-eslint/utils": "8.60.0",
-				"debug": "^4.4.3",
-				"ts-api-utils": "^2.5.0"
-			},
-			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			},
-			"peerDependencies": {
-				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-				"typescript": ">=4.8.4 <6.1.0"
-			}
-		},
 		"node_modules/@typescript-eslint/types": {
 			"version": "8.60.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.60.0.tgz",
@@ -542,58 +432,6 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
-			}
-		},
-		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "8.60.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.60.0.tgz",
-			"integrity": "sha512-3AcZNBGMClm6CXDyo8kYvVGT/sx29sS0oBsIb9oZI2gunA4Vm2M3YHzRLPvsUBBsl+yB5FPtltq7gGH0iTlp9g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@typescript-eslint/project-service": "8.60.0",
-				"@typescript-eslint/tsconfig-utils": "8.60.0",
-				"@typescript-eslint/types": "8.60.0",
-				"@typescript-eslint/visitor-keys": "8.60.0",
-				"debug": "^4.4.3",
-				"minimatch": "^10.2.2",
-				"semver": "^7.7.3",
-				"tinyglobby": "^0.2.15",
-				"ts-api-utils": "^2.5.0"
-			},
-			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			},
-			"peerDependencies": {
-				"typescript": ">=4.8.4 <6.1.0"
-			}
-		},
-		"node_modules/@typescript-eslint/utils": {
-			"version": "8.60.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.60.0.tgz",
-			"integrity": "sha512-HtXuPfrHTyBDkameWpl+vJb1Uevu2tznAyahM1Oc4AENidCLTPiZDWIo4GfcxNdC/RcfGcadzzkqbRG87dUrQA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@eslint-community/eslint-utils": "^4.9.1",
-				"@typescript-eslint/scope-manager": "8.60.0",
-				"@typescript-eslint/types": "8.60.0",
-				"@typescript-eslint/typescript-estree": "8.60.0"
-			},
-			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			},
-			"peerDependencies": {
-				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-				"typescript": ">=4.8.4 <6.1.0"
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
@@ -625,6 +463,21 @@
 			},
 			"funding": {
 				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/@typescript/old": {
+			"name": "typescript",
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+			"integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=14.17"
 			}
 		},
 		"node_modules/@webassemblyjs/ast": {
@@ -4862,9 +4715,9 @@
 			"license": "MIT"
 		},
 		"node_modules/semver": {
-			"version": "7.8.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
-			"integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+			"version": "7.8.5",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+			"integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -5637,9 +5490,9 @@
 			}
 		},
 		"node_modules/tinyglobby": {
-			"version": "0.2.16",
-			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-			"integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+			"version": "0.2.17",
+			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+			"integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5700,19 +5553,6 @@
 			},
 			"engines": {
 				"node": ">=8.0"
-			}
-		},
-		"node_modules/ts-api-utils": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
-			"integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=18.12"
-			},
-			"peerDependencies": {
-				"typescript": ">=4.8.4"
 			}
 		},
 		"node_modules/ts-json-schema-generator": {
@@ -5853,18 +5693,22 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
-			"integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+			"name": "@typescript/typescript6",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/@typescript/typescript6/-/typescript6-6.0.1.tgz",
+			"integrity": "sha512-JbesA1Y3wSOYpcw4b4XvG8KCk9AaStATxk1Vmc1qY0Y30fjovvcuRXX2fJ8eC2JRycKQi7V1VYKUljSVBJUzZA==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"bin": {
-				"tsc": "bin/tsc",
-				"tsserver": "bin/tsserver"
+			"dependencies": {
+				"@typescript/old": "npm:typescript@^6"
 			},
-			"engines": {
-				"node": ">=14.17"
+			"bin": {
+				"tsc6": "bin/tsc6"
 			}
+		},
+		"node_modules/typescript-7": {
+			"resolved": "../typescript-go/_packages/native-preview",
+			"link": true
 		},
 		"node_modules/typescript-eslint": {
 			"version": "8.60.0",
@@ -5888,6 +5732,212 @@
 			"peerDependencies": {
 				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
 				"typescript": ">=4.8.4 <6.1.0"
+			}
+		},
+		"node_modules/typescript-eslint/node_modules/@typescript-eslint/eslint-plugin": {
+			"version": "8.60.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.60.0.tgz",
+			"integrity": "sha512-QYb/sa74/s7OKMbACMjrYnGspj9Hs5YI5aaffSL65UfeBUzVzBJfVo3oWSpbzPurvm7yaCCo2Lk7lVj610HqKw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@eslint-community/regexpp": "^4.12.2",
+				"@typescript-eslint/scope-manager": "8.60.0",
+				"@typescript-eslint/type-utils": "8.60.0",
+				"@typescript-eslint/utils": "8.60.0",
+				"@typescript-eslint/visitor-keys": "8.60.0",
+				"ignore": "^7.0.5",
+				"natural-compare": "^1.4.0",
+				"ts-api-utils": "^2.5.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"@typescript-eslint/parser": "^8.60.0",
+				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+				"typescript": ">=4.8.4 <6.1.0"
+			}
+		},
+		"node_modules/typescript-eslint/node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/type-utils": {
+			"version": "8.60.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.60.0.tgz",
+			"integrity": "sha512-SX46wEUtitCpq7AN38HkUU/+zvUpdKf7ephtWAFgckH8O7PQIyL5gvrhQgBLuEYgLfuKWOVvWVskMbuFHAz5xg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/types": "8.60.0",
+				"@typescript-eslint/typescript-estree": "8.60.0",
+				"@typescript-eslint/utils": "8.60.0",
+				"debug": "^4.4.3",
+				"ts-api-utils": "^2.5.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+				"typescript": ">=4.8.4 <6.1.0"
+			}
+		},
+		"node_modules/typescript-eslint/node_modules/@typescript-eslint/eslint-plugin/node_modules/ts-api-utils": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+			"integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.12"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.8.4"
+			}
+		},
+		"node_modules/typescript-eslint/node_modules/@typescript-eslint/parser": {
+			"version": "8.60.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.60.0.tgz",
+			"integrity": "sha512-fcqpj/MyK4sxDPcbe7STNPbpQL4RLZOPWuaTmwZYuc+hJKzRf58yRxfhqGpc6PIq9ZyfSBpfHgmUHmHs0KwHwg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/scope-manager": "8.60.0",
+				"@typescript-eslint/types": "8.60.0",
+				"@typescript-eslint/typescript-estree": "8.60.0",
+				"@typescript-eslint/visitor-keys": "8.60.0",
+				"debug": "^4.4.3"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+				"typescript": ">=4.8.4 <6.1.0"
+			}
+		},
+		"node_modules/typescript-eslint/node_modules/@typescript-eslint/typescript-estree": {
+			"version": "8.60.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.60.0.tgz",
+			"integrity": "sha512-3AcZNBGMClm6CXDyo8kYvVGT/sx29sS0oBsIb9oZI2gunA4Vm2M3YHzRLPvsUBBsl+yB5FPtltq7gGH0iTlp9g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/project-service": "8.60.0",
+				"@typescript-eslint/tsconfig-utils": "8.60.0",
+				"@typescript-eslint/types": "8.60.0",
+				"@typescript-eslint/visitor-keys": "8.60.0",
+				"debug": "^4.4.3",
+				"minimatch": "^10.2.2",
+				"semver": "^7.7.3",
+				"tinyglobby": "^0.2.15",
+				"ts-api-utils": "^2.5.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.8.4 <6.1.0"
+			}
+		},
+		"node_modules/typescript-eslint/node_modules/@typescript-eslint/typescript-estree/node_modules/@typescript-eslint/project-service": {
+			"version": "8.60.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.60.0.tgz",
+			"integrity": "sha512-aZu74NNKJeUWqCjDddzdiKaS82dgYgV/vmf+Ui3ZdZejmgfXR/q+pRumgobnQ2cCJTgGTWp4ypiwsuofFubavg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/tsconfig-utils": "^8.60.0",
+				"@typescript-eslint/types": "^8.60.0",
+				"debug": "^4.4.3"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.8.4 <6.1.0"
+			}
+		},
+		"node_modules/typescript-eslint/node_modules/@typescript-eslint/typescript-estree/node_modules/@typescript-eslint/tsconfig-utils": {
+			"version": "8.60.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.60.0.tgz",
+			"integrity": "sha512-BZPR3RGYlAXnly6ymAxfkVn5rCbZzQNou0rxv3GfWZ8cTQp+hhVd73khbGLAd8k1TlAPLISH337M+tAgAnaJDQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.8.4 <6.1.0"
+			}
+		},
+		"node_modules/typescript-eslint/node_modules/@typescript-eslint/typescript-estree/node_modules/ts-api-utils": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+			"integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.12"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.8.4"
+			}
+		},
+		"node_modules/typescript-eslint/node_modules/@typescript-eslint/utils": {
+			"version": "8.60.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.60.0.tgz",
+			"integrity": "sha512-HtXuPfrHTyBDkameWpl+vJb1Uevu2tznAyahM1Oc4AENidCLTPiZDWIo4GfcxNdC/RcfGcadzzkqbRG87dUrQA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@eslint-community/eslint-utils": "^4.9.1",
+				"@typescript-eslint/scope-manager": "8.60.0",
+				"@typescript-eslint/types": "8.60.0",
+				"@typescript-eslint/typescript-estree": "8.60.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+				"typescript": ">=4.8.4 <6.1.0"
+			}
+		},
+		"node_modules/typescript-eslint/node_modules/ignore": {
+			"version": "7.0.5",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+			"integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4"
 			}
 		},
 		"node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -13,26 +13,27 @@
 		"url": "https://github.com/Microsoft/vscode-languageserver-node/issues"
 	},
 	"devDependencies": {
+		"@stylistic/eslint-plugin": "^5.10.0",
 		"@types/assert": "^1.5.11",
 		"@types/mocha": "^10.0.10",
 		"@types/node": "22.13.14",
-		"@stylistic/eslint-plugin": "^5.10.0",
 		"assert": "^2.1.0",
 		"eslint": "^10.4.0",
 		"globals": "^17.6.0",
-		"typescript-eslint": "^8.60.0",
 		"http-server": "^14.1.1",
 		"mocha": "^11.7.6",
+		"node-polyfill-webpack-plugin": "^4.1.0",
 		"playwright": "^1.60.0",
 		"rimraf": "^6.1.3",
 		"shelljs": "^0.10.0",
 		"shx": "^0.4.0",
 		"source-map-support": "^0.5.21",
 		"ts-json-schema-generator": "^2.9.0",
-		"typescript": "^6.0.3",
+		"typescript": "npm:@typescript/typescript6@^6.0.1",
+		"typescript-7": "file:../typescript-go/_packages/native-preview",
+		"typescript-eslint": "^8.60.0",
 		"webpack": "^5.107.2",
-		"webpack-cli": "^7.0.2",
-		"node-polyfill-webpack-plugin": "^4.1.0"
+		"webpack-cli": "^7.0.2"
 	},
 	"scripts": {
 		"postinstall": "node ./build/bin/all.js install && cd testbed && npm install && cd .. && npm run symlink:testbed && npx playwright install",

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
 		"shx": "^0.4.0",
 		"source-map-support": "^0.5.21",
 		"ts-json-schema-generator": "^2.9.0",
-		"typescript": "npm:@typescript/typescript6@^6.0.1",
-		"typescript-7": "file:../typescript-go/_packages/native-preview",
+		"typescript": "npm:@typescript/typescript6@^6.0.2",
+		"typescript-7": "npm:typescript@7.0.2",
 		"typescript-eslint": "^8.60.0",
 		"webpack": "^5.107.2",
 		"webpack-cli": "^7.0.2"

--- a/tools/src/generator-main.ts
+++ b/tools/src/generator-main.ts
@@ -21,7 +21,7 @@ async function main(): Promise<number> {
 		}
 	});
 
-	const api = new API({});
+	const api = new API();
 	const projectPath = path.resolve(args.values.project ?? '.');
 	let snapshot: Snapshot;
 	try {

--- a/tools/src/generator-main.ts
+++ b/tools/src/generator-main.ts
@@ -5,100 +5,34 @@
 
 import * as path from 'path';
 
-import * as ts from 'typescript';
+import { API, Snapshot } from 'typescript-7/unstable/sync';
 
-import * as tss from './typescripts';
 import Visitor from './visitor';
-
-function loadConfigFile(file: string): ts.ParsedCommandLine {
-	const absolute = path.resolve(file);
-
-	const readResult = ts.readConfigFile(absolute, ts.sys.readFile);
-	if (readResult.error) {
-		throw new Error(ts.formatDiagnostics([readResult.error], ts.createCompilerHost({})));
-	}
-	const config = readResult.config;
-	if (config.compilerOptions !== undefined) {
-		config.compilerOptions = Object.assign(config.compilerOptions, tss.CompileOptions.getDefaultOptions(file));
-	}
-	const result = ts.parseJsonConfigFileContent(config, ts.sys, path.dirname(absolute));
-	if (result.errors.length > 0) {
-		throw new Error(ts.formatDiagnostics(result.errors, ts.createCompilerHost({})));
-	}
-	return result;
-}
+import { parseArgs } from 'util';
 
 async function main(): Promise<number> {
-
-	let config: ts.ParsedCommandLine = 	ts.parseCommandLine(ts.sys.args);
-	const configFilePath: string | undefined = tss.CompileOptions.getConfigFilePath(config.options);
-	if (configFilePath && config.options.project) {
-		config = loadConfigFile(configFilePath);
-	}
-
-	const scriptSnapshots: Map<string, ts.IScriptSnapshot> = new Map();
-	const host: ts.LanguageServiceHost = {
-		getScriptFileNames: () => {
-			return config.fileNames;
-		},
-		getCompilationSettings: () => {
-			return config.options;
-		},
-		getProjectReferences: () => {
-			return config.projectReferences;
-		},
-		getScriptVersion: (_fileName: string): string => {
-			// The files are immutable.
-			return '0';
-		},
-		// The project is immutable
-		getProjectVersion: () => '0',
-		getScriptSnapshot: (fileName: string): ts.IScriptSnapshot | undefined => {
-			let result: ts.IScriptSnapshot | undefined = scriptSnapshots.get(fileName);
-			if (result === undefined) {
-				const content: string | undefined = ts.sys.readFile(fileName);
-				if (content === undefined) {
-					return undefined;
-				}
-				result = ts.ScriptSnapshot.fromString(content);
-				scriptSnapshots.set(fileName, result);
+	const args = parseArgs({
+		args: process.argv.slice(2),
+		options: {
+			project: {
+				type: 'string',
+				short: 'p'
 			}
-			return result;
-		},
-		getCurrentDirectory: () => {
-			if (configFilePath !== undefined) {
-				return path.dirname(configFilePath);
-			} else {
-				return process.cwd();
-			}
-		},
-		getDefaultLibFileName: (options) => {
-			// We need to return the path since the language service needs
-			// to know the full path and not only the name which is return
-			// from ts.getDefaultLibFileName
-			return ts.getDefaultLibFilePath(options);
-		},
-		directoryExists: ts.sys.directoryExists,
-		getDirectories: ts.sys.getDirectories,
-		fileExists: ts.sys.fileExists,
-		readFile: ts.sys.readFile,
-		readDirectory: ts.sys.readDirectory,
-		// this is necessary to make source references work.
-		realpath: ts.sys.realpath
-	};
-
-	tss.LanguageServiceHost.useSourceOfProjectReferenceRedirect(host, () => {
-		return !config.options.disableSourceOfProjectReferenceRedirect;
+		}
 	});
 
-	const languageService = ts.createLanguageService(host);
-	const program = languageService.getProgram();
-	if (program === undefined) {
-		console.error('Couldn\'t create language service with underlying program.');
+	const api = new API({});
+	const projectPath = path.resolve(args.values.project ?? '.');
+	let snapshot: Snapshot;
+	try {
+		snapshot = api.updateSnapshot({ openProject: projectPath });
+	} catch (error) {
+		console.error('Couldn\'t load project with underlying program.');
 		process.exitCode = -1;
 		return -1;
 	}
-	const visitor = new Visitor(program);
+
+	const visitor = new Visitor(snapshot.getProjects()[0]);
 	await visitor.visitProgram();
 	await visitor.endVisitProgram();
 

--- a/tools/src/typescripts.ts
+++ b/tools/src/typescripts.ts
@@ -3,104 +3,22 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 
-import * as path from 'path';
 import * as crypto from 'crypto';
 
-import * as ts from 'typescript';
-
-const isWindows = process.platform === 'win32';
-function normalizePath(value: string): string {
-	if (isWindows) {
-		value = value.replace(/\\/g, '/');
-		if (/^[a-z]:/.test(value)) {
-			value = value.charAt(0).toUpperCase() + value.substring(1);
-		}
-	}
-	const result = path.posix.normalize(value);
-	return result.length > 0 && result.charAt(result.length - 1) === '/' ? result.substr(0, result.length - 1) : result;
-}
-
-function makeAbsolute(p: string, root?: string): string {
-	if (path.isAbsolute(p)) {
-		return normalizePath(p);
-	}
-	if (root === undefined) {
-		return normalizePath(path.join(process.cwd(), p));
-	} else {
-		return normalizePath(path.join(root, p));
-	}
-}
-
-interface InternalCompilerOptions extends ts.CompilerOptions {
-	configFilePath?: string;
-}
-
-export namespace CompileOptions {
-	export function getConfigFilePath(options: ts.CompilerOptions): string | undefined {
-		if (options.project) {
-			const projectPath = path.resolve(options.project);
-			if (ts.sys.directoryExists(projectPath)) {
-				return normalizePath(path.join(projectPath, 'tsconfig.json'));
-			} else {
-				return normalizePath(projectPath);
-			}
-		}
-		const result = (options as InternalCompilerOptions).configFilePath;
-		return result && makeAbsolute(result);
-	}
-
-	export function getDefaultOptions(configFileName?: string) {
-		const options: ts.CompilerOptions = configFileName && path.basename(configFileName) === 'jsconfig.json'
-			? { allowJs: true, maxNodeModuleJsDepth: 2, allowSyntheticDefaultImports: true, skipLibCheck: true, noEmit: true }
-			: {};
-		return options;
-	}
-}
-
-
-interface InternalLanguageServiceHost extends ts.LanguageServiceHost {
-	useSourceOfProjectReferenceRedirect?(): boolean;
-}
-
-export namespace LanguageServiceHost {
-	export function useSourceOfProjectReferenceRedirect(host: ts.LanguageServiceHost, value: () => boolean): void {
-		(host as InternalLanguageServiceHost).useSourceOfProjectReferenceRedirect = value;
-	}
-}
-
-export namespace Type {
-	export function isObjectType(type: ts.Type): type is ts.ObjectType {
-		return (type.flags & ts.TypeFlags.Object) !== 0;
-	}
-
-	export function isTypeReference(type: ts.ObjectType): type is ts.TypeReference {
-		return (type.objectFlags & ts.ObjectFlags.Reference) !== 0;
-	}
-
-	export function isVoidType(type: ts.Type): type is ts.Type {
-		return (type.flags & ts.TypeFlags.Void) !== 0;
-	}
-
-	export function isNullType(type: ts.Type): boolean {
-		return (type.flags & ts.TypeFlags.Null) !== 0;
-	}
-
-	export function isUndefinedType(type: ts.Type): boolean {
-		return (type.flags & ts.TypeFlags.Undefined) !== 0;
-	}
-}
+import * as ts from 'typescript-7/unstable/sync';
+import { SyntaxKind, ClassDeclaration, Node } from 'typescript-7/unstable/ast';
 
 interface InternalSymbol extends ts.Symbol {
-	parent?: ts.Symbol;
-	containingType?: ts.UnionOrIntersectionType;
 	__symbol__data__key__: string | undefined;
 }
 
 export class Symbols {
 
-	private readonly typeChecker: ts.TypeChecker;
+	private readonly project: ts.Project;
+	private readonly typeChecker: ts.Checker;
 
-	constructor(typeChecker: ts.TypeChecker) {
+	constructor(project: ts.Project, typeChecker: ts.Checker) {
+		this.project = project;
 		this.typeChecker = typeChecker;
 	}
 
@@ -109,43 +27,43 @@ export class Symbols {
 	public static readonly None = 'none';
 
 	public static isClass(symbol: ts.Symbol): boolean {
-		return symbol !== undefined && (symbol.getFlags() & ts.SymbolFlags.Class) !== 0;
+		return symbol !== undefined && (symbol.flags & ts.SymbolFlags.Class) !== 0;
 	}
 
 	public static isInterface(symbol: ts.Symbol): boolean {
-		return symbol !== undefined && (symbol.getFlags() & ts.SymbolFlags.Interface) !== 0;
+		return symbol !== undefined && (symbol.flags & ts.SymbolFlags.Interface) !== 0;
 	}
 
 	public static isTypeLiteral(symbol: ts.Symbol): boolean {
-		return symbol !== undefined && (symbol.getFlags() & ts.SymbolFlags.TypeLiteral) !== 0;
+		return symbol !== undefined && (symbol.flags & ts.SymbolFlags.TypeLiteral) !== 0;
 	}
 
 	public static isAliasSymbol(symbol: ts.Symbol): boolean  {
-		return symbol !== undefined && (symbol.getFlags() & ts.SymbolFlags.Alias) !== 0;
+		return symbol !== undefined && (symbol.flags & ts.SymbolFlags.Alias) !== 0;
 	}
 
 	public static isTypeAlias(symbol: ts.Symbol): boolean {
-		return symbol !== undefined && (symbol.getFlags() & ts.SymbolFlags.TypeAlias) !== 0;
+		return symbol !== undefined && (symbol.flags & ts.SymbolFlags.TypeAlias) !== 0;
 	}
 
 	public static isPrototype(symbol: ts.Symbol): boolean {
-		return symbol !== undefined && (symbol.getFlags() & ts.SymbolFlags.Prototype) !== 0;
+		return symbol !== undefined && (symbol.flags & ts.SymbolFlags.Prototype) !== 0;
 	}
 
 	public static isRegularEnum(symbol: ts.Symbol): boolean {
-		return symbol !== undefined && (symbol.getFlags() & ts.SymbolFlags.RegularEnum) !== 0;
+		return symbol !== undefined && (symbol.flags & ts.SymbolFlags.RegularEnum) !== 0;
 	}
 
 	public static isProperty(symbol: ts.Symbol): boolean {
-		return symbol !== undefined && (symbol.getFlags() & ts.SymbolFlags.Property) !== 0;
+		return symbol !== undefined && (symbol.flags & ts.SymbolFlags.Property) !== 0;
 	}
 
 	public static isOptional(symbol: ts.Symbol): boolean {
-		return symbol !== undefined && (symbol.getFlags() & ts.SymbolFlags.Optional) !== 0;
+		return symbol !== undefined && (symbol.flags & ts.SymbolFlags.Optional) !== 0;
 	}
 
 	public static getParent(symbol: ts.Symbol): ts.Symbol | undefined {
-		return (symbol as InternalSymbol).parent;
+		return (symbol as InternalSymbol).getParent();
 	}
 
 	public createKey(symbol: ts.Symbol): string {
@@ -153,7 +71,7 @@ export class Symbols {
 		if (result !== undefined) {
 			return result;
 		}
-		const declarations = symbol.getDeclarations();
+		const declarations = symbol.declarations;
 		if (declarations === undefined) {
 			if (this.typeChecker.isUnknownSymbol(symbol)) {
 				return Symbols.Unknown;
@@ -163,30 +81,21 @@ export class Symbols {
 				return Symbols.None;
 			}
 		}
-		const fragments: { f: string; s: number; e: number; k: number }[] = [];
+		const fragments: { p: string; i: number; k: number }[] = [];
 		for (const declaration of declarations) {
 			fragments.push({
-				f: declaration.getSourceFile().fileName,
-				s: declaration.getStart(),
-				e: declaration.getEnd(),
+				p: declaration.path,
+				i: declaration.index,
 				k: declaration.kind
 			});
 		}
 		if (fragments.length > 1) {
 			fragments.sort((a, b) => {
-				let result = a.f < b.f ? -1 : (a.f > b.f ? 1 : 0);
+				let result = a.p < b.p ? -1 : (a.p > b.p ? 1 : 0);
 				if (result !== 0) {
 					return result;
 				}
-				result = a.s - b.s;
-				if (result !== 0) {
-					return result;
-				}
-				result = a.e - b.e;
-				if (result !== 0) {
-					return result;
-				}
-				return a.k - b.k;
+				return a.i - b.i;
 			});
 		}
 		const hash = crypto.createHash('sha256');
@@ -201,23 +110,25 @@ export class Symbols {
 
 	public computeBaseSymbolsForClass(symbol: ts.Symbol): ts.Symbol[] | undefined {
 		const result: ts.Symbol[] = [];
-		const declarations = symbol.getDeclarations();
+		const declarations = symbol.declarations;
 		if (declarations === undefined) {
 			return undefined;
 		}
 		const typeChecker = this.typeChecker;
 		for (const declaration of declarations) {
-			if (ts.isClassDeclaration(declaration)) {
-				const heritageClauses = declaration.heritageClauses;
-				if (heritageClauses) {
-					for (const heritageClause of heritageClauses) {
-						for (const type of heritageClause.types) {
-							const tsType = typeChecker.getTypeAtLocation(type.expression);
-							if (tsType !== undefined) {
-								const baseSymbol = tsType.getSymbol();
-								if (baseSymbol !== undefined && baseSymbol !== symbol) {
-									result.push(baseSymbol);
-								}
+			if (declaration.kind !== SyntaxKind.ClassDeclaration) {
+				continue;
+			}
+			const classDeclaration = declaration.resolve(this.project)! as ClassDeclaration;
+			const heritageClauses = classDeclaration.heritageClauses;
+			if (heritageClauses) {
+				for (const heritageClause of heritageClauses) {
+					for (const type of heritageClause.types) {
+						const tsType = typeChecker.getTypeAtLocation(type.expression);
+						if (tsType !== undefined) {
+							const baseSymbol = tsType.getSymbol();
+							if (baseSymbol !== undefined && baseSymbol !== symbol) {
+								result.push(baseSymbol);
 							}
 						}
 					}
@@ -247,20 +158,20 @@ export class Symbols {
 
 	public getTypeOfSymbol(symbol: ts.Symbol): ts.Type {
 		if (Symbols.isTypeAlias(symbol) || Symbols.isInterface(symbol)) {
-			return this.typeChecker.getDeclaredTypeOfSymbol(symbol);
+			return this.typeChecker.getDeclaredTypeOfSymbol(symbol)!;
 		}
 		const location = this.inferLocationNode(symbol);
 		if (location !== undefined) {
-			return this.typeChecker.getTypeOfSymbolAtLocation(symbol, location);
+			return this.typeChecker.getTypeOfSymbolAtLocation(symbol, location)!;
 		} else {
-			return this.typeChecker.getDeclaredTypeOfSymbol(symbol);
+			return this.typeChecker.getDeclaredTypeOfSymbol(symbol)!;
 		}
 	}
 
-	private inferLocationNode(symbol: ts.Symbol): ts.Node | undefined {
+	private inferLocationNode(symbol: ts.Symbol): Node | undefined {
 		const declarations = symbol.declarations;
 		if (declarations !== undefined && declarations.length > 0) {
-			return declarations[0];
+			return declarations[0].resolve(this.project);
 		}
 		if (Symbols.isPrototype(symbol)) {
 			const parent = Symbols.getParent(symbol);

--- a/tools/src/typescripts.ts
+++ b/tools/src/typescripts.ts
@@ -158,13 +158,13 @@ export class Symbols {
 
 	public getTypeOfSymbol(symbol: ts.Symbol): ts.Type {
 		if (Symbols.isTypeAlias(symbol) || Symbols.isInterface(symbol)) {
-			return this.typeChecker.getDeclaredTypeOfSymbol(symbol)!;
+			return this.typeChecker.getDeclaredTypeOfSymbol(symbol);
 		}
 		const location = this.inferLocationNode(symbol);
 		if (location !== undefined) {
-			return this.typeChecker.getTypeOfSymbolAtLocation(symbol, location)!;
+			return this.typeChecker.getTypeOfSymbolAtLocation(symbol, location);
 		} else {
-			return this.typeChecker.getDeclaredTypeOfSymbol(symbol)!;
+			return this.typeChecker.getDeclaredTypeOfSymbol(symbol);
 		}
 	}
 

--- a/tools/src/typescripts.ts
+++ b/tools/src/typescripts.ts
@@ -119,7 +119,7 @@ export class Symbols {
 			if (declaration.kind !== SyntaxKind.ClassDeclaration) {
 				continue;
 			}
-			const classDeclaration = declaration.resolve(this.project)! as ClassDeclaration;
+			const classDeclaration = declaration.resolve() as ClassDeclaration;
 			const heritageClauses = classDeclaration.heritageClauses;
 			if (heritageClauses) {
 				for (const heritageClause of heritageClauses) {
@@ -171,7 +171,7 @@ export class Symbols {
 	private inferLocationNode(symbol: ts.Symbol): Node | undefined {
 		const declarations = symbol.declarations;
 		if (declarations !== undefined && declarations.length > 0) {
-			return declarations[0].resolve(this.project);
+			return declarations[0].resolve();
 		}
 		if (Symbols.isPrototype(symbol)) {
 			const parent = Symbols.getParent(symbol);

--- a/tools/src/visitor.ts
+++ b/tools/src/visitor.ts
@@ -3,59 +3,57 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 
-import * as ts from 'typescript-7/unstable/sync';
 import {
-	__String,
-	SourceFile,
-	SyntaxKind,
-	Node,
-	NodeArray,
-	ModuleDeclaration,
-	TypeAliasDeclaration,
-	TypeNode,
-	Identifier,
-	TypeReferenceNode,
-	IntersectionTypeNode,
-	TypeLiteralNode,
-	VariableDeclaration,
-	JSDocTag,
-	JSDocComment,
-	isTypeAliasDeclaration,
-	isVariableStatement,
-	isVariableDeclaration,
-	isIdentifier,
-	isTypeReferenceNode,
-	isArrayTypeNode,
-	isUnionTypeNode,
-	isIntersectionTypeNode,
-	isTypeLiteralNode,
-	isTupleTypeNode,
-	isTypeQueryNode,
-	isQualifiedName,
-	isParenthesizedTypeNode,
-	isLiteralTypeNode,
-	isIndexSignatureDeclaration,
-	isPropertySignatureDeclaration,
-	isInterfaceDeclaration,
-	isModuleDeclaration,
-	isModuleBlock,
-	isEnumMember,
-	isNewExpression,
-	isCallExpression,
-	isPropertyAccessExpression,
-	isStringLiteral,
-	isNumericLiteral,
-	isNoSubstitutionTemplateLiteral,
-	isPrefixUnaryExpression,
-	isJSDoc,
-	isJSDocText,
-	isJSDocUnknownTag,
-	getLeadingCommentRanges,
+    __String,
+    getJSDocTags,
+    getLeadingCommentRanges,
+    getTextOfJSDocComment,
+    Identifier,
+    IntersectionTypeNode,
+    isArrayTypeNode,
+    isCallExpression,
+    isEnumMember,
+    isIdentifier,
+    isIndexSignatureDeclaration,
+    isInterfaceDeclaration,
+    isIntersectionTypeNode,
+    isJSDocUnknownTag,
+    isLiteralTypeNode,
+    isModuleBlock,
+    isModuleDeclaration,
+    isNewExpression,
+    isNoSubstitutionTemplateLiteral,
+    isNumericLiteral,
+    isParenthesizedTypeNode,
+    isPrefixUnaryExpression,
+    isPropertyAccessExpression,
+    isPropertySignatureDeclaration,
+    isQualifiedName,
+    isStringLiteral,
+    isTupleTypeNode,
+    isTypeAliasDeclaration,
+    isTypeLiteralNode,
+    isTypeQueryNode,
+    isTypeReferenceNode,
+    isUnionTypeNode,
+    isVariableDeclaration,
+    isVariableStatement,
+    JSDocTag,
+    ModuleDeclaration,
+    Node,
+    SourceFile,
+    SyntaxKind,
+    TypeAliasDeclaration,
+    TypeLiteralNode,
+    TypeNode,
+    TypeReferenceNode,
+    VariableDeclaration
 } from 'typescript-7/unstable/ast';
+import * as ts from 'typescript-7/unstable/sync';
 
 import { Symbols } from './typescripts';
 
-import { Type as JsonType, Request as JsonRequest, Notification as JsonNotification, Structure, Property, StructureLiteral, BaseTypes, TypeAlias, MetaModel, Enumeration, EnumerationEntry, EnumerationType, MessageDirection } from './metaModel';
+import { BaseTypes, Enumeration, EnumerationEntry, EnumerationType, Notification as JsonNotification, Request as JsonRequest, Type as JsonType, MessageDirection, MetaModel, Property, Structure, StructureLiteral, TypeAlias } from './metaModel';
 import path = require('path');
 
 const LSPBaseTypes = new Set(['URI', 'DocumentUri', 'integer', 'uinteger', 'decimal']);
@@ -1255,7 +1253,7 @@ export default class Visitor {
 	private fillDocProperties(node: Node, value: JsonRequest | JsonNotification | Property | Structure | StructureLiteral | EnumerationEntry | Enumeration | TypeAlias | LiteralInfo): void {
 		const filePath = node.getSourceFile().fileName;
 		const fileName = path.basename(filePath);
-		const tags = this.getJSDocTags(node);
+		const tags = getJSDocTags(node);
 		const { since, sinceTags, deprecated } = this.getTags(tags);
 		const proposed = (fileName.startsWith('proposed.') || tags.some((tag) => { return isJSDocUnknownTag(tag) && tag.tagName.text === 'proposed';})) ? true : undefined;
 		value.documentation = this.getDocumentation(node);
@@ -1263,21 +1261,6 @@ export default class Visitor {
 		value.sinceTags = sinceTags;
 		value.deprecated = deprecated;
 		value.proposed = proposed;
-	}
-
-	private getJSDocTags(node: Node): ReadonlyArray<JSDocTag> {
-		const result: JSDocTag[] = [];
-		const jsDocs = node.jsDoc;
-		if (jsDocs !== undefined) {
-			for (const jsDoc of jsDocs) {
-				if (isJSDoc(jsDoc) && jsDoc.tags !== undefined) {
-					for (const tag of jsDoc.tags) {
-						result.push(tag);
-					}
-				}
-			}
-		}
-		return result;
 	}
 
 	private getDocumentation(node: Node): string | undefined {
@@ -1319,7 +1302,7 @@ export default class Visitor {
 	private getTags(tags: ReadonlyArray<JSDocTag>): { since?: string; sinceTags?: string[]; deprecated?: string } {
 		const result: { since?: string; sinceTags?: string[];  deprecated?: string } = {};
 		for (const tag of tags) {
-			const comment = this.getJSDocCommentText(tag.comment);
+			const comment = getTextOfJSDocComment(tag.comment);
 			if (tag.tagName.text === 'since' && comment !== undefined) {
 				const value = comment.replace(/\r?\n/g, '\n');
 				result.since = value;
@@ -1336,20 +1319,6 @@ export default class Visitor {
 			delete result.sinceTags;
 		}
 		return result;
-	}
-
-	private getJSDocCommentText(comment: NodeArray<JSDocComment> | undefined): string | undefined {
-		if (comment === undefined) {
-			return undefined;
-		}
-		const parts: string[] = [];
-		for (const part of comment) {
-			if (!isJSDocText(part)) {
-				return undefined;
-			}
-			parts.push(part.text);
-		}
-		return parts.join('');
 	}
 }
 

--- a/tools/src/visitor.ts
+++ b/tools/src/visitor.ts
@@ -486,10 +486,8 @@ export default class Visitor {
 			}
 			this.symbolQueue.set(name, aliased ?? symbol);
 		} else {
-			// !!! getAliasedSymbol is guaranteed to resolve when isAliasSymbol is true
-			const left = Symbols.isAliasSymbol(symbol) ? this.typeChecker.getAliasedSymbol(symbol)! : symbol;
-			// !!! getAliasedSymbol is guaranteed to resolve when isAliasSymbol is true
-			const right = Symbols.isAliasSymbol(existing) ? this.typeChecker.getAliasedSymbol(existing)! : existing;
+			const left = Symbols.isAliasSymbol(symbol) ? this.typeChecker.getAliasedSymbol(symbol) : symbol;
+			const right = Symbols.isAliasSymbol(existing) ? this.typeChecker.getAliasedSymbol(existing) : existing;
 			if (this.symbols.createKey(left) !== this.symbols.createKey(right)) {
 				throw new Error(`The type ${name} has two different declarations`);
 			}
@@ -930,7 +928,6 @@ export default class Visitor {
 			if (isTypeLiteralNode(declaration.type)) {
 				// We have a single type literal node. So treat it as a structure
 				const result: Structure = { name: name, properties: [] };
-				// !!! type and symbol are assumed present for a type literal node
 				this.fillProperties(result, this.typeChecker.getTypeAtLocation(declaration.type)!.getSymbol()!);
 				this.fillDocProperties(declaration, result);
 				return result;
@@ -959,7 +956,6 @@ export default class Visitor {
 						result.mixins = mixins;
 					}
 					if (split.literal !== undefined) {
-						// !!! type and symbol are assumed present for a type literal node
 						this.fillProperties(result, this.typeChecker.getTypeAtLocation(split.literal)!.getSymbol()!);
 					}
 					this.fillDocProperties(declaration, result);

--- a/tools/src/visitor.ts
+++ b/tools/src/visitor.ts
@@ -3,7 +3,55 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 
-import * as ts from 'typescript';
+import * as ts from 'typescript-7/unstable/sync';
+import {
+	__String,
+	SourceFile,
+	SyntaxKind,
+	Node,
+	NodeArray,
+	ModuleDeclaration,
+	TypeAliasDeclaration,
+	TypeNode,
+	Identifier,
+	TypeReferenceNode,
+	IntersectionTypeNode,
+	TypeLiteralNode,
+	VariableDeclaration,
+	JSDocTag,
+	JSDocComment,
+	isTypeAliasDeclaration,
+	isVariableStatement,
+	isVariableDeclaration,
+	isIdentifier,
+	isTypeReferenceNode,
+	isArrayTypeNode,
+	isUnionTypeNode,
+	isIntersectionTypeNode,
+	isTypeLiteralNode,
+	isTupleTypeNode,
+	isTypeQueryNode,
+	isQualifiedName,
+	isParenthesizedTypeNode,
+	isLiteralTypeNode,
+	isIndexSignatureDeclaration,
+	isPropertySignatureDeclaration,
+	isInterfaceDeclaration,
+	isModuleDeclaration,
+	isModuleBlock,
+	isEnumMember,
+	isNewExpression,
+	isCallExpression,
+	isPropertyAccessExpression,
+	isStringLiteral,
+	isNumericLiteral,
+	isNoSubstitutionTemplateLiteral,
+	isPrefixUnaryExpression,
+	isJSDoc,
+	isJSDocText,
+	isJSDocUnknownTag,
+	getLeadingCommentRanges,
+} from 'typescript-7/unstable/ast';
 
 import { Symbols } from './typescripts';
 
@@ -155,11 +203,12 @@ type Capabilities = { clientCapability?: string; serverCapability?: string };
 
 export default class Visitor {
 
+	private readonly project: ts.Project;
 	private readonly program: ts.Program;
-	private readonly typeChecker: ts.TypeChecker;
+	private readonly typeChecker: ts.Checker;
 	private readonly symbols: Symbols;
 
-	#currentSourceFile: ts.SourceFile | undefined;
+	#currentSourceFile: SourceFile | undefined;
 
 	private readonly requests: JsonRequest[];
 	private readonly notifications: JsonNotification[];
@@ -172,10 +221,11 @@ export default class Visitor {
 		['TraceValues', Symbols.isTypeAlias]
 	]);
 
-	constructor(program: ts.Program) {
-		this.program = program;
-		this.typeChecker = this.program.getTypeChecker();
-		this.symbols = new Symbols(this.typeChecker);
+	constructor(project: ts.Project) {
+		this.project = project;
+		this.program = project.program;
+		this.typeChecker = project.checker;
+		this.symbols = new Symbols(this.project, this.typeChecker);
 		this.requests = [];
 		this.notifications = [];
 		this.structures = [];
@@ -186,7 +236,7 @@ export default class Visitor {
 
 	}
 
-	protected get currentSourceFile(): ts.SourceFile {
+	protected get currentSourceFile(): SourceFile {
 		if (this.#currentSourceFile === undefined) {
 			throw new Error(`Current source file not known`);
 		}
@@ -232,13 +282,13 @@ export default class Visitor {
 		};
 	}
 
-	protected visit(node: ts.Node): void {
+	protected visit(node: Node): void {
 		switch (node.kind) {
-			case ts.SyntaxKind.SourceFile:
-				this.doVisit(this.visitSourceFile, this.endVisitSourceFile, node as ts.SourceFile);
+			case SyntaxKind.SourceFile:
+				this.doVisit(this.visitSourceFile, this.endVisitSourceFile, node as SourceFile);
 				break;
-			case ts.SyntaxKind.ModuleDeclaration:
-				this.doVisit(this.visitModuleDeclaration, this.endVisitModuleDeclaration, node as ts.ModuleDeclaration);
+			case SyntaxKind.ModuleDeclaration:
+				this.doVisit(this.visitModuleDeclaration, this.endVisitModuleDeclaration, node as ModuleDeclaration);
 				break;
 			default:
 				this.doVisit(this.visitGeneric, this.endVisitGeneric, node);
@@ -246,7 +296,7 @@ export default class Visitor {
 		}
 	}
 
-	private doVisit<T extends ts.Node>(visit: (node: T) => boolean, endVisit: (node: T) => void, node: T): void {
+	private doVisit<T extends Node>(visit: (node: T) => boolean, endVisit: (node: T) => void, node: T): void {
 		if (visit.call(this, node)) {
 			node.forEachChild(child => this.visit(child));
 		}
@@ -260,7 +310,7 @@ export default class Visitor {
 	private endVisitGeneric(): void {
 	}
 
-	private visitSourceFile(node: ts.SourceFile): boolean {
+	private visitSourceFile(node: SourceFile): boolean {
 		this.#currentSourceFile = node;
 		// The file `protocol.$.ts` contains all definitions for things
 		// that are not reference through the protocol module but part of
@@ -268,19 +318,19 @@ export default class Visitor {
 		// to start with a $ to make this clear.
 		if (path.basename(node.fileName) === 'protocol.$.ts') {
 			for (const statement of node.statements) {
-				if (ts.isTypeAliasDeclaration(statement) && statement.name.getText()[0] === '$') {
+				if (isTypeAliasDeclaration(statement) && statement.name.text[0] === '$') {
 					this.visitTypeReference(statement);
 				}
-				if (ts.isVariableStatement(statement)) {
+				if (isVariableStatement(statement)) {
 					for (const declaration of statement.declarationList.declarations) {
-						if (declaration.name.getText()[0] !== '$' || declaration.initializer === undefined) {
+						if (isIdentifier(declaration.name) && declaration.name.text[0] !== '$' || declaration.initializer === undefined) {
 							continue;
 						}
 						const symbol = this.typeChecker.getSymbolAtLocation(declaration.initializer);
 						if (symbol === undefined) {
 							continue;
 						}
-						this.queueSymbol(symbol.getName(), symbol);
+						this.queueSymbol(symbol.name, symbol);
 					}
 				}
 			}
@@ -292,8 +342,8 @@ export default class Visitor {
 		this.#currentSourceFile = undefined;
 	}
 
-	private visitModuleDeclaration(node: ts.ModuleDeclaration): boolean {
-		const identifier = node.name.getText();
+	private visitModuleDeclaration(node: ModuleDeclaration): boolean {
+		const identifier = node.name.text;
 		// We have a request or notification definition.
 		if (identifier.endsWith('Request')) {
 			const request = this.visitRequest(node);
@@ -313,12 +363,12 @@ export default class Visitor {
 		return true;
 	}
 
-	private visitRequest(node: ts.ModuleDeclaration): JsonRequest | undefined {
+	private visitRequest(node: ModuleDeclaration): JsonRequest | undefined {
 		const symbol = this.typeChecker.getSymbolAtLocation(node.name);
 		if (symbol === undefined) {
 			return;
 		}
-		const type = symbol.exports?.get('type' as ts.__String);
+		const type = symbol.getExports().get('type' as __String);
 		if (type === undefined) {
 			return;
 		}
@@ -359,12 +409,12 @@ export default class Visitor {
 		return result;
 	}
 
-	private visitNotification(node: ts.ModuleDeclaration): JsonNotification | undefined {
+	private visitNotification(node: ModuleDeclaration): JsonNotification | undefined {
 		const symbol = this.typeChecker.getSymbolAtLocation(node.name);
 		if (symbol === undefined) {
 			return;
 		}
-		const type = symbol.exports?.get('type' as ts.__String);
+		const type = symbol.getExports().get('type' as __String);
 		if (type === undefined) {
 			return;
 		}
@@ -399,9 +449,9 @@ export default class Visitor {
 		return result;
 	}
 
-	private visitTypeReference(node: ts.TypeAliasDeclaration): void {
+	private visitTypeReference(node: TypeAliasDeclaration): void {
 		const type = node.type;
-		if (!ts.isTypeReferenceNode(type)) {
+		if (!isTypeReferenceNode(type)) {
 			return;
 		}
 		const symbol = this.typeChecker.getSymbolAtLocation(type.typeName);
@@ -427,31 +477,34 @@ export default class Visitor {
 	}
 
 	private queueSymbol(name: string, symbol: ts.Symbol): void {
-		if (name !== symbol.getName()) {
-			throw new Error(`Different symbol names [${name}, ${symbol.getName()}]`);
+		if (name !== symbol.name) {
+			throw new Error(`Different symbol names [${name}, ${symbol.name}]`);
 		}
 		const existing = this.symbolQueue.get(name) ?? this.processedStructures.get(name);
 		if (existing === undefined) {
 			const aliased = Symbols.isAliasSymbol(symbol) ? this.typeChecker.getAliasedSymbol(symbol) : undefined;
-			if (aliased !== undefined && aliased.getName() !== symbol.getName()) {
-				throw new Error(`The symbol ${symbol.getName()} has a different name than the aliased symbol ${aliased.getName()}`);
+			if (aliased !== undefined && aliased.name !== symbol.name) {
+				throw new Error(`The symbol ${symbol.name} has a different name than the aliased symbol ${aliased.name}`);
 			}
 			this.symbolQueue.set(name, aliased ?? symbol);
 		} else {
-			const left = Symbols.isAliasSymbol(symbol) ? this.typeChecker.getAliasedSymbol(symbol) : symbol;
-			const right = Symbols.isAliasSymbol(existing) ? this.typeChecker.getAliasedSymbol(existing) : existing;
+			// !!! getAliasedSymbol is guaranteed to resolve when isAliasSymbol is true
+			const left = Symbols.isAliasSymbol(symbol) ? this.typeChecker.getAliasedSymbol(symbol)! : symbol;
+			// !!! getAliasedSymbol is guaranteed to resolve when isAliasSymbol is true
+			const right = Symbols.isAliasSymbol(existing) ? this.typeChecker.getAliasedSymbol(existing)! : existing;
 			if (this.symbols.createKey(left) !== this.symbols.createKey(right)) {
 				throw new Error(`The type ${name} has two different declarations`);
 			}
 		}
 	}
 
-	private endVisitModuleDeclaration(_node: ts.ModuleDeclaration): void {
+	private endVisitModuleDeclaration(_node: ModuleDeclaration): void {
 	}
 
-	private getSourceFilesToIndex(): ReadonlyArray<ts.SourceFile> {
-		const result: ts.SourceFile[] = [];
-		for (const sourceFile of this.program.getSourceFiles()) {
+	private getSourceFilesToIndex(): ReadonlyArray<SourceFile> {
+		const result: SourceFile[] = [];
+		for (const fileName of this.program.getSourceFileNames()) {
+			const sourceFile = this.program.getSourceFile(fileName)!;
 			if (this.program.isSourceFileFromExternalLibrary(sourceFile) || this.program.isSourceFileDefaultLibrary(sourceFile)) {
 				continue;
 			}
@@ -461,18 +514,18 @@ export default class Visitor {
 	}
 
 	private getMethodName(namespace: ts.Symbol, type: ts.Symbol): string | undefined {
-		const method = namespace.exports?.get('method' as ts.__String);
+		const method = namespace.getExports().get('method' as __String);
 		let text: string;
 		if (method !== undefined) {
 			const declaration = this.getFirstDeclaration(method);
 			if (declaration === undefined) {
 				return undefined;
 			}
-			if (!ts.isVariableDeclaration(declaration)) {
+			if (!isVariableDeclaration(declaration)) {
 				return undefined;
 			}
 			const initializer = declaration.initializer;
-			if (initializer === undefined || (!ts.isStringLiteral(initializer) && !ts.isNoSubstitutionTemplateLiteral(initializer))) {
+			if (initializer === undefined || (!isStringLiteral(initializer) && !isNoSubstitutionTemplateLiteral(initializer))) {
 				return undefined;
 			}
 			text = initializer.getText();
@@ -481,11 +534,11 @@ export default class Visitor {
 			if (declaration === undefined) {
 				return undefined;
 			}
-			if (!ts.isVariableDeclaration(declaration)) {
+			if (!isVariableDeclaration(declaration)) {
 				return undefined;
 			}
 			const initializer = declaration.initializer;
-			if (initializer === undefined || !ts.isNewExpression(initializer)) {
+			if (initializer === undefined || !isNewExpression(initializer)) {
 				return undefined;
 			}
 			const args = initializer.arguments;
@@ -498,23 +551,23 @@ export default class Visitor {
 	}
 
 	private getRegistrationMethodName(namespace: ts.Symbol): string | undefined {
-		const registrationMethod = namespace.exports?.get('registrationMethod' as ts.__String);
+		const registrationMethod = namespace.getExports().get('registrationMethod' as __String);
 		if (registrationMethod === undefined) {
 			return undefined;
 		}
 		const declaration = this.getFirstDeclaration(registrationMethod);
-		if (declaration === undefined || !ts.isVariableDeclaration(declaration) || declaration.initializer === undefined || !ts.isPropertyAccessExpression(declaration.initializer)) {
+		if (declaration === undefined || !isVariableDeclaration(declaration) || declaration.initializer === undefined || !isPropertyAccessExpression(declaration.initializer)) {
 			return undefined;
 		}
 		const initializerSymbol = this.typeChecker.getSymbolAtLocation(declaration.initializer.name);
 		if (initializerSymbol === undefined || initializerSymbol.valueDeclaration === undefined) {
 			return undefined;
 		}
-		const valueDeclaration = initializerSymbol.valueDeclaration;
-		if (!ts.isVariableDeclaration(valueDeclaration)) {
+		const valueDeclaration = initializerSymbol.valueDeclaration.resolve(this.project);
+		if (valueDeclaration === undefined || !isVariableDeclaration(valueDeclaration)) {
 			return undefined;
 		}
-		if (valueDeclaration.initializer === undefined || (!ts.isStringLiteral(valueDeclaration.initializer) && !ts.isNoSubstitutionTemplateLiteral(valueDeclaration.initializer))) {
+		if (valueDeclaration.initializer === undefined || (!isStringLiteral(valueDeclaration.initializer) && !isNoSubstitutionTemplateLiteral(valueDeclaration.initializer))) {
 			return undefined;
 		}
 
@@ -522,24 +575,24 @@ export default class Visitor {
 	}
 
 	private getMessageDirection(namespace: ts.Symbol): MessageDirection {
-		const errorMessage = `No message direction specified for request ${namespace.getName()}`;
-		const messageDirection = namespace.exports?.get('messageDirection' as ts.__String);
+		const errorMessage = `No message direction specified for request ${namespace.name}`;
+		const messageDirection = namespace.getExports().get('messageDirection' as __String);
 		if (messageDirection === undefined) {
 			throw new Error(errorMessage);
 		}
 		const declaration = this.getFirstDeclaration(messageDirection);
-		if (declaration === undefined || !ts.isVariableDeclaration(declaration) || declaration.initializer === undefined || !ts.isPropertyAccessExpression(declaration.initializer)) {
+		if (declaration === undefined || !isVariableDeclaration(declaration) || declaration.initializer === undefined || !isPropertyAccessExpression(declaration.initializer)) {
 			throw new Error(errorMessage);
 		}
 		const initializerSymbol = this.typeChecker.getSymbolAtLocation(declaration.initializer.name);
 		if (initializerSymbol === undefined || initializerSymbol.valueDeclaration === undefined) {
 			throw new Error(errorMessage);
 		}
-		const valueDeclaration = initializerSymbol.valueDeclaration;
-		if (!ts.isEnumMember(valueDeclaration)) {
+		const valueDeclaration = initializerSymbol.valueDeclaration.resolve(this.project);
+		if (valueDeclaration === undefined || !isEnumMember(valueDeclaration)) {
 			throw new Error(errorMessage);
 		}
-		if (valueDeclaration.initializer === undefined || !ts.isStringLiteral(valueDeclaration.initializer)) {
+		if (valueDeclaration.initializer === undefined || !isStringLiteral(valueDeclaration.initializer)) {
 			throw new Error(errorMessage);
 		}
 		const value = this.removeQuotes(valueDeclaration.initializer.getText());
@@ -554,11 +607,11 @@ export default class Visitor {
 		if (declaration === undefined) {
 			return undefined;
 		}
-		if (!ts.isVariableDeclaration(declaration)) {
+		if (!isVariableDeclaration(declaration)) {
 			return;
 		}
 		const initializer = declaration.initializer;
-		if (initializer === undefined || !ts.isNewExpression(initializer)) {
+		if (initializer === undefined || !isNewExpression(initializer)) {
 			return undefined;
 		}
 		if (initializer.typeArguments === undefined) {
@@ -585,7 +638,7 @@ export default class Visitor {
 	}
 
 	private getCapabilities(namespace: ts.Symbol): Capabilities | undefined {
-		const capabilities = namespace.exports?.get('capabilities' as ts.__String);
+		const capabilities = namespace.getExports().get('capabilities' as __String);
 		if (capabilities === undefined) {
 			return undefined;
 		}
@@ -593,18 +646,18 @@ export default class Visitor {
 		if (declaration === undefined) {
 			return undefined;
 		}
-		if (!ts.isVariableDeclaration(declaration)) {
+		if (!isVariableDeclaration(declaration)) {
 			return undefined;
 		}
 		const initializer = declaration.initializer;
-		if (initializer === undefined || !ts.isCallExpression(initializer)) {
+		if (initializer === undefined || !isCallExpression(initializer)) {
 			return undefined;
 		}
 		const result: Capabilities = {};
-		if (initializer.arguments[0] !== undefined && ts.isStringLiteral(initializer.arguments[0])) {
+		if (initializer.arguments[0] !== undefined && isStringLiteral(initializer.arguments[0])) {
 			result.clientCapability = this.removeQuotes(initializer.arguments[0].getText());
 		}
-		if (initializer.arguments[1] !== undefined && ts.isStringLiteral(initializer.arguments[1])) {
+		if (initializer.arguments[1] !== undefined && isStringLiteral(initializer.arguments[1])) {
 			result.serverCapability = this.removeQuotes(initializer.arguments[1].getText());
 		}
 		return result;
@@ -615,11 +668,11 @@ export default class Visitor {
 		if (declaration === undefined) {
 			return undefined;
 		}
-		if (!ts.isVariableDeclaration(declaration)) {
+		if (!isVariableDeclaration(declaration)) {
 			return;
 		}
 		const initializer = declaration.initializer;
-		if (initializer === undefined || !ts.isNewExpression(initializer)) {
+		if (initializer === undefined || !isNewExpression(initializer)) {
 			return undefined;
 		}
 		if (initializer.typeArguments === undefined) {
@@ -645,8 +698,8 @@ export default class Visitor {
 		return undefined;
 	}
 
-	private getTypeInfo(typeNode: ts.TypeNode | ts.Identifier, isLSPAny = false): TypeInfo | undefined {
-		if (ts.isIdentifier(typeNode)) {
+	private getTypeInfo(typeNode: TypeNode | Identifier, isLSPAny = false): TypeInfo | undefined {
+		if (isIdentifier(typeNode)) {
 			const typeName = typeNode.text;
 			if (LSPBaseTypes.has(typeName)) {
 				return { kind: 'base', name: typeName as BaseTypeInfoKind };
@@ -656,8 +709,8 @@ export default class Visitor {
 				return undefined;
 			}
 			return { kind: 'reference', name: typeName, symbol };
-		} else if (ts.isTypeReferenceNode(typeNode)) {
-			const typeName = ts.isIdentifier(typeNode.typeName) ? typeNode.typeName.text : typeNode.typeName.right.text;
+		} else if (isTypeReferenceNode(typeNode)) {
+			const typeName = isIdentifier(typeNode.typeName) ? typeNode.typeName.text : typeNode.typeName.right.text;
 			if (LSPBaseTypes.has(typeName)) {
 				return { kind: 'base', name: typeName as BaseTypeInfoKind };
 			}
@@ -666,13 +719,13 @@ export default class Visitor {
 				return undefined;
 			}
 			return { kind: 'reference', name: typeName, symbol };
-		} else if (ts.isArrayTypeNode(typeNode)) {
+		} else if (isArrayTypeNode(typeNode)) {
 			const elementType = this.getTypeInfo(typeNode.elementType);
 			if (elementType === undefined) {
 				return undefined;
 			}
 			return { kind: 'array', elementType: elementType };
-		} else if (ts.isUnionTypeNode(typeNode)) {
+		} else if (isUnionTypeNode(typeNode)) {
 			const items: TypeInfo[] = [];
 			for (const item of typeNode.types) {
 				const typeInfo = this.getTypeInfo(item);
@@ -687,7 +740,7 @@ export default class Visitor {
 				items.push(typeInfo);
 			}
 			return { kind: 'union', items };
-		} else if (ts.isIntersectionTypeNode(typeNode)) {
+		} else if (isIntersectionTypeNode(typeNode)) {
 			const items: TypeInfo[] = [];
 			for (const item of typeNode.types) {
 				const typeInfo = this.getTypeInfo(item);
@@ -697,12 +750,12 @@ export default class Visitor {
 				items.push(typeInfo);
 			}
 			return { kind: 'intersection', items };
-		} else if (ts.isTypeLiteralNode(typeNode)) {
+		} else if (isTypeLiteralNode(typeNode)) {
 			const type = this.typeChecker.getTypeAtLocation(typeNode);
-			const info = this.typeChecker.getIndexInfoOfType(type, ts.IndexKind.String);
+			const info = type !== undefined ? this.typeChecker.getIndexInfosOfType(type).find(info => (info.keyType.flags & ts.TypeFlags.String) !== 0) : undefined;
 			if (info !== undefined) {
-				const declaration = info.declaration;
-				if (declaration === undefined || declaration.parameters.length < 1) {
+				const declaration = info.declaration?.resolve(this.project);
+				if (declaration === undefined || !isIndexSignatureDeclaration(declaration) || declaration.parameters.length < 1) {
 					return undefined;
 				}
 				const keyTypeNode = declaration.parameters[0].type;
@@ -721,33 +774,30 @@ export default class Visitor {
 			} else {
 				// We can't directly ask for the symbol since the literal has no name.
 				const type = this.typeChecker.getTypeAtLocation(typeNode);
-				const symbol = type.symbol;
+				const symbol = type?.getSymbol();
 				if (symbol === undefined) {
 					return undefined;
 				}
-				if (symbol.members === undefined) {
-					return { kind: 'literal', items: new Map() };
-				}
 				const items = new Map<string, { type: TypeInfo; optional: boolean }>();
-				symbol.members.forEach((member) => {
+				symbol.getMembers().forEach((member) => {
 					if (!Symbols.isProperty(member)) {
 						return;
 					}
-					const declaration = this.getDeclaration(member, ts.SyntaxKind.PropertySignature);
-					if (declaration === undefined || !ts.isPropertySignature(declaration) || declaration.type === undefined) {
-						throw new Error(`Can't parse property ${member.getName()} of structure ${symbol.getName()}`);
+					const declaration = this.getDeclaration(member, SyntaxKind.PropertySignature);
+					if (declaration === undefined || !isPropertySignatureDeclaration(declaration) || declaration.type === undefined) {
+						throw new Error(`Can't parse property ${member.name} of structure ${symbol.name}`);
 					}
 					const propertyType = this.getTypeInfo(declaration.type);
 					if (propertyType === undefined) {
-						throw new Error(`Can't parse property ${member.getName()} of structure ${symbol.getName()}`);
+						throw new Error(`Can't parse property ${member.name} of structure ${symbol.name}`);
 					}
 					const literalInfo: LiteralInfo = { type: propertyType, optional: Symbols.isOptional(member) };
 					this.fillDocProperties(declaration, literalInfo);
-					items.set(member.getName(), literalInfo);
+					items.set(member.name, literalInfo);
 				});
 				return { kind: 'literal', items };
 			}
-		} else if (ts.isTupleTypeNode(typeNode)) {
+		} else if (isTupleTypeNode(typeNode)) {
 			const items: TypeInfo[] = [];
 			for (const item of typeNode.elements) {
 				const typeInfo = this.getTypeInfo(item);
@@ -757,7 +807,7 @@ export default class Visitor {
 				items.push(typeInfo);
 			}
 			return { kind: 'tuple', items };
-		} else if (ts.isTypeQueryNode(typeNode) && ts.isQualifiedName(typeNode.exprName)) {
+		} else if (isTypeQueryNode(typeNode) && isQualifiedName(typeNode.exprName)) {
 			// Currently we only us the typeof operator to get to the type of a enum
 			// value expressed by an or type (e.g. kind: typeof DocumentDiagnosticReportKind.full)
 			// So we assume a qualifed name and turn it into a string literal type
@@ -765,49 +815,49 @@ export default class Visitor {
 			if (typeNodeSymbol === undefined) {
 				throw new Error(`Can't resolve symbol for right hand side of enum declaration`);
 			}
-			const declaration = this.getDeclaration(typeNodeSymbol, ts.SyntaxKind.VariableDeclaration);
-			if (declaration === undefined || !ts.isVariableDeclaration(declaration) || declaration.initializer === undefined) {
+			const declaration = this.getDeclaration(typeNodeSymbol, SyntaxKind.VariableDeclaration);
+			if (declaration === undefined || !isVariableDeclaration(declaration) || declaration.initializer === undefined) {
 				throw new Error(`Can't resolve variable declaration for right hand side of enum declaration`);
 			}
-			if (ts.isNumericLiteral(declaration.initializer)) {
+			if (isNumericLiteral(declaration.initializer)) {
 				return { kind: 'integerLiteral', value: Number.parseInt(declaration.initializer.getText()) };
-			} else if (ts.isStringLiteral(declaration.initializer)) {
+			} else if (isStringLiteral(declaration.initializer)) {
 				return { kind: 'stringLiteral', value: this.removeQuotes(declaration.initializer.getText()) };
 			}
 			return { kind: 'stringLiteral', value: typeNode.exprName.right.getText() };
-		} else if (ts.isParenthesizedTypeNode(typeNode)) {
+		} else if (isParenthesizedTypeNode(typeNode)) {
 			return this.getTypeInfo(typeNode.type);
-		} else if (ts.isLiteralTypeNode(typeNode)) {
+		} else if (isLiteralTypeNode(typeNode)) {
 			return this.getBaseTypeInfo(typeNode.literal);
 		}
 		return this.getBaseTypeInfo(typeNode);
 	}
 
-	private getBaseTypeInfo(node: ts.Node): TypeInfo | undefined {
+	private getBaseTypeInfo(node: Node): TypeInfo | undefined {
 		switch (node.kind){
-			case ts.SyntaxKind.NullKeyword:
+			case SyntaxKind.NullKeyword:
 				return { kind: 'base', name: 'null' };
-			case ts.SyntaxKind.UnknownKeyword:
+			case SyntaxKind.UnknownKeyword:
 				return { kind: 'base', name: 'unknown' };
-			case ts.SyntaxKind.NeverKeyword:
+			case SyntaxKind.NeverKeyword:
 				return { kind: 'base', name: 'never' };
-			case ts.SyntaxKind.VoidKeyword:
+			case SyntaxKind.VoidKeyword:
 				return { kind: 'base', name: 'void' };
-			case ts.SyntaxKind.UndefinedKeyword:
+			case SyntaxKind.UndefinedKeyword:
 				return { kind: 'base', name: 'undefined' };
-			case ts.SyntaxKind.AnyKeyword:
+			case SyntaxKind.AnyKeyword:
 				return { kind: 'base', name: 'any' };
-			case ts.SyntaxKind.StringKeyword:
+			case SyntaxKind.StringKeyword:
 				return  { kind: 'base', name: 'string' };
-			case ts.SyntaxKind.NumberKeyword:
+			case SyntaxKind.NumberKeyword:
 				return { kind: 'base', name: 'integer' };
-			case ts.SyntaxKind.BooleanKeyword:
+			case SyntaxKind.BooleanKeyword:
 				return { kind: 'base', name: 'boolean' };
-			case ts.SyntaxKind.StringLiteral:
+			case SyntaxKind.StringLiteral:
 				return { kind: 'stringLiteral', value: this.removeQuotes(node.getText()) };
-			case ts.SyntaxKind.NumericLiteral:
+			case SyntaxKind.NumericLiteral:
 				return { kind: 'integerLiteral', value: Number.parseInt(node.getText()) };
-			case ts.SyntaxKind.ObjectKeyword:
+			case SyntaxKind.ObjectKeyword:
 				return { kind: 'base', name: 'object' };
 		}
 		return undefined;
@@ -842,13 +892,13 @@ export default class Visitor {
 		}
 		if (Symbols.isInterface(symbol)) {
 			const result: Structure = { name: name, properties: [] };
-			const declaration = this.getDeclaration(symbol, ts.SyntaxKind.InterfaceDeclaration);
-			if (declaration !== undefined && ts.isInterfaceDeclaration(declaration) && declaration.heritageClauses !== undefined) {
+			const declaration = this.getDeclaration(symbol, SyntaxKind.InterfaceDeclaration);
+			if (declaration !== undefined && isInterfaceDeclaration(declaration) && declaration.heritageClauses !== undefined) {
 				const mixins: JsonType[] = [];
 				const extend: JsonType[] = [];
 				for (const clause of declaration.heritageClauses) {
 					for (const type of clause.types) {
-						if (ts.isIdentifier(type.expression)) {
+						if (isIdentifier(type.expression)) {
 							const typeInfo = this.getTypeInfo(type.expression);
 							if (typeInfo === undefined || typeInfo.kind !== 'reference') {
 								throw new Error(`Can't create type info for extends clause ${type.expression.getText()}`);
@@ -875,17 +925,18 @@ export default class Visitor {
 			this.fillProperties(result, symbol);
 			return result;
 		} else if (Symbols.isTypeAlias(symbol)) {
-			const declaration = this.getDeclaration(symbol, ts.SyntaxKind.TypeAliasDeclaration);
-			if (declaration === undefined ||!ts.isTypeAliasDeclaration(declaration)) {
-				throw new Error (`No declaration found for type alias ${symbol.getName() }`);
+			const declaration = this.getDeclaration(symbol, SyntaxKind.TypeAliasDeclaration);
+			if (declaration === undefined ||!isTypeAliasDeclaration(declaration)) {
+				throw new Error (`No declaration found for type alias ${symbol.name }`);
 			}
-			if (ts.isTypeLiteralNode(declaration.type)) {
+			if (isTypeLiteralNode(declaration.type)) {
 				// We have a single type literal node. So treat it as a structure
 				const result: Structure = { name: name, properties: [] };
-				this.fillProperties(result, this.typeChecker.getTypeAtLocation(declaration.type).symbol);
+				// !!! type and symbol are assumed present for a type literal node
+				this.fillProperties(result, this.typeChecker.getTypeAtLocation(declaration.type)!.getSymbol()!);
 				this.fillDocProperties(declaration, result);
 				return result;
-			} else if (ts.isIntersectionTypeNode(declaration.type)) {
+			} else if (isIntersectionTypeNode(declaration.type)) {
 				const split = this.splitIntersectionType(declaration.type);
 				if (split.rest.length === 0) {
 					const result: Structure = { name: name, properties: [] };
@@ -910,7 +961,8 @@ export default class Visitor {
 						result.mixins = mixins;
 					}
 					if (split.literal !== undefined) {
-						this.fillProperties(result, this.typeChecker.getTypeAtLocation(split.literal).symbol);
+						// !!! type and symbol are assumed present for a type literal node
+						this.fillProperties(result, this.typeChecker.getTypeAtLocation(split.literal)!.getSymbol()!);
 					}
 					this.fillDocProperties(declaration, result);
 					return result;
@@ -918,30 +970,30 @@ export default class Visitor {
 			}
 			const target = this.getTypeInfo(declaration.type, name === 'LSPAny');
 			if (target === undefined) {
-				throw new Error(`Can't resolve target type for type alias ${symbol.getName()}`);
+				throw new Error(`Can't resolve target type for type alias ${symbol.name}`);
 			}
-			const namespace = this.getDeclaration(symbol, ts.SyntaxKind.ModuleDeclaration);
+			const namespace = this.getDeclaration(symbol, SyntaxKind.ModuleDeclaration);
 			if (namespace !== undefined && symbol.declarations !== undefined && symbol.declarations.length === 2) {
 				const fixedSet = (target.kind === 'union' || target.kind === 'stringLiteral' || target.kind === 'integerLiteral');
 				const openSet = (target.kind === 'base' && (target.name === 'string' || target.name === 'integer' || target.name === 'uinteger'));
 				if (openSet || fixedSet) {
 					// Check if we have a enum declaration.
-					const body = namespace.getChildren().find(node => node.kind === ts.SyntaxKind.ModuleBlock);
-					if (body !== undefined && ts.isModuleBlock(body)) {
+					const body = isModuleDeclaration(namespace) ? namespace.body : undefined;
+					if (body !== undefined && isModuleBlock(body)) {
 						const enumValues = this.getEnumValues(target);
-						const variableStatements = body.statements.filter((statement => ts.isVariableStatement(statement)));
+						const variableStatements = body.statements.filter((statement => isVariableStatement(statement)));
 						if ((fixedSet && enumValues !== undefined && enumValues.length > 0 && variableStatements.length === enumValues.length) || (openSet && variableStatements.length > 0)) {
 							// Same length and all variable statement.
 							const enumValuesSet: Set<number | string> | undefined = enumValues ? new Set<any>(enumValues as any) : undefined;
 							let isEnum = true;
 							const enumerations: EnumerationEntry[] = [];
 							for (const variable of variableStatements) {
-								if (!ts.isVariableStatement(variable) || variable.declarationList.declarations.length !== 1) {
+								if (!isVariableStatement(variable) || variable.declarationList.declarations.length !== 1) {
 									isEnum = false;
 									break;
 								}
 								const declaration = variable.declarationList.declarations[0];
-								if (!ts.isVariableDeclaration(declaration)) {
+								if (!isVariableDeclaration(declaration)) {
 									isEnum = false;
 									break;
 								}
@@ -1010,26 +1062,26 @@ export default class Visitor {
 			const exports = this.typeChecker.getExportsOfModule(symbol);
 			let enumBaseType: 'string' | 'integer' | 'uinteger' | undefined = undefined;
 			for (const item of exports) {
-				const declaration = this.getDeclaration(item, ts.SyntaxKind.EnumMember);
-				if (declaration === undefined || !ts.isEnumMember(declaration) || declaration.initializer === undefined) {
+				const declaration = this.getDeclaration(item, SyntaxKind.EnumMember);
+				if (declaration === undefined || !isEnumMember(declaration) || declaration.initializer === undefined) {
 					continue;
 				}
 				let value: string | number | undefined;
-				if (ts.isNumericLiteral(declaration.initializer)) {
+				if (isNumericLiteral(declaration.initializer)) {
 					value = Number.parseInt(declaration.initializer.getText());
 					if (value >= 0 && enumBaseType === undefined) {
 						enumBaseType = 'uinteger';
 					} else {
 						enumBaseType = 'integer';
 					}
-				} else if (ts.isStringLiteral(declaration.initializer)) {
+				} else if (isStringLiteral(declaration.initializer)) {
 					value = this.removeQuotes(declaration.initializer.getText());
 					enumBaseType = 'string';
 				}
 				if (value === undefined) {
 					continue;
 				}
-				const entry: EnumerationEntry = { name: item.getName(), value: value };
+				const entry: EnumerationEntry = { name: item.name, value: value };
 				if (Visitor.PropertyFilters.has(name) && Visitor.PropertyFilters.get(name)?.has(entry.name)) {
 					continue;
 				}
@@ -1043,7 +1095,7 @@ export default class Visitor {
 			if (name === 'SemanticTokenTypes' || name === 'SemanticTokenModifiers') {
 				result.supportsCustomValues = true;
 			}
-			const declaration = this.getDeclaration(symbol, ts.SyntaxKind.EnumDeclaration);
+			const declaration = this.getDeclaration(symbol, SyntaxKind.EnumDeclaration);
 			if (declaration !== undefined) {
 				this.fillDocProperties(declaration, result);
 			}
@@ -1061,26 +1113,23 @@ export default class Visitor {
 		// Using the type here to navigate the properties will result in folding
 		// all properties since the type contains all inherited properties. So we go
 		// over the symbol to make things work.
-		if (symbol.members === undefined) {
-			return;
-		}
-		symbol.members.forEach((member) => {
+		symbol.getMembers().forEach((member) => {
 			if (!Symbols.isProperty(member)) {
 				return;
 			}
-			const declaration = this.getDeclaration(member, ts.SyntaxKind.PropertySignature);
-			if (declaration === undefined || !ts.isPropertySignature(declaration) || declaration.type === undefined) {
-				throw new Error(`Can't parse property ${member.getName()} of structure ${symbol.getName()}`);
+			const declaration = this.getDeclaration(member, SyntaxKind.PropertySignature);
+			if (declaration === undefined || !isPropertySignatureDeclaration(declaration) || declaration.type === undefined) {
+				throw new Error(`Can't parse property ${member.name} of structure ${symbol.name}`);
 			}
 			const typeInfo = this.getTypeInfo(declaration.type);
 			if (typeInfo === undefined) {
-				throw new Error(`Can't parse property ${member.getName()} of structure ${symbol.getName()}`);
+				throw new Error(`Can't parse property ${member.name} of structure ${symbol.name}`);
 			}
 
-			const isExperimentalProperty = (result.name === 'ServerCapabilities' && member.getName() === 'experimental' && typeInfo.kind === 'reference' && typeInfo.name === 'T');
+			const isExperimentalProperty = (result.name === 'ServerCapabilities' && member.name === 'experimental' && typeInfo.kind === 'reference' && typeInfo.name === 'T');
 			const property: Property = isExperimentalProperty
-				? { name: member.getName(), type: TypeInfo.asJsonType({ kind: 'reference', name: 'LSPAny', symbol: typeInfo.symbol }) }
-				: { name: member.getName(), type: TypeInfo.asJsonType(typeInfo) };
+				? { name: member.name, type: TypeInfo.asJsonType({ kind: 'reference', name: 'LSPAny', symbol: typeInfo.symbol }) }
+				: { name: member.name, type: TypeInfo.asJsonType(typeInfo) };
 			if (Symbols.isOptional(member)) {
 				property.optional = true;
 			}
@@ -1092,18 +1141,18 @@ export default class Visitor {
 		});
 	}
 
-	private splitIntersectionType(node: ts.IntersectionTypeNode): { literal: ts.TypeLiteralNode | undefined; references: ts.TypeReferenceNode[]; rest: ts.TypeNode[] } {
-		let literal: ts.TypeLiteralNode | undefined;
-		const rest: ts.TypeNode[] = [];
-		const references: ts.TypeReferenceNode[] = [];
+	private splitIntersectionType(node: IntersectionTypeNode): { literal: TypeLiteralNode | undefined; references: TypeReferenceNode[]; rest: TypeNode[] } {
+		let literal: TypeLiteralNode | undefined;
+		const rest: TypeNode[] = [];
+		const references: TypeReferenceNode[] = [];
 		for (const element of node.types) {
-			if (ts.isTypeLiteralNode(element)) {
+			if (isTypeLiteralNode(element)) {
 				if (literal === undefined) {
 					literal = element;
 				} else {
 					rest.push(element);
 				}
-			} else if (ts.isTypeReferenceNode(element)) {
+			} else if (isTypeReferenceNode(element)) {
 				references.push(element);
 			} else {
 				rest.push(element);
@@ -1112,19 +1161,19 @@ export default class Visitor {
 		return { literal, references, rest };
 	}
 
-	private getFirstDeclaration(symbol: ts.Symbol): ts.Node | undefined {
-		const declarations = symbol.getDeclarations();
-		return declarations !== undefined && declarations.length > 0 ? declarations[0] : undefined;
+	private getFirstDeclaration(symbol: ts.Symbol): Node | undefined {
+		const declarations = symbol.declarations;
+		return declarations !== undefined && declarations.length > 0 ? declarations[0].resolve(this.project) : undefined;
 	}
 
-	private getDeclaration(symbol: ts.Symbol, kind: ts.SyntaxKind): ts.Node | undefined {
-		const declarations = symbol.getDeclarations();
+	private getDeclaration(symbol: ts.Symbol, kind: SyntaxKind): Node | undefined {
+		const declarations = symbol.declarations;
 		if (declarations === undefined) {
 			return undefined;
 		}
 		for (const declaration of declarations) {
 			if (declaration.kind === kind) {
-				return declaration;
+				return declaration.resolve(this.project);
 			}
 		}
 		return undefined;
@@ -1161,19 +1210,19 @@ export default class Visitor {
 		return (result as string[] | number[]);
 	}
 
-	private getEnumValue(declaration: ts.VariableDeclaration): number | string | undefined {
-		let enumValueNode: ts.Node | undefined;
+	private getEnumValue(declaration: VariableDeclaration): number | string | undefined {
+		let enumValueNode: Node | undefined;
 		if (declaration.initializer !== undefined) {
 			enumValueNode = declaration.initializer;
-		} else if (declaration.type !== undefined && ts.isLiteralTypeNode(declaration.type)) {
+		} else if (declaration.type !== undefined && isLiteralTypeNode(declaration.type)) {
 			enumValueNode = declaration.type.literal;
 		}
 		if (enumValueNode === undefined) {
 			return undefined;
 		}
-		if (ts.isNumericLiteral(enumValueNode) || (ts.isPrefixUnaryExpression(enumValueNode) && ts.isNumericLiteral(enumValueNode.operand))) {
+		if (isNumericLiteral(enumValueNode) || (isPrefixUnaryExpression(enumValueNode) && isNumericLiteral(enumValueNode.operand))) {
 			return Number.parseInt(enumValueNode.getText());
-		} else if (ts.isStringLiteral(enumValueNode)) {
+		} else if (isStringLiteral(enumValueNode)) {
 			return this.removeQuotes(enumValueNode.getText());
 		}
 		return undefined;
@@ -1203,12 +1252,12 @@ export default class Visitor {
 		return text.substring(1, text.length - 1);
 	}
 
-	private fillDocProperties(node: ts.Node, value: JsonRequest | JsonNotification | Property | Structure | StructureLiteral | EnumerationEntry | Enumeration | TypeAlias | LiteralInfo): void {
+	private fillDocProperties(node: Node, value: JsonRequest | JsonNotification | Property | Structure | StructureLiteral | EnumerationEntry | Enumeration | TypeAlias | LiteralInfo): void {
 		const filePath = node.getSourceFile().fileName;
 		const fileName = path.basename(filePath);
-		const tags = ts.getJSDocTags(node);
+		const tags = this.getJSDocTags(node);
 		const { since, sinceTags, deprecated } = this.getTags(tags);
-		const proposed = (fileName.startsWith('proposed.') || tags.some((tag) => { return ts.isJSDocUnknownTag(tag) && tag.tagName.text === 'proposed';})) ? true : undefined;
+		const proposed = (fileName.startsWith('proposed.') || tags.some((tag) => { return isJSDocUnknownTag(tag) && tag.tagName.text === 'proposed';})) ? true : undefined;
 		value.documentation = this.getDocumentation(node);
 		value.since = since;
 		value.sinceTags = sinceTags;
@@ -1216,9 +1265,24 @@ export default class Visitor {
 		value.proposed = proposed;
 	}
 
-	private getDocumentation(node: ts.Node): string | undefined {
+	private getJSDocTags(node: Node): ReadonlyArray<JSDocTag> {
+		const result: JSDocTag[] = [];
+		const jsDocs = node.jsDoc;
+		if (jsDocs !== undefined) {
+			for (const jsDoc of jsDocs) {
+				if (isJSDoc(jsDoc) && jsDoc.tags !== undefined) {
+					for (const tag of jsDoc.tags) {
+						result.push(tag);
+					}
+				}
+			}
+		}
+		return result;
+	}
+
+	private getDocumentation(node: Node): string | undefined {
 		const fullText = node.getFullText();
-		const ranges = ts.getLeadingCommentRanges(fullText, 0);
+		const ranges = getLeadingCommentRanges(fullText, 0);
 		if (ranges !== undefined && ranges.length > 0) {
 			const start = ranges[ranges.length - 1].pos;
 			const end = ranges[ranges.length -1 ].end;
@@ -1252,25 +1316,40 @@ export default class Visitor {
 		return undefined;
 	}
 
-	private getTags(tags: ReadonlyArray<ts.JSDocTag>): { since?: string; sinceTags?: string[]; deprecated?: string } {
+	private getTags(tags: ReadonlyArray<JSDocTag>): { since?: string; sinceTags?: string[]; deprecated?: string } {
 		const result: { since?: string; sinceTags?: string[];  deprecated?: string } = {};
 		for (const tag of tags) {
-			if (tag.tagName.text === 'since' && typeof tag.comment === 'string') {
-				const value = tag.comment.replace(/\r?\n/g, '\n');
+			const comment = this.getJSDocCommentText(tag.comment);
+			if (tag.tagName.text === 'since' && comment !== undefined) {
+				const value = comment.replace(/\r?\n/g, '\n');
 				result.since = value;
 				if (result.sinceTags === undefined) {
 					result.sinceTags = [value];
 				} else {
 					result.sinceTags.push(value);
 				}
-			} else if (tag.tagName.text === 'deprecated' && typeof tag.comment === 'string') {
-				result.deprecated = tag.comment.replace(/\r?\n/g, '\n');
+			} else if (tag.tagName.text === 'deprecated' && comment !== undefined) {
+				result.deprecated = comment.replace(/\r?\n/g, '\n');
 			}
 		}
 		if (Array.isArray(result.sinceTags) && result.sinceTags.length === 1) {
 			delete result.sinceTags;
 		}
 		return result;
+	}
+
+	private getJSDocCommentText(comment: NodeArray<JSDocComment> | undefined): string | undefined {
+		if (comment === undefined) {
+			return undefined;
+		}
+		const parts: string[] = [];
+		for (const part of comment) {
+			if (!isJSDocText(part)) {
+				return undefined;
+			}
+			parts.push(part.text);
+		}
+		return parts.join('');
 	}
 }
 

--- a/tools/src/visitor.ts
+++ b/tools/src/visitor.ts
@@ -559,7 +559,7 @@ export default class Visitor {
 		if (initializerSymbol === undefined || initializerSymbol.valueDeclaration === undefined) {
 			return undefined;
 		}
-		const valueDeclaration = initializerSymbol.valueDeclaration.resolve(this.project);
+		const valueDeclaration = initializerSymbol.valueDeclaration.resolve();
 		if (valueDeclaration === undefined || !isVariableDeclaration(valueDeclaration)) {
 			return undefined;
 		}
@@ -584,7 +584,7 @@ export default class Visitor {
 		if (initializerSymbol === undefined || initializerSymbol.valueDeclaration === undefined) {
 			throw new Error(errorMessage);
 		}
-		const valueDeclaration = initializerSymbol.valueDeclaration.resolve(this.project);
+		const valueDeclaration = initializerSymbol.valueDeclaration.resolve();
 		if (valueDeclaration === undefined || !isEnumMember(valueDeclaration)) {
 			throw new Error(errorMessage);
 		}
@@ -750,7 +750,7 @@ export default class Visitor {
 			const type = this.typeChecker.getTypeAtLocation(typeNode);
 			const info = type !== undefined ? this.typeChecker.getIndexInfosOfType(type).find(info => (info.keyType.flags & ts.TypeFlags.String) !== 0) : undefined;
 			if (info !== undefined) {
-				const declaration = info.declaration?.resolve(this.project);
+				const declaration = info.declaration?.resolve();
 				if (declaration === undefined || !isIndexSignatureDeclaration(declaration) || declaration.parameters.length < 1) {
 					return undefined;
 				}
@@ -1157,7 +1157,7 @@ export default class Visitor {
 
 	private getFirstDeclaration(symbol: ts.Symbol): Node | undefined {
 		const declarations = symbol.declarations;
-		return declarations !== undefined && declarations.length > 0 ? declarations[0].resolve(this.project) : undefined;
+		return declarations !== undefined && declarations.length > 0 ? declarations[0].resolve() : undefined;
 	}
 
 	private getDeclaration(symbol: ts.Symbol, kind: SyntaxKind): Node | undefined {
@@ -1167,7 +1167,7 @@ export default class Visitor {
 		}
 		for (const declaration of declarations) {
 			if (declaration.kind === kind) {
-				return declaration.resolve(this.project);
+				return declaration.resolve();
 			}
 		}
 		return undefined;

--- a/tools/tsconfig.json
+++ b/tools/tsconfig.json
@@ -1,7 +1,6 @@
 {
     "compilerOptions": {
-        "module": "node16",
-        "moduleResolution": "node16",
+        "module": "node20",
         "rootDir": "./src",
         "types": [
             "node"
@@ -22,7 +21,7 @@
         ],
         "outDir": "./lib",
         "tsBuildInfoFile": "lib/compile.tsbuildInfo",
-        "incremental": true
+        "incremental": true,
     },
     "include": [
         "."

--- a/tools/tsconfig.watch.json
+++ b/tools/tsconfig.watch.json
@@ -1,7 +1,6 @@
 {
     "compilerOptions": {
-        "module": "node16",
-        "moduleResolution": "node16",
+        "module": "node20",
         "rootDir": "./src",
         "types": [
             "node"


### PR DESCRIPTION
This was done as an exercise/example—we probably don't want to merge it until the TS 7 API is actually stable.

Produces 100% identical output in almost exactly the same amount of time as the TS 6 API, with less setup code.