### PR TITLE
Correctly type URIs in file operations and clarify comments

### DIFF
--- a/protocol/metaModel.json
+++ b/protocol/metaModel.json
@@ -7142,7 +7142,7 @@
 						"kind": "base",
 						"name": "DocumentUri"
 					},
-					"documentation": "A file:// URI for the location of the file/folder being created."
+					"documentation": "A URI for the location of the file/folder being created."
 				}
 			],
 			"documentation": "Represents information on a file/folder create.\n\n@since 3.16.0",
@@ -7376,7 +7376,7 @@
 						"kind": "base",
 						"name": "DocumentUri"
 					},
-					"documentation": "A file:// URI for the original location of the file/folder being renamed."
+					"documentation": "A URI for the original location of the file/folder being renamed."
 				},
 				{
 					"name": "newUri",
@@ -7384,7 +7384,7 @@
 						"kind": "base",
 						"name": "DocumentUri"
 					},
-					"documentation": "A file:// URI for the new location of the file/folder being renamed."
+					"documentation": "A URI for the new location of the file/folder being renamed."
 				}
 			],
 			"documentation": "Represents information on a file/folder rename.\n\n@since 3.16.0",
@@ -7399,7 +7399,7 @@
 						"kind": "base",
 						"name": "DocumentUri"
 					},
-					"documentation": "A file:// URI for the location of the file/folder being deleted."
+					"documentation": "A URI for the location of the file/folder being deleted."
 				}
 			],
 			"documentation": "Represents information on a file/folder delete.\n\n@since 3.16.0",

--- a/protocol/metaModel.json
+++ b/protocol/metaModel.json
@@ -5923,8 +5923,8 @@
 						}
 					},
 					"optional": true,
-					"documentation": "Tags for this code action.\n\n@since 3.18.0 - proposed",
-					"since": "3.18.0 - proposed"
+					"documentation": "Tags for this code action.\n\n@since 3.18.0",
+					"since": "3.18.0"
 				}
 			],
 			"documentation": "A code action represents a change that can be performed in code, e.g. to fix a problem or\nto refactor code.\n\nA CodeAction must set either `edit` and/or a `command`. If both are supplied, the `edit` is applied first, then the `command` is executed."
@@ -7140,7 +7140,7 @@
 					"name": "uri",
 					"type": {
 						"kind": "base",
-						"name": "string"
+						"name": "DocumentUri"
 					},
 					"documentation": "A file:// URI for the location of the file/folder being created."
 				}
@@ -7374,7 +7374,7 @@
 					"name": "oldUri",
 					"type": {
 						"kind": "base",
-						"name": "string"
+						"name": "DocumentUri"
 					},
 					"documentation": "A file:// URI for the original location of the file/folder being renamed."
 				},
@@ -7382,7 +7382,7 @@
 					"name": "newUri",
 					"type": {
 						"kind": "base",
-						"name": "string"
+						"name": "DocumentUri"
 					},
 					"documentation": "A file:// URI for the new location of the file/folder being renamed."
 				}
@@ -7397,7 +7397,7 @@
 					"name": "uri",
 					"type": {
 						"kind": "base",
-						"name": "string"
+						"name": "DocumentUri"
 					},
 					"documentation": "A file:// URI for the location of the file/folder being deleted."
 				}
@@ -15001,8 +15001,8 @@
 					"documentation": "Marks the code action as LLM-generated."
 				}
 			],
-			"documentation": "Code action tags are extra annotations that tweak the behavior of a code action.\n\n@since 3.18.0 - proposed",
-			"since": "3.18.0 - proposed"
+			"documentation": "Code action tags are extra annotations that tweak the behavior of a code action.\n\n@since 3.18.0",
+			"since": "3.18.0"
 		},
 		{
 			"name": "TraceValue",

--- a/protocol/src/common/protocol.fileOperations.ts
+++ b/protocol/src/common/protocol.fileOperations.ts
@@ -211,7 +211,7 @@ export interface CreateFilesParams {
 export interface FileCreate {
 
 	/**
-	 * A file:// URI for the location of the file/folder being created.
+	 * A URI for the location of the file/folder being created.
 	 */
 	uri: DocumentUri;
 }
@@ -239,12 +239,12 @@ export interface RenameFilesParams {
 export interface FileRename {
 
 	/**
-	 * A file:// URI for the original location of the file/folder being renamed.
+	 * A URI for the original location of the file/folder being renamed.
 	 */
 	oldUri: DocumentUri;
 
 	/**
-	 * A file:// URI for the new location of the file/folder being renamed.
+	 * A URI for the new location of the file/folder being renamed.
 	 */
 	newUri: DocumentUri;
 }
@@ -271,7 +271,7 @@ export interface DeleteFilesParams {
 export interface FileDelete {
 
 	/**
-	 * A file:// URI for the location of the file/folder being deleted.
+	 * A URI for the location of the file/folder being deleted.
 	 */
 	uri: DocumentUri;
 }

--- a/protocol/src/common/protocol.fileOperations.ts
+++ b/protocol/src/common/protocol.fileOperations.ts
@@ -4,7 +4,7 @@
  * ------------------------------------------------------------------------------------------ */
 
 import { NotificationHandler, RequestHandler } from 'vscode-jsonrpc';
-import { WorkspaceEdit } from 'vscode-languageserver-types';
+import { WorkspaceEdit, type DocumentUri } from 'vscode-languageserver-types';
 import { CM, MessageDirection, ProtocolNotificationType, ProtocolRequestType } from './messages';
 
 /**
@@ -213,7 +213,7 @@ export interface FileCreate {
 	/**
 	 * A file:// URI for the location of the file/folder being created.
 	 */
-	uri: string;
+	uri: DocumentUri;
 }
 
 /**
@@ -241,12 +241,12 @@ export interface FileRename {
 	/**
 	 * A file:// URI for the original location of the file/folder being renamed.
 	 */
-	oldUri: string;
+	oldUri: DocumentUri;
 
 	/**
 	 * A file:// URI for the new location of the file/folder being renamed.
 	 */
-	newUri: string;
+	newUri: DocumentUri;
 }
 
 /**
@@ -273,7 +273,7 @@ export interface FileDelete {
 	/**
 	 * A file:// URI for the location of the file/folder being deleted.
 	 */
-	uri: string;
+	uri: DocumentUri;
 }
 
 


### PR DESCRIPTION
Update file creation, renaming, and deletion operations to use the `DocumentUri` type for URIs. Clarify comments for better understanding.