### PR TITLE
Disable Azure Artifacts package publishing

### DIFF
--- a/build/azure-pipelines/pipeline.yml
+++ b/build/azure-pipelines/pipeline.yml
@@ -84,6 +84,7 @@ extends:
         tag: ${{ parameters.quality }}
         preReleaseTag: next
         publishPackage: ${{ parameters.publishTsconfigGen }}
+        publishPackageToAzureArtifacts: false
         workingDirectory: $(Build.SourcesDirectory)/tsconfig-gen
 
       - name: textDocument
@@ -110,6 +111,7 @@ extends:
         tag: ${{ parameters.quality }}
         preReleaseTag: next
         publishPackage: ${{ parameters.publishTextDocument }}
+        publishPackageToAzureArtifacts: false
         workingDirectory: $(Build.SourcesDirectory)/textDocument
 
       - name: types
@@ -136,6 +138,7 @@ extends:
         tag: ${{ parameters.quality }}
         preReleaseTag: next
         publishPackage: ${{ parameters.publishTypes }}
+        publishPackageToAzureArtifacts: false
         workingDirectory: $(Build.SourcesDirectory)/types
 
       - name: jsonrpc
@@ -162,6 +165,7 @@ extends:
         tag: ${{ parameters.quality }}
         preReleaseTag: next
         publishPackage: ${{ parameters.publishJsonrpc }}
+        publishPackageToAzureArtifacts: false
         workingDirectory: $(Build.SourcesDirectory)/jsonrpc
 
       - name: protocol
@@ -188,6 +192,7 @@ extends:
         tag: ${{ parameters.quality }}
         preReleaseTag: next
         publishPackage: ${{ parameters.publishProtocol }}
+        publishPackageToAzureArtifacts: false
         workingDirectory: $(Build.SourcesDirectory)/protocol
 
       - name: server
@@ -214,6 +219,7 @@ extends:
         tag: ${{ parameters.quality }}
         preReleaseTag: next
         publishPackage: ${{ parameters.publishServer }}
+        publishPackageToAzureArtifacts: false
         workingDirectory: $(Build.SourcesDirectory)/server
 
       - name: client
@@ -240,4 +246,5 @@ extends:
         tag: ${{ parameters.quality }}
         preReleaseTag: next
         publishPackage: ${{ parameters.publishClient }}
+        publishPackageToAzureArtifacts: false
         workingDirectory: $(Build.SourcesDirectory)/client


### PR DESCRIPTION
## Summary

Opt this pipeline out of publishing npm packages to the internal Azure Artifacts feed.

<details>
<summary>Session Context</summary>

Key decisions from the development session:

- **Internal feed publishing**: The shared npm-package template now defaults `publishPackageToAzureArtifacts` to the value of `publishPackage` when it is omitted. This pipeline should continue publishing only to the public npm registry when its existing release switches are enabled.
- **Pipeline artifacts**: Azure Pipelines run artifacts remain enabled intentionally; only publication to the Azure Artifacts npm feed is disabled.

</details>

## Changes

- Set `publishPackageToAzureArtifacts: false` for every npm package configured by the pipeline.
- Preserve the existing per-package public npm publishing parameters.

## Validation

- `git diff --check`
- VS Code YAML diagnostics: no errors