### PR TITLE
redirect `console.info` to avoid corrupting stdio

### DIFF
--- a/server/src/node/main.ts
+++ b/server/src/node/main.ts
@@ -330,4 +330,8 @@ function patchConsole(logger: Logger): undefined {
 	console.warn = function warn(...args) {
 		logger.warn(serialize(args));
 	};
+
+	console.info = function info(...args) {
+		logger.info(serialize(args));
+	};
 }


### PR DESCRIPTION
It is unclear to me why only `console.info` is not redirected in `patchConsole`.

This is causing a bug in a [neovim plugin](https://github.com/funemy/fstar.nvim) I'm maintaining, which runs the language server in stdio mode.