### PR TITLE
Add support for workspace read requests

### DIFF
--- a/client-node-tests/src/converter.test.ts
+++ b/client-node-tests/src/converter.test.ts
@@ -1766,4 +1766,32 @@ suite('Code Converter', () => {
 		rangeEqual(result.selectedCompletionInfo.range, item.selectedCompletionInfo!.range);
 		strictEqual(result.selectedCompletionInfo.text, item.selectedCompletionInfo!.text);
 	});
+
+	test('DirectoryEntry', () => {
+		const entries: [string, vscode.FileType][] = [
+			['file.txt', vscode.FileType.File],
+			['dir', vscode.FileType.Directory],
+			['link', vscode.FileType.SymbolicLink | vscode.FileType.File],
+			['dirLink', vscode.FileType.SymbolicLink | vscode.FileType.Directory],
+			['danglingLink', vscode.FileType.SymbolicLink],
+			['unknown', vscode.FileType.Unknown]
+		];
+
+		deepStrictEqual(entries.map(c2p.asDirectoryEntry), [
+			{ name: 'file.txt', type: proto.FileType.file, flags: 0 },
+			{ name: 'dir', type: proto.FileType.directory, flags: 0 },
+			{ name: 'link', type: proto.FileType.file, flags: proto.FileFlags.symbolicLink },
+			{ name: 'dirLink', type: proto.FileType.directory, flags: proto.FileFlags.symbolicLink },
+			{ name: 'danglingLink', type: proto.FileType.unknown, flags: proto.FileFlags.symbolicLink },
+			{ name: 'unknown', type: proto.FileType.unknown, flags: 0 }
+		]);
+	});
+
+	test('FileStat', () => {
+		const result = c2p.asFileStat({ type: vscode.FileType.SymbolicLink | vscode.FileType.File, ctime: 1, mtime: 2, size: 3 });
+		deepStrictEqual(result, { type: proto.FileType.file, flags: proto.FileFlags.symbolicLink, ctime: 1, mtime: 2, size: 3 });
+
+		const dir = c2p.asFileStat({ type: vscode.FileType.Directory, ctime: 4, mtime: 5, size: 6 });
+		deepStrictEqual(dir, { type: proto.FileType.directory, flags: 0, ctime: 4, mtime: 5, size: 6 });
+	});
 });

--- a/client/src/common/client.ts
+++ b/client/src/common/client.ts
@@ -95,6 +95,7 @@ import { InlineCompletionItemFeature, InlineCompletionMiddleware } from './inlin
 import { TextDocumentContentFeature, type TextDocumentContentMiddleware, type TextDocumentContentProviderShape } from './textDocumentContent';
 import { FileSystemWatcherFeature } from './fileSystemWatcher';
 import { ProgressFeature } from './progress';
+import { FileSystemFeature, FileSystemMiddleware } from './fileSystem';
 
 /**
  * Controls when the output channel is revealed.
@@ -291,7 +292,7 @@ type _WorkspaceMiddleware = {
 	handleApplyEdit?: (this: void, params: ApplyWorkspaceEditParams, next: ApplyWorkspaceEditRequest.HandlerSignature) => HandlerResult<ApplyWorkspaceEditResult, void>;
 };
 
-export type WorkspaceMiddleware = _WorkspaceMiddleware & ConfigurationMiddleware & DidChangeConfigurationMiddleware & WorkspaceFolderMiddleware & FileOperationsMiddleware;
+export type WorkspaceMiddleware = _WorkspaceMiddleware & ConfigurationMiddleware & DidChangeConfigurationMiddleware & WorkspaceFolderMiddleware & FileOperationsMiddleware & FileSystemMiddleware;
 
 interface _WindowMiddleware {
 	showDocument?: ShowDocumentRequest.MiddlewareSignature;
@@ -342,7 +343,7 @@ DocumentHighlightMiddleware & DocumentSymbolMiddleware & WorkspaceSymbolMiddlewa
 ColorProviderMiddleware & CodeActionMiddleware & CodeLensMiddleware & FormattingMiddleware & RenameMiddleware & DocumentLinkMiddleware & ExecuteCommandMiddleware &
 FoldingRangeProviderMiddleware & DeclarationMiddleware & SelectionRangeProviderMiddleware & CallHierarchyMiddleware & SemanticTokensMiddleware &
 LinkedEditingRangeMiddleware & TypeHierarchyMiddleware & InlineValueMiddleware & InlayHintsMiddleware & NotebookDocumentMiddleware & DiagnosticProviderMiddleware &
-InlineCompletionMiddleware & TextDocumentContentMiddleware & GeneralMiddleware;
+InlineCompletionMiddleware & TextDocumentContentMiddleware & FileSystemMiddleware & GeneralMiddleware;
 
 export type LanguageClientOptions = {
 	documentSelector?: DocumentSelector | string[];
@@ -2085,6 +2086,7 @@ export abstract class BaseLanguageClient implements FeatureClient<Middleware, La
 		this.registerFeature(new NotebookDocumentSyncFeature(this));
 		this.registerFeature(new InlineCompletionItemFeature(this));
 		this.registerFeature(new TextDocumentContentFeature(this));
+		this.registerFeature(new FileSystemFeature(this));
 	}
 
 	public registerProposedFeatures() {

--- a/client/src/common/client.ts
+++ b/client/src/common/client.ts
@@ -343,7 +343,7 @@ DocumentHighlightMiddleware & DocumentSymbolMiddleware & WorkspaceSymbolMiddlewa
 ColorProviderMiddleware & CodeActionMiddleware & CodeLensMiddleware & FormattingMiddleware & RenameMiddleware & DocumentLinkMiddleware & ExecuteCommandMiddleware &
 FoldingRangeProviderMiddleware & DeclarationMiddleware & SelectionRangeProviderMiddleware & CallHierarchyMiddleware & SemanticTokensMiddleware &
 LinkedEditingRangeMiddleware & TypeHierarchyMiddleware & InlineValueMiddleware & InlayHintsMiddleware & NotebookDocumentMiddleware & DiagnosticProviderMiddleware &
-InlineCompletionMiddleware & TextDocumentContentMiddleware & FileSystemMiddleware & GeneralMiddleware;
+InlineCompletionMiddleware & TextDocumentContentMiddleware & GeneralMiddleware;
 
 export type LanguageClientOptions = {
 	documentSelector?: DocumentSelector | string[];

--- a/client/src/common/codeConverter.ts
+++ b/client/src/common/codeConverter.ts
@@ -982,7 +982,7 @@ export function createConverter(uriConverter?: URIConverter): Converter {
 
 	function asFileType(value: code.FileType): {
 		type: proto.FileType;
-		isSymlink: boolean;
+		flags: proto.FileFlags;
 	} {
 		let type: proto.FileType = proto.FileType.unknown;
 		if (value & code.FileType.Directory) {
@@ -990,28 +990,31 @@ export function createConverter(uriConverter?: URIConverter): Converter {
 		} else if (value & code.FileType.File) {
 			type = proto.FileType.file;
 		}
-		const isSymlink = (value & code.FileType.SymbolicLink) !== 0;
+		let flags: proto.FileFlags = 0;
+		if (value & code.FileType.SymbolicLink) {
+			flags |= proto.FileFlags.symbolicLink;
+		}
 		return {
 			type,
-			isSymlink
+			flags
 		};
 	}
 
 	function asDirectoryEntry(item: [string, code.FileType]): proto.DirectoryEntry {
-		const { type, isSymlink } = asFileType(item[1]);
+		const { type, flags } = asFileType(item[1]);
 		const result: proto.DirectoryEntry = {
 			name: item[0],
 			type,
-			isSymlink
+			flags
 		};
 		return result;
 	}
 
 	function asFileStat(item: code.FileStat): proto.FileStat {
-		const { type, isSymlink } = asFileType(item.type);
+		const { type, flags } = asFileType(item.type);
 		const result: proto.FileStat = {
 			type,
-			isSymlink,
+			flags,
 			ctime: item.ctime,
 			mtime: item.mtime,
 			size: item.size

--- a/client/src/common/codeConverter.ts
+++ b/client/src/common/codeConverter.ts
@@ -145,6 +145,9 @@ export interface Converter {
 
 	asInlineCompletionParams(document: code.TextDocument, position: code.Position, context: code.InlineCompletionContext): proto.InlineCompletionParams;
 	asInlineCompletionContext(context: code.InlineCompletionContext): proto.InlineCompletionContext;
+
+	asDirectoryEntry(item: [string, code.FileType]): proto.DirectoryEntry;
+	asFileStat(item: code.FileStat): proto.FileStat;
 }
 
 export interface URIConverter {
@@ -977,6 +980,45 @@ export function createConverter(uriConverter?: URIConverter): Converter {
 		return result;
 	}
 
+	function asFileType(value: code.FileType): {
+		type: proto.FileType;
+		isSymlink: boolean;
+	} {
+		let type: proto.FileType = proto.FileType.unknown;
+		if (value & code.FileType.Directory) {
+			type = proto.FileType.directory;
+		} else if (value & code.FileType.File) {
+			type = proto.FileType.file;
+		}
+		const isSymlink = (value & code.FileType.SymbolicLink) !== 0;
+		return {
+			type,
+			isSymlink
+		};
+	}
+
+	function asDirectoryEntry(item: [string, code.FileType]): proto.DirectoryEntry {
+		const { type, isSymlink } = asFileType(item[1]);
+		const result: proto.DirectoryEntry = {
+			name: item[0],
+			type,
+			isSymlink
+		};
+		return result;
+	}
+
+	function asFileStat(item: code.FileStat): proto.FileStat {
+		const { type, isSymlink } = asFileType(item.type);
+		const result: proto.FileStat = {
+			type,
+			isSymlink,
+			ctime: item.ctime,
+			mtime: item.mtime,
+			size: item.size
+		};
+		return result;
+	}
+
 	return {
 		asUri,
 		asTextDocumentIdentifier,
@@ -1031,6 +1073,8 @@ export function createConverter(uriConverter?: URIConverter): Converter {
 		asInlayHint,
 		asWorkspaceSymbol,
 		asInlineCompletionParams,
-		asInlineCompletionContext
+		asInlineCompletionContext,
+		asDirectoryEntry,
+		asFileStat,
 	};
 }

--- a/client/src/common/fileSystem.ts
+++ b/client/src/common/fileSystem.ts
@@ -6,13 +6,14 @@
 import * as vscode from 'vscode';
 
 import {
-	ClientCapabilities, StatRequest, ReadFileRequest, ReadDirectoryRequest
+	ClientCapabilities, StatRequest, ReadFileRequest, ReadDirectoryRequest,
+	ReadFileParamKind
 } from 'vscode-languageserver-protocol';
 
 import { StaticFeature, FeatureClient, FeatureState } from './features';
 
 export interface FileSystemReadFileSignature {
-	(this: void, uri: vscode.Uri, encoding?: string): Promise<string | null>;
+	(this: void, kind: ReadFileParamKind, uri: vscode.Uri, encoding?: string): Promise<string | null>;
 }
 
 export interface FileSystemStatSignature {
@@ -31,7 +32,7 @@ export interface FileSystemReadDirectorySignature {
 export interface FileSystemMiddleware {
 	fs?: {
 		stat?: (this: void, uri: vscode.Uri, next: FileSystemStatSignature) => vscode.ProviderResult<vscode.FileStat | null>;
-		readFile?: (this: void, uri: vscode.Uri, encoding: string | undefined, next: FileSystemReadFileSignature) => vscode.ProviderResult<string | null>;
+		readFile?: (this: void, kind: ReadFileParamKind, uri: vscode.Uri, encoding: string | undefined, next: FileSystemReadFileSignature) => vscode.ProviderResult<string | null>;
 		readDirectory?: (this: void, uri: vscode.Uri, next: FileSystemReadDirectorySignature) => vscode.ProviderResult<[string, vscode.FileType][] | null>;
 	};
 }
@@ -92,24 +93,31 @@ export class FileSystemFeature implements StaticFeature {
 				: null;
 		});
 		client.onRequest(ReadFileRequest.type, async (params) => {
+			const encoding = params.kind === 'text' ? params.encoding : undefined;
 			const paramsUri = this._client.protocol2CodeConverter.asUri(params.uri);
-			const fileRead: FileSystemReadFileSignature = async (uri, encoding) => {
+			const fileRead: FileSystemReadFileSignature = async (kind, uri, encoding) => {
 				try {
 					const bytes = await vscode.workspace.fs.readFile(uri);
-					const decoder = new TextDecoder(encoding || 'utf-8');
-					return decoder.decode(bytes);
+					if (kind === 'binary') {
+						return toBase64(bytes);
+					} else if (kind === 'text') {
+						const decoder = new TextDecoder(encoding || 'utf-8');
+						return decoder.decode(bytes);
+					} else {
+						return null;
+					}
 				} catch {
 					return null;
 				}
 			};
 			const middleware = client.middleware.workspace;
 			const result = await (middleware?.fs?.readFile
-				? middleware.fs.readFile(paramsUri, params.encoding, fileRead)
-				: fileRead(paramsUri, params.encoding));
+				? middleware.fs.readFile(params.kind, paramsUri, encoding, fileRead)
+				: fileRead(params.kind, paramsUri, encoding));
 			if (result === undefined || result === null) {
 				return null;
 			}
-			return { text: result };
+			return { content: result };
 		});
 		client.onRequest(ReadDirectoryRequest.type, async (params) => {
 			const paramsUri = this._client.protocol2CodeConverter.asUri(params.uri);
@@ -135,4 +143,34 @@ export class FileSystemFeature implements StaticFeature {
 
 	public clear(): void {
 	}
+}
+
+declare const Buffer: undefined | {
+	from(bytes: Uint8Array): { toString(encoding: 'base64'): string };
+};
+
+const base64Chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
+function toBase64(bytes: Uint8Array): string {
+	// First, try to use the new toBase64() method on Uint8Array if available.
+	if (typeof (bytes as any).toBase64 === 'function') {
+		return (bytes as any).toBase64();
+	}
+	// Then, try to use the node.js buffer implementation if available.
+	if (typeof Buffer !== 'undefined') {
+		return Buffer.from(bytes).toString('base64');
+	}
+	// Fallback to a manual implementation, which is slower but works in all environments.
+	// File might be quite large, use an array to avoid concat overhead
+	const chars = new Array<string>(Math.ceil(bytes.length / 3) * 4);
+	let j = 0;
+	for (let i = 0; i < bytes.length; i += 3) {
+		const b0 = bytes[i];
+		const b1 = i + 1 < bytes.length ? bytes[i + 1] : 0;
+		const b2 = i + 2 < bytes.length ? bytes[i + 2] : 0;
+		chars[j++] = base64Chars[b0 >> 2];
+		chars[j++] = base64Chars[((b0 & 0x03) << 4) | (b1 >> 4)];
+		chars[j++] = i + 1 < bytes.length ? base64Chars[((b1 & 0x0f) << 2) | (b2 >> 6)] : '=';
+		chars[j++] = i + 2 < bytes.length ? base64Chars[b2 & 0x3f] : '=';
+	}
+	return chars.join('');
 }

--- a/client/src/common/fileSystem.ts
+++ b/client/src/common/fileSystem.ts
@@ -1,0 +1,138 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import * as vscode from 'vscode';
+
+import {
+	ClientCapabilities, StatRequest, ReadFileRequest, ReadDirectoryRequest
+} from 'vscode-languageserver-protocol';
+
+import { StaticFeature, FeatureClient, FeatureState } from './features';
+
+export interface FileSystemReadFileSignature {
+	(this: void, uri: vscode.Uri, encoding?: string): Promise<string | null>;
+}
+
+export interface FileSystemStatSignature {
+	(this: void, uri: vscode.Uri): Promise<vscode.FileStat | null>;
+}
+
+export interface FileSystemReadDirectorySignature {
+	(this: void, uri: vscode.Uri): Promise<[string, vscode.FileType][] | null>;
+}
+
+/**
+ * File system middleware.
+ *
+ * @since 3.19.0
+ */
+export interface FileSystemMiddleware {
+	fs?: {
+		stat?: (this: void, uri: vscode.Uri, next: FileSystemStatSignature) => vscode.ProviderResult<vscode.FileStat | null>;
+		readFile?: (this: void, uri: vscode.Uri, encoding: string | undefined, next: FileSystemReadFileSignature) => vscode.ProviderResult<string | null>;
+		readDirectory?: (this: void, uri: vscode.Uri, next: FileSystemReadDirectorySignature) => vscode.ProviderResult<[string, vscode.FileType][] | null>;
+	};
+}
+
+interface WorkspaceFileSystemMiddleware {
+	workspace?: FileSystemMiddleware;
+}
+
+// TextDecoder is available in all supported environments, but we can't use it directly
+// because that would require us to use the dom or webworker lib, which we don't want to do.
+// So we declare it here to make TypeScript happy.
+declare class TextDecoder {
+	constructor(label?: string, options?: { fatal?: boolean; ignoreBOM?: boolean });
+	decode(input?: Uint8Array): string;
+}
+
+/**
+ * file system feature. From server to client.
+ */
+export class FileSystemFeature implements StaticFeature {
+
+	private readonly _client: FeatureClient<WorkspaceFileSystemMiddleware>;
+
+	constructor(client: FeatureClient<WorkspaceFileSystemMiddleware>) {
+		this._client = client;
+	}
+
+	getState(): FeatureState {
+		return { kind: 'static' };
+	}
+
+	public fillClientCapabilities(capabilities: ClientCapabilities): void {
+		capabilities.workspace ??= {};
+		capabilities.workspace.fileSystem ??= {};
+		capabilities.workspace.fileSystem.stat = true;
+		capabilities.workspace.fileSystem.readFile = true;
+		capabilities.workspace.fileSystem.readDirectory = true;
+	}
+
+	public initialize(): void {
+		const client = this._client;
+		client.onRequest(StatRequest.type, async (params) => {
+			const paramsUri = this._client.protocol2CodeConverter.asUri(params.uri);
+			const fileStat: FileSystemStatSignature = async (uri) => {
+				try {
+					const vstat = await vscode.workspace.fs.stat(uri);
+					return vstat;
+				} catch {
+					return null;
+				}
+			};
+			const middleware = client.middleware.workspace;
+			const result = await (middleware?.fs?.stat
+				? middleware.fs.stat(paramsUri, fileStat)
+				: fileStat(paramsUri));
+			return result
+				? this._client.code2ProtocolConverter.asFileStat(result)
+				: null;
+		});
+		client.onRequest(ReadFileRequest.type, async (params) => {
+			const paramsUri = this._client.protocol2CodeConverter.asUri(params.uri);
+			const fileRead: FileSystemReadFileSignature = async (uri, encoding) => {
+				try {
+					const bytes = await vscode.workspace.fs.readFile(uri);
+					const decoder = new TextDecoder(encoding || 'utf-8');
+					return decoder.decode(bytes);
+				} catch {
+					return null;
+				}
+			};
+			const middleware = client.middleware.workspace;
+			const result = await (middleware?.fs?.readFile
+				? middleware.fs.readFile(paramsUri, params.encoding, fileRead)
+				: fileRead(paramsUri, params.encoding));
+			if (result === undefined || result === null) {
+				return null;
+			}
+			return { text: result };
+		});
+		client.onRequest(ReadDirectoryRequest.type, async (params) => {
+			const paramsUri = this._client.protocol2CodeConverter.asUri(params.uri);
+			const directoryRead: FileSystemReadDirectorySignature = async (uri) => {
+				try {
+					const entries = await vscode.workspace.fs.readDirectory(uri);
+					return entries;
+				} catch {
+					return null;
+				}
+			};
+			const middleware = client.middleware.workspace;
+			const result = await (middleware?.fs?.readDirectory
+				? middleware.fs.readDirectory(paramsUri, directoryRead)
+				: directoryRead(paramsUri));
+			if (result === undefined || result === null) {
+				return null;
+			}
+			const entries = result.map(this._client.code2ProtocolConverter.asDirectoryEntry);
+			return entries;
+		});
+	}
+
+	public clear(): void {
+	}
+}

--- a/protocol/metaModel.json
+++ b/protocol/metaModel.json
@@ -1150,6 +1150,84 @@
 			"since": "3.18.0"
 		},
 		{
+			"method": "workspace/stat",
+			"typeName": "StatRequest",
+			"result": {
+				"kind": "or",
+				"items": [
+					{
+						"kind": "reference",
+						"name": "FileStat"
+					},
+					{
+						"kind": "base",
+						"name": "null"
+					}
+				]
+			},
+			"messageDirection": "serverToClient",
+			"clientCapability": "workspace.fileOperations.fileStat",
+			"params": {
+				"kind": "reference",
+				"name": "StatParams"
+			},
+			"documentation": "The stat request is sent from the server to the client to get metadata about a file.\n\nThe request can return a `FileStat` which will be used to determine the type of the file,\nits size, and the creation and modification time. Returns `null` if the file does not exist.\n\n@since 3.19.0",
+			"since": "3.19.0"
+		},
+		{
+			"method": "workspace/readDirectory",
+			"typeName": "ReadDirectoryRequest",
+			"result": {
+				"kind": "or",
+				"items": [
+					{
+						"kind": "array",
+						"element": {
+							"kind": "reference",
+							"name": "DirectoryEntry"
+						}
+					},
+					{
+						"kind": "base",
+						"name": "null"
+					}
+				]
+			},
+			"messageDirection": "serverToClient",
+			"clientCapability": "workspace.fileOperations.readDirectory",
+			"params": {
+				"kind": "reference",
+				"name": "ReadDirectoryParams"
+			},
+			"documentation": "The read directory request is sent from the server to the client to get the entries of a directory.\n\nThe request can return a `DirectoryEntry[]` which contains the directory entries.\nReturns `null` if the directory does not exist or the client cannot read it.\n\n@since 3.19.0",
+			"since": "3.19.0"
+		},
+		{
+			"method": "workspace/readFile",
+			"typeName": "ReadFileRequest",
+			"result": {
+				"kind": "or",
+				"items": [
+					{
+						"kind": "reference",
+						"name": "ReadFileResult"
+					},
+					{
+						"kind": "base",
+						"name": "null"
+					}
+				]
+			},
+			"messageDirection": "serverToClient",
+			"clientCapability": "workspace.fileOperations.readFile",
+			"params": {
+				"kind": "reference",
+				"name": "ReadFileParams"
+			},
+			"documentation": "The read file request is sent from the server to the client to get the content of a file.\n\nThe request can return a `ReadFileResult` which contains the content of the file.\nReturns `null` if the file does not exist or the client cannot read it.\n\n@since 3.19.0",
+			"since": "3.19.0"
+		},
+		{
 			"method": "client/registerCapability",
 			"typeName": "RegistrationRequest",
 			"result": {
@@ -4516,6 +4594,153 @@
 			],
 			"documentation": "Parameters for the `workspace/textDocumentContent/refresh` request.\n\n@since 3.18.0",
 			"since": "3.18.0"
+		},
+		{
+			"name": "StatParams",
+			"properties": [
+				{
+					"name": "uri",
+					"type": {
+						"kind": "base",
+						"name": "DocumentUri"
+					},
+					"documentation": "A URI for the location of the file/folder."
+				}
+			],
+			"documentation": "The parameters sent in a request to get metadata about a file.\n\n@since 3.19.0",
+			"since": "3.19.0"
+		},
+		{
+			"name": "FileStat",
+			"properties": [
+				{
+					"name": "type",
+					"type": {
+						"kind": "reference",
+						"name": "FileType"
+					},
+					"documentation": "The type of the file, e.g. is a regular file or a directory."
+				},
+				{
+					"name": "isSymlink",
+					"type": {
+						"kind": "base",
+						"name": "boolean"
+					},
+					"documentation": "Whether the file is a symbolic link."
+				},
+				{
+					"name": "ctime",
+					"type": {
+						"kind": "base",
+						"name": "integer"
+					},
+					"documentation": "The creation timestamp in milliseconds elapsed since January 1, 1970 00:00:00 UTC."
+				},
+				{
+					"name": "mtime",
+					"type": {
+						"kind": "base",
+						"name": "integer"
+					},
+					"documentation": "The modification timestamp in milliseconds elapsed since January 1, 1970 00:00:00 UTC."
+				},
+				{
+					"name": "size",
+					"type": {
+						"kind": "base",
+						"name": "integer"
+					},
+					"documentation": "The size in bytes."
+				}
+			],
+			"documentation": "Represents metadata about a file.\n\n@since 3.19.0",
+			"since": "3.19.0"
+		},
+		{
+			"name": "ReadDirectoryParams",
+			"properties": [
+				{
+					"name": "uri",
+					"type": {
+						"kind": "base",
+						"name": "DocumentUri"
+					},
+					"documentation": "A URI for the location of the folder."
+				}
+			],
+			"documentation": "The parameters sent in a request to read the contents of a directory.\n\n@since 3.19.0",
+			"since": "3.19.0"
+		},
+		{
+			"name": "DirectoryEntry",
+			"properties": [
+				{
+					"name": "name",
+					"type": {
+						"kind": "base",
+						"name": "string"
+					},
+					"documentation": "The name of the entry."
+				},
+				{
+					"name": "type",
+					"type": {
+						"kind": "reference",
+						"name": "FileType"
+					},
+					"documentation": "The type of the entry."
+				},
+				{
+					"name": "isSymlink",
+					"type": {
+						"kind": "base",
+						"name": "boolean"
+					},
+					"documentation": "Whether the entry is a symbolic link."
+				}
+			],
+			"documentation": "A directory entry represents a file or a folder in a directory.\n\n@since 3.19.0",
+			"since": "3.19.0"
+		},
+		{
+			"name": "ReadFileParams",
+			"properties": [
+				{
+					"name": "uri",
+					"type": {
+						"kind": "base",
+						"name": "DocumentUri"
+					},
+					"documentation": "A URI for the location of the file."
+				},
+				{
+					"name": "encoding",
+					"type": {
+						"kind": "base",
+						"name": "string"
+					},
+					"optional": true,
+					"documentation": "The encoding of the file content. If not specified, the content is assumed to be UTF-8."
+				}
+			],
+			"documentation": "The parameters sent in a request to read the contents of a file.\n\n@since 3.19.0",
+			"since": "3.19.0"
+		},
+		{
+			"name": "ReadFileResult",
+			"properties": [
+				{
+					"name": "text",
+					"type": {
+						"kind": "base",
+						"name": "string"
+					},
+					"documentation": "The content of the file as a unicode string.\nIt will be read using the encoding specified in the request.\nAny invalid byte sequences will be replaced with the unicode replacement character `U+FFFD`."
+				}
+			],
+			"documentation": "The result of a read file request.\n\n@since 3.19.0",
+			"since": "3.19.0"
 		},
 		{
 			"name": "RegistrationParams",
@@ -11237,6 +11462,16 @@
 					"optional": true,
 					"documentation": "Capabilities specific to the `workspace/textDocumentContent` request.\n\n@since 3.18.0",
 					"since": "3.18.0"
+				},
+				{
+					"name": "fileSystem",
+					"type": {
+						"kind": "reference",
+						"name": "FileSystemClientCapabilities"
+					},
+					"optional": true,
+					"documentation": "Client capabilities specific to file system requests.\n\n@since 3.19.0",
+					"since": "3.19.0"
 				}
 			],
 			"documentation": "Workspace specific client capabilities."
@@ -12300,6 +12535,40 @@
 			],
 			"documentation": "Client capabilities for a text document content provider.\n\n@since 3.18.0",
 			"since": "3.18.0"
+		},
+		{
+			"name": "FileSystemClientCapabilities",
+			"properties": [
+				{
+					"name": "stat",
+					"type": {
+						"kind": "base",
+						"name": "boolean"
+					},
+					"optional": true,
+					"documentation": "Whether the client supports the `workspace/stat` request."
+				},
+				{
+					"name": "readDirectory",
+					"type": {
+						"kind": "base",
+						"name": "boolean"
+					},
+					"optional": true,
+					"documentation": "Whether the client supports the `workspace/readDirectory` request."
+				},
+				{
+					"name": "readFile",
+					"type": {
+						"kind": "base",
+						"name": "boolean"
+					},
+					"optional": true,
+					"documentation": "Whether the client supports the `workspace/readFile` request."
+				}
+			],
+			"documentation": "Client capabilities specific to file system requests.\n\n@since 3.19.0",
+			"since": "3.19.0"
 		},
 		{
 			"name": "TextDocumentSyncClientCapabilities",
@@ -14631,6 +14900,32 @@
 			],
 			"documentation": "Inlay hint kinds.\n\n@since 3.17.0",
 			"since": "3.17.0"
+		},
+		{
+			"name": "FileType",
+			"type": {
+				"kind": "base",
+				"name": "string"
+			},
+			"values": [
+				{
+					"name": "unknown",
+					"value": "unknown",
+					"documentation": "The file type is unknown."
+				},
+				{
+					"name": "file",
+					"value": "file",
+					"documentation": "A regular file."
+				},
+				{
+					"name": "directory",
+					"value": "directory",
+					"documentation": "A directory."
+				}
+			],
+			"documentation": "The file type of a file system entry.\n\n@since 3.19.0",
+			"since": "3.19.0"
 		},
 		{
 			"name": "MessageType",

--- a/protocol/metaModel.json
+++ b/protocol/metaModel.json
@@ -4716,39 +4716,15 @@
 			"since": "3.19.0"
 		},
 		{
-			"name": "ReadFileParams",
-			"properties": [
-				{
-					"name": "uri",
-					"type": {
-						"kind": "base",
-						"name": "DocumentUri"
-					},
-					"documentation": "A URI for the location of the file."
-				},
-				{
-					"name": "encoding",
-					"type": {
-						"kind": "base",
-						"name": "string"
-					},
-					"optional": true,
-					"documentation": "The encoding of the file content. If not specified, the content is assumed to be UTF-8."
-				}
-			],
-			"documentation": "The parameters sent in a request to read the contents of a file.\n\n@since 3.19.0",
-			"since": "3.19.0"
-		},
-		{
 			"name": "ReadFileResult",
 			"properties": [
 				{
-					"name": "text",
+					"name": "content",
 					"type": {
 						"kind": "base",
 						"name": "string"
 					},
-					"documentation": "The content of the file as a unicode string.\nIt will be read using the encoding specified in the request.\nAny invalid byte sequences will be replaced with the unicode replacement character `U+FFFD`."
+					"documentation": "The content of the file as a unicode string.\n\nIf the content is requested as text, it will be read using the encoding specified in the request.\nAny invalid byte sequences will be replaced with the unicode replacement character `U+FFFD`.\n\nIf the content is requested as binary, it will be returned as a base64 encoded string."
 				}
 			],
 			"documentation": "The result of a read file request.\n\n@since 3.19.0",
@@ -8284,6 +8260,61 @@
 			],
 			"documentation": "Text document content provider options.\n\n@since 3.18.0",
 			"since": "3.18.0"
+		},
+		{
+			"name": "TextReadFileParams",
+			"properties": [
+				{
+					"name": "kind",
+					"type": {
+						"kind": "stringLiteral",
+						"value": "text"
+					},
+					"documentation": "Indicator that the file content should be read as a text file."
+				},
+				{
+					"name": "uri",
+					"type": {
+						"kind": "base",
+						"name": "DocumentUri"
+					},
+					"documentation": "A URI for the location of the file."
+				},
+				{
+					"name": "encoding",
+					"type": {
+						"kind": "base",
+						"name": "string"
+					},
+					"optional": true,
+					"documentation": "The encoding of the file content. If not specified, the content is assumed to be UTF-8."
+				}
+			],
+			"documentation": "The parameters sent in a request to read the text contents of a file.\nFile will be read using the encoding specified in the request.\n\n@since 3.19.0",
+			"since": "3.19.0"
+		},
+		{
+			"name": "BinaryReadFileParams",
+			"properties": [
+				{
+					"name": "kind",
+					"type": {
+						"kind": "stringLiteral",
+						"value": "binary"
+					},
+					"documentation": "Indicator that the file content should be read as a binary file."
+				},
+				{
+					"name": "uri",
+					"type": {
+						"kind": "base",
+						"name": "DocumentUri"
+					},
+					"documentation": "A URI for the location of the file."
+				}
+			],
+			"documentation": "The parameters sent in a request to read the binary contents of a file.\nFile content will be returned as a base64 encoded string.\n\n@since 3.19.0",
+			"since": "3.19.0"
 		},
 		{
 			"name": "Registration",
@@ -16161,6 +16192,22 @@
 			},
 			"documentation": "The document diagnostic report used when reporting partial result.\n\nWhen using partial results, the first literal sent needs to be a\nDocumentDiagnosticReport providing the diagnostics on the document\nfollowed by n DocumentDiagnosticReportPartialResult literals providing\nthe diagnostics for related documents.\n\n```\nDocumentDiagnosticReport\nDocumentDiagnosticReportPartialResult\nDocumentDiagnosticReportPartialResult\n...\n```\n\n@since 3.18.1",
 			"since": "3.18.1"
+		},
+		{
+			"name": "ReadFileParams",
+			"type": {
+				"kind": "or",
+				"items": [
+					{
+						"kind": "reference",
+						"name": "TextReadFileParams"
+					},
+					{
+						"kind": "reference",
+						"name": "BinaryReadFileParams"
+					}
+				]
+			}
 		},
 		{
 			"name": "PrepareRenameResult",

--- a/protocol/metaModel.json
+++ b/protocol/metaModel.json
@@ -1166,13 +1166,14 @@
 				]
 			},
 			"messageDirection": "serverToClient",
-			"clientCapability": "workspace.fileOperations.fileStat",
+			"clientCapability": "workspace.fileSystem.stat",
 			"params": {
 				"kind": "reference",
 				"name": "StatParams"
 			},
-			"documentation": "The stat request is sent from the server to the client to get metadata about a file.\n\nThe request can return a `FileStat` which will be used to determine the type of the file,\nits size, and the creation and modification time. Returns `null` if the file does not exist.\n\n@since 3.19.0",
-			"since": "3.19.0"
+			"documentation": "The stat request is sent from the server to the client to get metadata about a file.\n\nThe request can return a `FileStat` which will be used to determine the type of the file,\nits size, and the creation and modification time. Returns `null` if the file does not exist.\n\n@since 3.19.0\n@proposed",
+			"since": "3.19.0",
+			"proposed": true
 		},
 		{
 			"method": "workspace/readDirectory",
@@ -1194,13 +1195,14 @@
 				]
 			},
 			"messageDirection": "serverToClient",
-			"clientCapability": "workspace.fileOperations.readDirectory",
+			"clientCapability": "workspace.fileSystem.readDirectory",
 			"params": {
 				"kind": "reference",
 				"name": "ReadDirectoryParams"
 			},
-			"documentation": "The read directory request is sent from the server to the client to get the entries of a directory.\n\nThe request can return a `DirectoryEntry[]` which contains the directory entries.\nReturns `null` if the directory does not exist or the client cannot read it.\n\n@since 3.19.0",
-			"since": "3.19.0"
+			"documentation": "The read directory request is sent from the server to the client to get the entries of a directory.\n\nThe request can return a `DirectoryEntry[]` which contains the directory entries.\nReturns `null` if the directory does not exist or the client cannot read it.\n\n@since 3.19.0\n@proposed",
+			"since": "3.19.0",
+			"proposed": true
 		},
 		{
 			"method": "workspace/readFile",
@@ -1219,13 +1221,14 @@
 				]
 			},
 			"messageDirection": "serverToClient",
-			"clientCapability": "workspace.fileOperations.readFile",
+			"clientCapability": "workspace.fileSystem.readFile",
 			"params": {
 				"kind": "reference",
 				"name": "ReadFileParams"
 			},
-			"documentation": "The read file request is sent from the server to the client to get the content of a file.\n\nThe request can return a `ReadFileResult` which contains the content of the file.\nReturns `null` if the file does not exist or the client cannot read it.\n\n@since 3.19.0",
-			"since": "3.19.0"
+			"documentation": "The read file request is sent from the server to the client to get the content of a file.\n\nThe request can return a `ReadFileResult` which contains the content of the file.\nReturns `null` if the file does not exist or the client cannot read it.\n\n@since 3.19.0\n@proposed",
+			"since": "3.19.0",
+			"proposed": true
 		},
 		{
 			"method": "client/registerCapability",
@@ -4619,8 +4622,9 @@
 					"documentation": "A URI for the location of the file/folder."
 				}
 			],
-			"documentation": "The parameters sent in a request to get metadata about a file.\n\n@since 3.19.0",
-			"since": "3.19.0"
+			"documentation": "The parameters sent in a request to get metadata about a file.\n\n@since 3.19.0\n@proposed",
+			"since": "3.19.0",
+			"proposed": true
 		},
 		{
 			"name": "FileStat",
@@ -4645,7 +4649,7 @@
 					"name": "ctime",
 					"type": {
 						"kind": "base",
-						"name": "integer"
+						"name": "decimal"
 					},
 					"documentation": "The creation timestamp in milliseconds elapsed since January 1, 1970 00:00:00 UTC."
 				},
@@ -4653,7 +4657,7 @@
 					"name": "mtime",
 					"type": {
 						"kind": "base",
-						"name": "integer"
+						"name": "decimal"
 					},
 					"documentation": "The modification timestamp in milliseconds elapsed since January 1, 1970 00:00:00 UTC."
 				},
@@ -4661,13 +4665,14 @@
 					"name": "size",
 					"type": {
 						"kind": "base",
-						"name": "integer"
+						"name": "decimal"
 					},
 					"documentation": "The size in bytes."
 				}
 			],
-			"documentation": "Represents metadata about a file.\n\n@since 3.19.0",
-			"since": "3.19.0"
+			"documentation": "Represents metadata about a file.\n\n@since 3.19.0\n@proposed",
+			"since": "3.19.0",
+			"proposed": true
 		},
 		{
 			"name": "ReadDirectoryParams",
@@ -4681,8 +4686,9 @@
 					"documentation": "A URI for the location of the folder."
 				}
 			],
-			"documentation": "The parameters sent in a request to read the contents of a directory.\n\n@since 3.19.0",
-			"since": "3.19.0"
+			"documentation": "The parameters sent in a request to read the contents of a directory.\n\n@since 3.19.0\n@proposed",
+			"since": "3.19.0",
+			"proposed": true
 		},
 		{
 			"name": "DirectoryEntry",
@@ -4712,8 +4718,9 @@
 					"documentation": "Additional flags about the entry."
 				}
 			],
-			"documentation": "A directory entry represents a file or a folder in a directory.\n\n@since 3.19.0",
-			"since": "3.19.0"
+			"documentation": "A directory entry represents a file or a folder in a directory.\n\n@since 3.19.0\n@proposed",
+			"since": "3.19.0",
+			"proposed": true
 		},
 		{
 			"name": "ReadFileResult",
@@ -4727,8 +4734,9 @@
 					"documentation": "The content of the file as a unicode string.\n\nIf the content is requested as text, it will be read using the encoding specified in the request.\nAny invalid byte sequences will be replaced with the unicode replacement character `U+FFFD`.\n\nIf the content is requested as binary, it will be returned as a base64 encoded string."
 				}
 			],
-			"documentation": "The result of a read file request.\n\n@since 3.19.0",
-			"since": "3.19.0"
+			"documentation": "The result of a read file request.\n\n@since 3.19.0\n@proposed",
+			"since": "3.19.0",
+			"proposed": true
 		},
 		{
 			"name": "RegistrationParams",
@@ -8290,8 +8298,9 @@
 					"documentation": "The encoding of the file content. If not specified, the content is assumed to be UTF-8."
 				}
 			],
-			"documentation": "The parameters sent in a request to read the text contents of a file.\nFile will be read using the encoding specified in the request.\n\n@since 3.19.0",
-			"since": "3.19.0"
+			"documentation": "The parameters sent in a request to read the text contents of a file.\nFile will be read using the encoding specified in the request.\n\n@since 3.19.0\n@proposed",
+			"since": "3.19.0",
+			"proposed": true
 		},
 		{
 			"name": "BinaryReadFileParams",
@@ -8313,8 +8322,9 @@
 					"documentation": "A URI for the location of the file."
 				}
 			],
-			"documentation": "The parameters sent in a request to read the binary contents of a file.\nFile content will be returned as a base64 encoded string.\n\n@since 3.19.0",
-			"since": "3.19.0"
+			"documentation": "The parameters sent in a request to read the binary contents of a file.\nFile content will be returned as a base64 encoded string.\n\n@since 3.19.0\n@proposed",
+			"since": "3.19.0",
+			"proposed": true
 		},
 		{
 			"name": "Registration",
@@ -11513,8 +11523,9 @@
 						"name": "FileSystemClientCapabilities"
 					},
 					"optional": true,
-					"documentation": "Client capabilities specific to file system requests.\n\n@since 3.19.0",
-					"since": "3.19.0"
+					"documentation": "Client capabilities specific to file system requests.\n\n@since 3.19.0\n@proposed",
+					"since": "3.19.0",
+					"proposed": true
 				}
 			],
 			"documentation": "Workspace specific client capabilities."
@@ -12610,8 +12621,9 @@
 					"documentation": "Whether the client supports the `workspace/readFile` request."
 				}
 			],
-			"documentation": "Client capabilities specific to file system requests.\n\n@since 3.19.0",
-			"since": "3.19.0"
+			"documentation": "Client capabilities specific to file system requests.\n\n@since 3.19.0\n@proposed",
+			"since": "3.19.0",
+			"proposed": true
 		},
 		{
 			"name": "TextDocumentSyncClientCapabilities",
@@ -14967,8 +14979,9 @@
 					"documentation": "A directory."
 				}
 			],
-			"documentation": "The file type of a file system entry.\n\n@since 3.19.0",
-			"since": "3.19.0"
+			"documentation": "The file type of a file system entry.\n\n@since 3.19.0\n@proposed",
+			"since": "3.19.0",
+			"proposed": true
 		},
 		{
 			"name": "FileFlags",
@@ -14984,7 +14997,9 @@
 				}
 			],
 			"supportsCustomValues": true,
-			"documentation": "Additional flags about a file system entry.\nImplemented as a bitmask so that multiple flags can be combined."
+			"documentation": "Additional flags about a file system entry.\nImplemented as a bitmask so that multiple flags can be combined.\n\n@since 3.19.0\n@proposed",
+			"since": "3.19.0",
+			"proposed": true
 		},
 		{
 			"name": "MessageType",
@@ -16207,7 +16222,10 @@
 						"name": "BinaryReadFileParams"
 					}
 				]
-			}
+			},
+			"documentation": "The parameters sent in a request to read the contents of a file.\n\n@since 3.19.0\n@proposed",
+			"since": "3.19.0",
+			"proposed": true
 		},
 		{
 			"name": "PrepareRenameResult",

--- a/protocol/metaModel.json
+++ b/protocol/metaModel.json
@@ -4634,12 +4634,12 @@
 					"documentation": "The type of the file, e.g. is a regular file or a directory."
 				},
 				{
-					"name": "isSymlink",
+					"name": "flags",
 					"type": {
-						"kind": "base",
-						"name": "boolean"
+						"kind": "reference",
+						"name": "FileFlags"
 					},
-					"documentation": "Whether the file is a symbolic link."
+					"documentation": "Additional flags about the file."
 				},
 				{
 					"name": "ctime",
@@ -4704,12 +4704,12 @@
 					"documentation": "The type of the entry."
 				},
 				{
-					"name": "isSymlink",
+					"name": "flags",
 					"type": {
-						"kind": "base",
-						"name": "boolean"
+						"kind": "reference",
+						"name": "FileFlags"
 					},
-					"documentation": "Whether the entry is a symbolic link."
+					"documentation": "Additional flags about the entry."
 				}
 			],
 			"documentation": "A directory entry represents a file or a folder in a directory.\n\n@since 3.19.0",
@@ -14938,6 +14938,22 @@
 			],
 			"documentation": "The file type of a file system entry.\n\n@since 3.19.0",
 			"since": "3.19.0"
+		},
+		{
+			"name": "FileFlags",
+			"type": {
+				"kind": "base",
+				"name": "uinteger"
+			},
+			"values": [
+				{
+					"name": "symbolicLink",
+					"value": 1,
+					"documentation": "The file is a symbolic link."
+				}
+			],
+			"supportsCustomValues": true,
+			"documentation": "Additional flags about a file system entry.\nImplemented as a bitmask so that multiple flags can be combined."
 		},
 		{
 			"name": "MessageType",

--- a/protocol/metaModel.json
+++ b/protocol/metaModel.json
@@ -1150,6 +1150,84 @@
 			"since": "3.18.0"
 		},
 		{
+			"method": "workspace/stat",
+			"typeName": "StatRequest",
+			"result": {
+				"kind": "or",
+				"items": [
+					{
+						"kind": "reference",
+						"name": "FileStat"
+					},
+					{
+						"kind": "base",
+						"name": "null"
+					}
+				]
+			},
+			"messageDirection": "serverToClient",
+			"clientCapability": "workspace.fileOperations.fileStat",
+			"params": {
+				"kind": "reference",
+				"name": "StatParams"
+			},
+			"documentation": "The stat request is sent from the server to the client to get metadata about a file.\n\nThe request can return a `FileStat` which will be used to determine the type of the file,\nits size, and the creation and modification time. Returns `null` if the file does not exist.\n\n@since 3.19.0",
+			"since": "3.19.0"
+		},
+		{
+			"method": "workspace/readDirectory",
+			"typeName": "ReadDirectoryRequest",
+			"result": {
+				"kind": "or",
+				"items": [
+					{
+						"kind": "array",
+						"element": {
+							"kind": "reference",
+							"name": "DirectoryEntry"
+						}
+					},
+					{
+						"kind": "base",
+						"name": "null"
+					}
+				]
+			},
+			"messageDirection": "serverToClient",
+			"clientCapability": "workspace.fileOperations.readDirectory",
+			"params": {
+				"kind": "reference",
+				"name": "ReadDirectoryParams"
+			},
+			"documentation": "The read directory request is sent from the server to the client to get the entries of a directory.\n\nThe request can return a `DirectoryEntry[]` which contains the directory entries.\nReturns `null` if the directory does not exist or the client cannot read it.\n\n@since 3.19.0",
+			"since": "3.19.0"
+		},
+		{
+			"method": "workspace/readFile",
+			"typeName": "ReadFileRequest",
+			"result": {
+				"kind": "or",
+				"items": [
+					{
+						"kind": "reference",
+						"name": "ReadFileResult"
+					},
+					{
+						"kind": "base",
+						"name": "null"
+					}
+				]
+			},
+			"messageDirection": "serverToClient",
+			"clientCapability": "workspace.fileOperations.readFile",
+			"params": {
+				"kind": "reference",
+				"name": "ReadFileParams"
+			},
+			"documentation": "The read file request is sent from the server to the client to get the content of a file.\n\nThe request can return a `ReadFileResult` which contains the content of the file.\nReturns `null` if the file does not exist or the client cannot read it.\n\n@since 3.19.0",
+			"since": "3.19.0"
+		},
+		{
 			"method": "client/registerCapability",
 			"typeName": "RegistrationRequest",
 			"result": {
@@ -4528,6 +4606,153 @@
 			],
 			"documentation": "Parameters for the `workspace/textDocumentContent/refresh` request.\n\n@since 3.18.0",
 			"since": "3.18.0"
+		},
+		{
+			"name": "StatParams",
+			"properties": [
+				{
+					"name": "uri",
+					"type": {
+						"kind": "base",
+						"name": "DocumentUri"
+					},
+					"documentation": "A URI for the location of the file/folder."
+				}
+			],
+			"documentation": "The parameters sent in a request to get metadata about a file.\n\n@since 3.19.0",
+			"since": "3.19.0"
+		},
+		{
+			"name": "FileStat",
+			"properties": [
+				{
+					"name": "type",
+					"type": {
+						"kind": "reference",
+						"name": "FileType"
+					},
+					"documentation": "The type of the file, e.g. is a regular file or a directory."
+				},
+				{
+					"name": "isSymlink",
+					"type": {
+						"kind": "base",
+						"name": "boolean"
+					},
+					"documentation": "Whether the file is a symbolic link."
+				},
+				{
+					"name": "ctime",
+					"type": {
+						"kind": "base",
+						"name": "integer"
+					},
+					"documentation": "The creation timestamp in milliseconds elapsed since January 1, 1970 00:00:00 UTC."
+				},
+				{
+					"name": "mtime",
+					"type": {
+						"kind": "base",
+						"name": "integer"
+					},
+					"documentation": "The modification timestamp in milliseconds elapsed since January 1, 1970 00:00:00 UTC."
+				},
+				{
+					"name": "size",
+					"type": {
+						"kind": "base",
+						"name": "integer"
+					},
+					"documentation": "The size in bytes."
+				}
+			],
+			"documentation": "Represents metadata about a file.\n\n@since 3.19.0",
+			"since": "3.19.0"
+		},
+		{
+			"name": "ReadDirectoryParams",
+			"properties": [
+				{
+					"name": "uri",
+					"type": {
+						"kind": "base",
+						"name": "DocumentUri"
+					},
+					"documentation": "A URI for the location of the folder."
+				}
+			],
+			"documentation": "The parameters sent in a request to read the contents of a directory.\n\n@since 3.19.0",
+			"since": "3.19.0"
+		},
+		{
+			"name": "DirectoryEntry",
+			"properties": [
+				{
+					"name": "name",
+					"type": {
+						"kind": "base",
+						"name": "string"
+					},
+					"documentation": "The name of the entry."
+				},
+				{
+					"name": "type",
+					"type": {
+						"kind": "reference",
+						"name": "FileType"
+					},
+					"documentation": "The type of the entry."
+				},
+				{
+					"name": "isSymlink",
+					"type": {
+						"kind": "base",
+						"name": "boolean"
+					},
+					"documentation": "Whether the entry is a symbolic link."
+				}
+			],
+			"documentation": "A directory entry represents a file or a folder in a directory.\n\n@since 3.19.0",
+			"since": "3.19.0"
+		},
+		{
+			"name": "ReadFileParams",
+			"properties": [
+				{
+					"name": "uri",
+					"type": {
+						"kind": "base",
+						"name": "DocumentUri"
+					},
+					"documentation": "A URI for the location of the file."
+				},
+				{
+					"name": "encoding",
+					"type": {
+						"kind": "base",
+						"name": "string"
+					},
+					"optional": true,
+					"documentation": "The encoding of the file content. If not specified, the content is assumed to be UTF-8."
+				}
+			],
+			"documentation": "The parameters sent in a request to read the contents of a file.\n\n@since 3.19.0",
+			"since": "3.19.0"
+		},
+		{
+			"name": "ReadFileResult",
+			"properties": [
+				{
+					"name": "text",
+					"type": {
+						"kind": "base",
+						"name": "string"
+					},
+					"documentation": "The content of the file as a unicode string.\nIt will be read using the encoding specified in the request.\nAny invalid byte sequences will be replaced with the unicode replacement character `U+FFFD`."
+				}
+			],
+			"documentation": "The result of a read file request.\n\n@since 3.19.0",
+			"since": "3.19.0"
 		},
 		{
 			"name": "RegistrationParams",
@@ -11249,6 +11474,16 @@
 					"optional": true,
 					"documentation": "Capabilities specific to the `workspace/textDocumentContent` request.\n\n@since 3.18.0",
 					"since": "3.18.0"
+				},
+				{
+					"name": "fileSystem",
+					"type": {
+						"kind": "reference",
+						"name": "FileSystemClientCapabilities"
+					},
+					"optional": true,
+					"documentation": "Client capabilities specific to file system requests.\n\n@since 3.19.0",
+					"since": "3.19.0"
 				}
 			],
 			"documentation": "Workspace specific client capabilities."
@@ -12312,6 +12547,40 @@
 			],
 			"documentation": "Client capabilities for a text document content provider.\n\n@since 3.18.0",
 			"since": "3.18.0"
+		},
+		{
+			"name": "FileSystemClientCapabilities",
+			"properties": [
+				{
+					"name": "stat",
+					"type": {
+						"kind": "base",
+						"name": "boolean"
+					},
+					"optional": true,
+					"documentation": "Whether the client supports the `workspace/stat` request."
+				},
+				{
+					"name": "readDirectory",
+					"type": {
+						"kind": "base",
+						"name": "boolean"
+					},
+					"optional": true,
+					"documentation": "Whether the client supports the `workspace/readDirectory` request."
+				},
+				{
+					"name": "readFile",
+					"type": {
+						"kind": "base",
+						"name": "boolean"
+					},
+					"optional": true,
+					"documentation": "Whether the client supports the `workspace/readFile` request."
+				}
+			],
+			"documentation": "Client capabilities specific to file system requests.\n\n@since 3.19.0",
+			"since": "3.19.0"
 		},
 		{
 			"name": "TextDocumentSyncClientCapabilities",
@@ -14643,6 +14912,32 @@
 			],
 			"documentation": "Inlay hint kinds.\n\n@since 3.17.0",
 			"since": "3.17.0"
+		},
+		{
+			"name": "FileType",
+			"type": {
+				"kind": "base",
+				"name": "string"
+			},
+			"values": [
+				{
+					"name": "unknown",
+					"value": "unknown",
+					"documentation": "The file type is unknown."
+				},
+				{
+					"name": "file",
+					"value": "file",
+					"documentation": "A regular file."
+				},
+				{
+					"name": "directory",
+					"value": "directory",
+					"documentation": "A directory."
+				}
+			],
+			"documentation": "The file type of a file system entry.\n\n@since 3.19.0",
+			"since": "3.19.0"
 		},
 		{
 			"name": "MessageType",

--- a/protocol/src/common/protocol.fileSystem.ts
+++ b/protocol/src/common/protocol.fileSystem.ts
@@ -136,11 +136,16 @@ export interface DirectoryEntry {
 }
 
 /**
- * The parameters sent in a request to read the contents of a file.
+ * The parameters sent in a request to read the text contents of a file.
+ * File will be read using the encoding specified in the request.
  *
  * @since 3.19.0
  */
-export interface ReadFileParams {
+export interface TextReadFileParams {
+	/**
+	 * Indicator that the file content should be read as a text file.
+	 */
+	kind: 'text';
 	/**
 	 * A URI for the location of the file.
 	 */
@@ -152,6 +157,32 @@ export interface ReadFileParams {
 }
 
 /**
+ * The parameters sent in a request to read the binary contents of a file.
+ * File content will be returned as a base64 encoded string.
+ *
+ * @since 3.19.0
+ */
+export interface BinaryReadFileParams {
+	/**
+	 * Indicator that the file content should be read as a binary file.
+	 */
+	kind: 'binary';
+	/**
+	 * A URI for the location of the file.
+	 */
+	uri: DocumentUri;
+}
+
+/**
+ * The parameters sent in a request to read the contents of a file.
+ *
+ * @since 3.19.0
+ */
+export type ReadFileParams = TextReadFileParams | BinaryReadFileParams;
+export type ReadFileParamKind = ReadFileParams['kind'];
+
+
+/**
  * The result of a read file request.
  *
  * @since 3.19.0
@@ -159,10 +190,13 @@ export interface ReadFileParams {
 export interface ReadFileResult {
 	/**
 	 * The content of the file as a unicode string.
-	 * It will be read using the encoding specified in the request.
+	 *
+	 * If the content is requested as text, it will be read using the encoding specified in the request.
 	 * Any invalid byte sequences will be replaced with the unicode replacement character `U+FFFD`.
+	 *
+	 * If the content is requested as binary, it will be returned as a base64 encoded string.
 	 */
-	text: string;
+	content: string;
 }
 
 /**

--- a/protocol/src/common/protocol.fileSystem.ts
+++ b/protocol/src/common/protocol.fileSystem.ts
@@ -1,0 +1,202 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import { RequestHandler } from 'vscode-jsonrpc';
+import { type DocumentUri } from 'vscode-languageserver-types';
+import { CM, MessageDirection, ProtocolRequestType } from './messages';
+
+/**
+ * Client capabilities specific to file system requests.
+ *
+ * @since 3.19.0
+ */
+export interface FileSystemClientCapabilities {
+
+	/**
+	 * Whether the client supports the `workspace/stat` request.
+	 */
+	stat?: boolean;
+
+	/**
+	 * Whether the client supports the `workspace/readDirectory` request.
+	 */
+	readDirectory?: boolean;
+
+	/**
+	 * Whether the client supports the `workspace/readFile` request.
+	 */
+	readFile?: boolean;
+}
+
+/**
+ * Represents metadata about a file.
+ *
+ * @since 3.19.0
+ */
+export interface FileStat {
+	/**
+	 * The type of the file, e.g. is a regular file or a directory.
+	 */
+	type: FileType;
+	/**
+	 * Whether the file is a symbolic link.
+	 */
+	isSymlink: boolean;
+	/**
+	 * The creation timestamp in milliseconds elapsed since January 1, 1970 00:00:00 UTC.
+	 */
+	ctime: number;
+	/**
+	 * The modification timestamp in milliseconds elapsed since January 1, 1970 00:00:00 UTC.
+	 */
+	mtime: number;
+	/**
+	 * The size in bytes.
+	 */
+	size: number;
+}
+
+/**
+ * The parameters sent in a request to get metadata about a file.
+ *
+ * @since 3.19.0
+ */
+export interface StatParams {
+	/**
+	 * A URI for the location of the file/folder.
+	 */
+	uri: DocumentUri;
+}
+
+/**
+ * The file type of a file system entry.
+ *
+ * @since 3.19.0
+ */
+export namespace FileType {
+	/**
+	 * The file type is unknown.
+	 */
+	export const unknown = 'unknown';
+	/**
+	 * A regular file.
+	 */
+	export const file = 'file';
+	/**
+	 * A directory.
+	 */
+	export const directory = 'directory';
+}
+export type FileType = 'unknown' | 'file' | 'directory';
+
+/**
+ * The parameters sent in a request to read the contents of a directory.
+ *
+ * @since 3.19.0
+ */
+export interface ReadDirectoryParams {
+	/**
+	 * A URI for the location of the folder.
+	 */
+	uri: DocumentUri;
+}
+
+/**
+ * A directory entry represents a file or a folder in a directory.
+ *
+ * @since 3.19.0
+ */
+export interface DirectoryEntry {
+	/**
+	 * The name of the entry.
+	 */
+	name: string;
+	/**
+	 * The type of the entry.
+	 */
+	type: FileType;
+	/**
+	 * Whether the entry is a symbolic link.
+	 */
+	isSymlink: boolean;
+}
+
+/**
+ * The parameters sent in a request to read the contents of a file.
+ *
+ * @since 3.19.0
+ */
+export interface ReadFileParams {
+	/**
+	 * A URI for the location of the file.
+	 */
+	uri: DocumentUri;
+	/**
+	 * The encoding of the file content. If not specified, the content is assumed to be UTF-8.
+	 */
+	encoding?: string;
+}
+
+/**
+ * The result of a read file request.
+ *
+ * @since 3.19.0
+ */
+export interface ReadFileResult {
+	/**
+	 * The content of the file as a unicode string.
+	 * It will be read using the encoding specified in the request.
+	 * Any invalid byte sequences will be replaced with the unicode replacement character `U+FFFD`.
+	 */
+	text: string;
+}
+
+/**
+ * The stat request is sent from the server to the client to get metadata about a file.
+ *
+ * The request can return a `FileStat` which will be used to determine the type of the file,
+ * its size, and the creation and modification time. Returns `null` if the file does not exist.
+ *
+ * @since 3.19.0
+ */
+export namespace StatRequest {
+	export const method: 'workspace/stat' = 'workspace/stat';
+	export const messageDirection: MessageDirection = MessageDirection.serverToClient;
+	export const type = new ProtocolRequestType<StatParams, FileStat | null, never, void, void>(method);
+	export type HandlerSignature = RequestHandler<StatParams, FileStat | null, void>;
+	export const capabilities = CM.create('workspace.fileOperations.fileStat', undefined);
+}
+
+/**
+ * The read directory request is sent from the server to the client to get the entries of a directory.
+ *
+ * The request can return a `DirectoryEntry[]` which contains the directory entries.
+ * Returns `null` if the directory does not exist or the client cannot read it.
+ *
+ * @since 3.19.0
+ */
+export namespace ReadDirectoryRequest {
+	export const method: 'workspace/readDirectory' = 'workspace/readDirectory';
+	export const messageDirection: MessageDirection = MessageDirection.serverToClient;
+	export const type = new ProtocolRequestType<ReadDirectoryParams, DirectoryEntry[] | null, never, void, void>(method);
+	export type HandlerSignature = RequestHandler<ReadDirectoryParams, DirectoryEntry[] | null, void>;
+	export const capabilities = CM.create('workspace.fileOperations.readDirectory', undefined);
+}
+
+/**
+ * The read file request is sent from the server to the client to get the content of a file.
+ *
+ * The request can return a `ReadFileResult` which contains the content of the file.
+ * Returns `null` if the file does not exist or the client cannot read it.
+ *
+ * @since 3.19.0
+ */
+export namespace ReadFileRequest {
+	export const method: 'workspace/readFile' = 'workspace/readFile';
+	export const messageDirection: MessageDirection = MessageDirection.serverToClient;
+	export const type = new ProtocolRequestType<ReadFileParams, ReadFileResult | null, never, void, void>(method);
+	export type HandlerSignature = RequestHandler<ReadFileParams, ReadFileResult | null, void>;
+	export const capabilities = CM.create('workspace.fileOperations.readFile', undefined);
+}

--- a/protocol/src/common/protocol.fileSystem.ts
+++ b/protocol/src/common/protocol.fileSystem.ts
@@ -4,7 +4,7 @@
  * ------------------------------------------------------------------------------------------ */
 
 import { RequestHandler } from 'vscode-jsonrpc';
-import { type DocumentUri } from 'vscode-languageserver-types';
+import { uinteger, type DocumentUri } from 'vscode-languageserver-types';
 import { CM, MessageDirection, ProtocolRequestType } from './messages';
 
 /**
@@ -41,9 +41,9 @@ export interface FileStat {
 	 */
 	type: FileType;
 	/**
-	 * Whether the file is a symbolic link.
+	 * Additional flags about the file.
 	 */
-	isSymlink: boolean;
+	flags: FileFlags;
 	/**
 	 * The creation timestamp in milliseconds elapsed since January 1, 1970 00:00:00 UTC.
 	 */
@@ -92,6 +92,18 @@ export namespace FileType {
 export type FileType = 'unknown' | 'file' | 'directory';
 
 /**
+ * Additional flags about a file system entry.
+ * Implemented as a bitmask so that multiple flags can be combined.
+ */
+export namespace FileFlags {
+	/**
+	 * The file is a symbolic link.
+	 */
+	export const symbolicLink = 1;
+}
+export type FileFlags = uinteger;
+
+/**
  * The parameters sent in a request to read the contents of a directory.
  *
  * @since 3.19.0
@@ -118,9 +130,9 @@ export interface DirectoryEntry {
 	 */
 	type: FileType;
 	/**
-	 * Whether the entry is a symbolic link.
+	 * Additional flags about the entry.
 	 */
-	isSymlink: boolean;
+	flags: FileFlags;
 }
 
 /**

--- a/protocol/src/common/protocol.fileSystem.ts
+++ b/protocol/src/common/protocol.fileSystem.ts
@@ -4,13 +4,14 @@
  * ------------------------------------------------------------------------------------------ */
 
 import { RequestHandler } from 'vscode-jsonrpc';
-import { uinteger, type DocumentUri } from 'vscode-languageserver-types';
+import { decimal, uinteger, type DocumentUri } from 'vscode-languageserver-types';
 import { CM, MessageDirection, ProtocolRequestType } from './messages';
 
 /**
  * Client capabilities specific to file system requests.
  *
  * @since 3.19.0
+ * @proposed
  */
 export interface FileSystemClientCapabilities {
 
@@ -34,6 +35,7 @@ export interface FileSystemClientCapabilities {
  * Represents metadata about a file.
  *
  * @since 3.19.0
+ * @proposed
  */
 export interface FileStat {
 	/**
@@ -47,21 +49,22 @@ export interface FileStat {
 	/**
 	 * The creation timestamp in milliseconds elapsed since January 1, 1970 00:00:00 UTC.
 	 */
-	ctime: number;
+	ctime: decimal;
 	/**
 	 * The modification timestamp in milliseconds elapsed since January 1, 1970 00:00:00 UTC.
 	 */
-	mtime: number;
+	mtime: decimal;
 	/**
 	 * The size in bytes.
 	 */
-	size: number;
+	size: decimal;
 }
 
 /**
  * The parameters sent in a request to get metadata about a file.
  *
  * @since 3.19.0
+ * @proposed
  */
 export interface StatParams {
 	/**
@@ -74,6 +77,7 @@ export interface StatParams {
  * The file type of a file system entry.
  *
  * @since 3.19.0
+ * @proposed
  */
 export namespace FileType {
 	/**
@@ -94,6 +98,9 @@ export type FileType = 'unknown' | 'file' | 'directory';
 /**
  * Additional flags about a file system entry.
  * Implemented as a bitmask so that multiple flags can be combined.
+ *
+ * @since 3.19.0
+ * @proposed
  */
 export namespace FileFlags {
 	/**
@@ -107,6 +114,7 @@ export type FileFlags = uinteger;
  * The parameters sent in a request to read the contents of a directory.
  *
  * @since 3.19.0
+ * @proposed
  */
 export interface ReadDirectoryParams {
 	/**
@@ -119,6 +127,7 @@ export interface ReadDirectoryParams {
  * A directory entry represents a file or a folder in a directory.
  *
  * @since 3.19.0
+ * @proposed
  */
 export interface DirectoryEntry {
 	/**
@@ -140,6 +149,7 @@ export interface DirectoryEntry {
  * File will be read using the encoding specified in the request.
  *
  * @since 3.19.0
+ * @proposed
  */
 export interface TextReadFileParams {
 	/**
@@ -161,6 +171,7 @@ export interface TextReadFileParams {
  * File content will be returned as a base64 encoded string.
  *
  * @since 3.19.0
+ * @proposed
  */
 export interface BinaryReadFileParams {
 	/**
@@ -177,6 +188,7 @@ export interface BinaryReadFileParams {
  * The parameters sent in a request to read the contents of a file.
  *
  * @since 3.19.0
+ * @proposed
  */
 export type ReadFileParams = TextReadFileParams | BinaryReadFileParams;
 export type ReadFileParamKind = ReadFileParams['kind'];
@@ -186,6 +198,7 @@ export type ReadFileParamKind = ReadFileParams['kind'];
  * The result of a read file request.
  *
  * @since 3.19.0
+ * @proposed
  */
 export interface ReadFileResult {
 	/**
@@ -206,13 +219,14 @@ export interface ReadFileResult {
  * its size, and the creation and modification time. Returns `null` if the file does not exist.
  *
  * @since 3.19.0
+ * @proposed
  */
 export namespace StatRequest {
 	export const method: 'workspace/stat' = 'workspace/stat';
 	export const messageDirection: MessageDirection = MessageDirection.serverToClient;
 	export const type = new ProtocolRequestType<StatParams, FileStat | null, never, void, void>(method);
 	export type HandlerSignature = RequestHandler<StatParams, FileStat | null, void>;
-	export const capabilities = CM.create('workspace.fileOperations.fileStat', undefined);
+	export const capabilities = CM.create('workspace.fileSystem.stat', undefined);
 }
 
 /**
@@ -222,13 +236,14 @@ export namespace StatRequest {
  * Returns `null` if the directory does not exist or the client cannot read it.
  *
  * @since 3.19.0
+ * @proposed
  */
 export namespace ReadDirectoryRequest {
 	export const method: 'workspace/readDirectory' = 'workspace/readDirectory';
 	export const messageDirection: MessageDirection = MessageDirection.serverToClient;
 	export const type = new ProtocolRequestType<ReadDirectoryParams, DirectoryEntry[] | null, never, void, void>(method);
 	export type HandlerSignature = RequestHandler<ReadDirectoryParams, DirectoryEntry[] | null, void>;
-	export const capabilities = CM.create('workspace.fileOperations.readDirectory', undefined);
+	export const capabilities = CM.create('workspace.fileSystem.readDirectory', undefined);
 }
 
 /**
@@ -238,11 +253,12 @@ export namespace ReadDirectoryRequest {
  * Returns `null` if the file does not exist or the client cannot read it.
  *
  * @since 3.19.0
+ * @proposed
  */
 export namespace ReadFileRequest {
 	export const method: 'workspace/readFile' = 'workspace/readFile';
 	export const messageDirection: MessageDirection = MessageDirection.serverToClient;
 	export const type = new ProtocolRequestType<ReadFileParams, ReadFileResult | null, never, void, void>(method);
 	export type HandlerSignature = RequestHandler<ReadFileParams, ReadFileResult | null, void>;
-	export const capabilities = CM.create('workspace.fileOperations.readFile', undefined);
+	export const capabilities = CM.create('workspace.fileSystem.readFile', undefined);
 }

--- a/protocol/src/common/protocol.ts
+++ b/protocol/src/common/protocol.ts
@@ -131,6 +131,11 @@ import {
 	TextDocumentContentRequest, TextDocumentContentRefreshParams, TextDocumentContentRefreshRequest
 } from './protocol.textDocumentContent';
 
+import {
+	FileStat, StatParams, StatRequest, DirectoryEntry, FileType, ReadDirectoryParams, ReadDirectoryRequest, ReadFileParams, ReadFileRequest, ReadFileResult,
+	FileSystemClientCapabilities
+} from './protocol.fileSystem';
+
 // @ts-ignore: to avoid inlining LocationLink as dynamic import
 let __noDynamicImport: LocationLink | undefined;
 
@@ -674,6 +679,13 @@ export interface WorkspaceClientCapabilities {
 	 * @since 3.18.0
 	 */
 	textDocumentContent?: TextDocumentContentClientCapabilities;
+
+	/**
+	 * Client capabilities specific to file system requests.
+	 *
+	 * @since 3.19.0
+	 */
+	fileSystem?: FileSystemClientCapabilities;
 }
 
 /**
@@ -4379,7 +4391,9 @@ export {
 	InlineCompletionClientCapabilities, InlineCompletionOptions, InlineCompletionParams, InlineCompletionRegistrationOptions, InlineCompletionRequest,
 	// Text Document Content
 	TextDocumentContentClientCapabilities, TextDocumentContentOptions, TextDocumentContentRegistrationOptions, TextDocumentContentParams, TextDocumentContentResult,
-	TextDocumentContentRequest, TextDocumentContentRefreshParams, TextDocumentContentRefreshRequest
+	TextDocumentContentRequest, TextDocumentContentRefreshParams, TextDocumentContentRefreshRequest,
+	// File System
+	FileStat, StatParams, StatRequest, DirectoryEntry, FileType, ReadDirectoryParams, ReadDirectoryRequest, ReadFileParams, ReadFileRequest, ReadFileResult,
 };
 
 // To be backwards compatible

--- a/protocol/src/common/protocol.ts
+++ b/protocol/src/common/protocol.ts
@@ -133,7 +133,7 @@ import {
 
 import {
 	FileStat, StatParams, StatRequest, DirectoryEntry, FileType, ReadDirectoryParams, ReadDirectoryRequest, ReadFileParams, ReadFileRequest, ReadFileResult,
-	FileSystemClientCapabilities
+	FileSystemClientCapabilities, FileFlags
 } from './protocol.fileSystem';
 
 // @ts-ignore: to avoid inlining LocationLink as dynamic import
@@ -4393,7 +4393,7 @@ export {
 	TextDocumentContentClientCapabilities, TextDocumentContentOptions, TextDocumentContentRegistrationOptions, TextDocumentContentParams, TextDocumentContentResult,
 	TextDocumentContentRequest, TextDocumentContentRefreshParams, TextDocumentContentRefreshRequest,
 	// File System
-	FileStat, StatParams, StatRequest, DirectoryEntry, FileType, ReadDirectoryParams, ReadDirectoryRequest, ReadFileParams, ReadFileRequest, ReadFileResult,
+	FileStat, StatParams, StatRequest, DirectoryEntry, FileType, FileFlags, ReadDirectoryParams, ReadDirectoryRequest, ReadFileParams, ReadFileRequest, ReadFileResult,
 };
 
 // To be backwards compatible

--- a/protocol/src/common/protocol.ts
+++ b/protocol/src/common/protocol.ts
@@ -133,7 +133,7 @@ import {
 
 import {
 	FileStat, StatParams, StatRequest, DirectoryEntry, FileType, ReadDirectoryParams, ReadDirectoryRequest, ReadFileParams, ReadFileRequest, ReadFileResult,
-	FileSystemClientCapabilities, FileFlags
+	FileSystemClientCapabilities, FileFlags, ReadFileParamKind, TextReadFileParams, BinaryReadFileParams,
 } from './protocol.fileSystem';
 
 // @ts-ignore: to avoid inlining LocationLink as dynamic import
@@ -4394,6 +4394,7 @@ export {
 	TextDocumentContentRequest, TextDocumentContentRefreshParams, TextDocumentContentRefreshRequest,
 	// File System
 	FileStat, StatParams, StatRequest, DirectoryEntry, FileType, FileFlags, ReadDirectoryParams, ReadDirectoryRequest, ReadFileParams, ReadFileRequest, ReadFileResult,
+	ReadFileParamKind, TextReadFileParams, BinaryReadFileParams,
 };
 
 // To be backwards compatible

--- a/protocol/src/common/protocol.ts
+++ b/protocol/src/common/protocol.ts
@@ -684,6 +684,7 @@ export interface WorkspaceClientCapabilities {
 	 * Client capabilities specific to file system requests.
 	 *
 	 * @since 3.19.0
+	 * @proposed
 	 */
 	fileSystem?: FileSystemClientCapabilities;
 }
@@ -4394,7 +4395,7 @@ export {
 	TextDocumentContentRequest, TextDocumentContentRefreshParams, TextDocumentContentRefreshRequest,
 	// File System
 	FileStat, StatParams, StatRequest, DirectoryEntry, FileType, FileFlags, ReadDirectoryParams, ReadDirectoryRequest, ReadFileParams, ReadFileRequest, ReadFileResult,
-	ReadFileParamKind, TextReadFileParams, BinaryReadFileParams,
+	FileSystemClientCapabilities, ReadFileParamKind, TextReadFileParams, BinaryReadFileParams,
 };
 
 // To be backwards compatible

--- a/server/src/common/fileSystem.ts
+++ b/server/src/common/fileSystem.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 
-import { DirectoryEntry, FileStat, StatRequest, ReadDirectoryRequest, ReadFileRequest, ReadFileResult, type DocumentUri } from 'vscode-languageserver-protocol';
+import { DirectoryEntry, FileStat, StatRequest, ReadDirectoryRequest, ReadFileRequest, ReadFileResult, TextReadFileParams, BinaryReadFileParams, ReadFileParamKind, DocumentUri } from 'vscode-languageserver-protocol';
 
 import type { Feature, _RemoteWorkspace } from './server';
 
@@ -26,12 +26,18 @@ export interface FileSystemFeatureShape {
 		 */
 		stat(uri: DocumentUri): Promise<FileStat | null>;
 		/**
-		 * Reads the contents of a file.
+		 * Reads the contents of a file as binary. Content is returned as a base64 encoded string.
+		 *
+		 * @param uri The URI of the file to read.
+		 */
+		readFile(kind: BinaryReadFileParams['kind'], uri: DocumentUri): Promise<ReadFileResult | null>;
+		/**
+		 * Reads the contents of a file as text.
 		 *
 		 * @param uri The URI of the file to read.
 		 * @param encoding The encoding to use when reading the file. Uses UTF-8 if not specified.
 		 */
-		readFile(uri: DocumentUri, encoding?: string): Promise<ReadFileResult | null>;
+		readFile(kind: TextReadFileParams['kind'], uri: DocumentUri, encoding?: string): Promise<ReadFileResult | null>;
 		/**
 		 * Reads the contents of a directory.
 		 *
@@ -48,8 +54,8 @@ export const FileSystemFeature: Feature<_RemoteWorkspace, FileSystemFeatureShape
 				stat: (uri: DocumentUri): Promise<FileStat | null> => {
 					return this.connection.sendRequest(StatRequest.type, { uri });
 				},
-				readFile: (uri: DocumentUri, encoding?: string): Promise<ReadFileResult | null> => {
-					return this.connection.sendRequest(ReadFileRequest.type, { uri, encoding });
+				readFile: (kind: ReadFileParamKind, uri: DocumentUri, encoding?: string): Promise<ReadFileResult | null> => {
+					return this.connection.sendRequest(ReadFileRequest.type, { kind, uri, encoding });
 				},
 				readDirectory: (uri: DocumentUri): Promise<DirectoryEntry[] | null> => {
 					return this.connection.sendRequest(ReadDirectoryRequest.type, { uri });

--- a/server/src/common/fileSystem.ts
+++ b/server/src/common/fileSystem.ts
@@ -1,0 +1,60 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import { DirectoryEntry, FileStat, StatRequest, ReadDirectoryRequest, ReadFileRequest, ReadFileResult, type DocumentUri } from 'vscode-languageserver-protocol';
+
+import type { Feature, _RemoteWorkspace } from './server';
+
+/**
+ * Shape of the file system feature
+ *
+ * @since 3.19.0
+ */
+export interface FileSystemFeatureShape {
+	/**
+	 * Provides access to the file system of the client.
+	 *
+	 * @since 3.19.0
+	 */
+	fs: {
+		/**
+		 * Returns metadata about a file system entry.
+		 *
+		 * @param uri The URI of the file to stat.
+		 */
+		stat(uri: DocumentUri): Promise<FileStat | null>;
+		/**
+		 * Reads the contents of a file.
+		 *
+		 * @param uri The URI of the file to read.
+		 * @param encoding The encoding to use when reading the file. Uses UTF-8 if not specified.
+		 */
+		readFile(uri: DocumentUri, encoding?: string): Promise<ReadFileResult | null>;
+		/**
+		 * Reads the contents of a directory.
+		 *
+		 * @param uri The URI of the directory to read.
+		 */
+		readDirectory(uri: DocumentUri): Promise<DirectoryEntry[] | null>;
+	};
+}
+
+export const FileSystemFeature: Feature<_RemoteWorkspace, FileSystemFeatureShape> = (Base) => {
+	return class extends Base {
+		public get fs() {
+			return {
+				stat: (uri: DocumentUri): Promise<FileStat | null> => {
+					return this.connection.sendRequest(StatRequest.type, { uri });
+				},
+				readFile: (uri: DocumentUri, encoding?: string): Promise<ReadFileResult | null> => {
+					return this.connection.sendRequest(ReadFileRequest.type, { uri, encoding });
+				},
+				readDirectory: (uri: DocumentUri): Promise<DirectoryEntry[] | null> => {
+					return this.connection.sendRequest(ReadDirectoryRequest.type, { uri });
+				}
+			};
+		}
+	};
+};

--- a/server/src/common/server.ts
+++ b/server/src/common/server.ts
@@ -49,6 +49,7 @@ import { MonikerFeature, MonikerFeatureShape } from './moniker';
 import type { ConnectionState } from './textDocuments';
 import { InlineCompletionFeature, type InlineCompletionFeatureShape } from './inlineCompletion';
 import { TextDocumentContentFeature, type TextDocumentContentFeatureShape } from './textDocumentContent';
+import { FileSystemFeature, FileSystemFeatureShape } from './fileSystem';
 
 function null2Undefined<T>(value: T | null): T | undefined {
 	if (value === null) {
@@ -646,7 +647,7 @@ export interface _RemoteWorkspace extends FeatureBase {
 	applyEdit(paramOrEdit: ApplyWorkspaceEditParams | WorkspaceEdit): Promise<ApplyWorkspaceEditResponse>;
 }
 
-export type RemoteWorkspace = _RemoteWorkspace & Configuration & WorkspaceFolders & FileOperationsFeatureShape & TextDocumentContentFeatureShape;
+export type RemoteWorkspace = _RemoteWorkspace & Configuration & WorkspaceFolders & FileOperationsFeatureShape & TextDocumentContentFeatureShape & FileSystemFeatureShape;
 
 class _RemoteWorkspaceImpl implements _RemoteWorkspace, Remote {
 
@@ -682,7 +683,7 @@ class _RemoteWorkspaceImpl implements _RemoteWorkspace, Remote {
 	}
 }
 
-const RemoteWorkspaceImpl: new () => RemoteWorkspace = TextDocumentContentFeature(FileOperationsFeature(WorkspaceFoldersFeature(ConfigurationFeature(_RemoteWorkspaceImpl)))) as (new () => RemoteWorkspace);
+const RemoteWorkspaceImpl: new () => RemoteWorkspace = FileSystemFeature(TextDocumentContentFeature(FileOperationsFeature(WorkspaceFoldersFeature(ConfigurationFeature(_RemoteWorkspaceImpl))))) as (new () => RemoteWorkspace);
 
 /**
  * Interface to log telemetry events. The events are actually send to the client

--- a/testbed/client/src/extension.ts
+++ b/testbed/client/src/extension.ts
@@ -116,6 +116,32 @@ REM or .bmp extension from c:\\source to c:\\images;;`;
 	commands.registerCommand('testbed.refreshContent', async () => {
 		await client.sendNotification(refreshNotification, 'test-content://file.txt');
 	});
+
+	const readFileRequest = new NotificationType<string>('testbed/readFile');
+	commands.registerCommand('testbed.readCurrentFile', async () => {
+		const uri = window.activeTextEditor?.document.uri.toString();
+		if (uri) {
+			await client.sendNotification(readFileRequest, uri);
+		}
+	});
+
+	const readDirectoryRequest = new NotificationType<string>('testbed/readDirectory');
+	commands.registerCommand('testbed.readCurrentDirectory', async () => {
+		const activeEditorUri = window.activeTextEditor?.document.uri;
+		if (!activeEditorUri) {
+			return;
+		}
+		const directoryUri = activeEditorUri.with({ path: path.dirname(activeEditorUri.path) });
+		await client.sendNotification(readDirectoryRequest, directoryUri.toString());
+	});
+
+	const statRequest = new NotificationType<string>('testbed/stat');
+	commands.registerCommand('testbed.statCurrentFile', async () => {
+		const uri = window.activeTextEditor?.document.uri.toString();
+		if (uri) {
+			await client.sendNotification(statRequest, uri);
+		}
+	});
 }
 
 export function deactivate() {

--- a/testbed/package.json
+++ b/testbed/package.json
@@ -25,6 +25,18 @@
 			{
 				"command": "testbed.refreshContent",
 				"title": "Refresh dynamic content"
+			},
+			{
+				"command": "testbed.readCurrentFile",
+				"title": "Read Current File"
+			},
+			{
+				"command": "testbed.readCurrentDirectory",
+				"title": "Read Current Directory"
+			},
+			{
+				"command": "testbed.statCurrentFile",
+				"title": "Stat Current File"
 			}
 		],
 		"configuration": {

--- a/testbed/server/src/server.ts
+++ b/testbed/server/src/server.ts
@@ -720,11 +720,13 @@ connection.onNotification(refreshNotification, async (uri) => {
 const readFileRequest = new NotificationType<string>('testbed/readFile');
 connection.onNotification(readFileRequest, async (uri) => {
 	const fileName = uri.split('/').pop();
-	const fileContent = await connection.workspace.fs.readFile(uri);
-	if (fileContent === null) {
+	const textContent = await connection.workspace.fs.readFile('text', uri);
+	const binaryContent = await connection.workspace.fs.readFile('binary', uri);
+	if (textContent === null || binaryContent === null) {
 		connection.window.showInformationMessage(`Read file '${fileName}' failed`);
 	} else {
-		connection.window.showInformationMessage(`Read file '${fileName}' with content length ${fileContent.text.length}`);
+		const base64Content = binaryContent.content.length > 100 ? binaryContent.content.substring(0, 97) + '...' : binaryContent.content;
+		connection.window.showInformationMessage(`Read file '${fileName}' with content length ${textContent.content.length} and base64 content ${base64Content}`);
 	}
 });
 

--- a/testbed/server/src/server.ts
+++ b/testbed/server/src/server.ts
@@ -18,7 +18,7 @@ import {
 	SemanticTokensClientCapabilities, SemanticTokensLegend, SemanticTokensBuilder, SemanticTokensRegistrationType,
 	SemanticTokensRegistrationOptions, ProtocolNotificationType, ChangeAnnotation, WorkspaceChange, CompletionItemKind, DiagnosticSeverity,
 	DocumentDiagnosticReportKind, WorkspaceDiagnosticReport, NotebookDocuments, CompletionList, DidChangeConfigurationNotification,
-	NotificationType
+	NotificationType, FileType
 } from 'vscode-languageserver/node';
 
 import {
@@ -717,6 +717,42 @@ connection.onNotification(refreshNotification, async (uri) => {
 	await connection.workspace.textDocumentContent.refresh(uri);
 });
 
+const readFileRequest = new NotificationType<string>('testbed/readFile');
+connection.onNotification(readFileRequest, async (uri) => {
+	const fileName = uri.split('/').pop();
+	const fileContent = await connection.workspace.fs.readFile(uri);
+	if (fileContent === null) {
+		connection.window.showInformationMessage(`Read file '${fileName}' failed`);
+	} else {
+		connection.window.showInformationMessage(`Read file '${fileName}' with content length ${fileContent.text.length}`);
+	}
+});
+
+const readDirectoryRequest = new NotificationType<string>('testbed/readDirectory');
+connection.onNotification(readDirectoryRequest, async (uri) => {
+	const dirName = uri.split('/').pop();
+	const directoryContent = await connection.workspace.fs.readDirectory(uri);
+	if (directoryContent === null) {
+		connection.window.showInformationMessage(`Read directory '${dirName}' failed`);
+	} else {
+		connection.window.showInformationMessage(`Read directory '${dirName}' with ${directoryContent.length} entries`);
+	}
+});
+
+const statRequest = new NotificationType<string>('testbed/stat');
+connection.onNotification(statRequest, async (uri) => {
+	const fileName = uri.split('/').pop();
+	const fileStat = await connection.workspace.fs.stat(uri);
+	if (fileStat === null) {
+		connection.window.showInformationMessage(`File stat ${fileName} failed`);
+	} else {
+		let type = fileStat.type;
+		if (fileStat.isSymlink) {
+			type += ' (symlink)';
+		}
+		connection.window.showInformationMessage(`File stat '${fileName}' with type '${type}' and size ${fileStat.size}`);
+	}
+});
 
 const notebooks = new NotebookDocuments(TextDocument);
 notebooks.onDidOpen(() => {

--- a/testbed/server/src/server.ts
+++ b/testbed/server/src/server.ts
@@ -18,7 +18,7 @@ import {
 	SemanticTokensClientCapabilities, SemanticTokensLegend, SemanticTokensBuilder, SemanticTokensRegistrationType,
 	SemanticTokensRegistrationOptions, ProtocolNotificationType, ChangeAnnotation, WorkspaceChange, CompletionItemKind, DiagnosticSeverity,
 	DocumentDiagnosticReportKind, WorkspaceDiagnosticReport, NotebookDocuments, CompletionList, DidChangeConfigurationNotification,
-	NotificationType, FileType
+	NotificationType, FileFlags
 } from 'vscode-languageserver/node';
 
 import {
@@ -747,7 +747,7 @@ connection.onNotification(statRequest, async (uri) => {
 		connection.window.showInformationMessage(`File stat ${fileName} failed`);
 	} else {
 		let type = fileStat.type;
-		if (fileStat.isSymlink) {
+		if (fileStat.flags & FileFlags.symbolicLink) {
 			type += ' (symlink)';
 		}
 		connection.window.showInformationMessage(`File stat '${fileName}' with type '${type}' and size ${fileStat.size}`);


### PR DESCRIPTION
Related to https://github.com/microsoft/language-server-protocol/issues/1264 (does not fully resolve it, since this PR does not include features to write into a file system - only read from it).

Adds support for the server to read files/directories/stat info from the client.

As indicated by https://github.com/microsoft/language-server-protocol/issues/1264#issuecomment-1493373396, I also thought it'd be best to start with read-only access to the file system. However, the new interfaces/types should be extendable enough to also add write requests if required later on.

Some questions/considerations:
* Right now, if the read/stat fails, the LSP returns `null`. Should it return a response error instead?
* I'm not entirely sure about the properties in `FileSystemClientCapabilities`. Does it make sense to expose each individual request type as an opt-in flag? Or is it enough to provide a `read?: boolean` flag (maybe extend this with a `write?: boolean` flag later on)?
* The `FileType.unknown` value results from the fact that vscode offers `vscode.FileType.unknown` as a possible value to return for `FileStat.type`. Should this be included in the protocol, or should stats/directory entries with this type simply be omitted?
* The LSP has been using *folder* instead of *directory* for the most part. Should this change align to this? I've simply used the same nomenclature as vscode does.