### PR TITLE
Fix socket transport when TransportKind.socket uses port 0

### DIFF
--- a/client-node-tests/src/integration.test.ts
+++ b/client-node-tests/src/integration.test.ts
@@ -242,6 +242,23 @@ suite('Server output', () => {
 	});
 });
 
+suite('Socket transport', () => {
+
+	test('Uses an OS-assigned port when transport.port is 0', async () => {
+		const serverOptions: lsclient.ServerOptions = {
+			module: path.join(__dirname, './servers/nullServer.js'),
+			transport: { kind: lsclient.TransportKind.socket, port: 0 },
+		};
+		const clientOptions: lsclient.LanguageClientOptions = {};
+		const client = new lsclient.LanguageClient('socket zero', 'Socket Transport (port=0)', serverOptions, clientOptions);
+		await client.start();
+		// If the client had passed --socket=0 to the server (the pre-fix bug), the server
+		// would either fail to connect or listen on a different random port, and start()
+		// would time out. Reaching this line proves the actual bound port was handed over.
+		await client.stop();
+	});
+});
+
 suite('Client integration', () => {
 
 	let client!: lsclient.LanguageClient;

--- a/client/src/node/main.ts
+++ b/client/src/node/main.ts
@@ -395,8 +395,6 @@ export class LanguageClient extends BaseLanguageClient {
 					} else if (transport === TransportKind.pipe) {
 						pipeName = generateRandomPipeName();
 						args.push(`--pipe=${pipeName}`);
-					} else if (Transport.isSocket(transport)) {
-						args.push(`--socket=${transport.port}`);
 					}
 					args.push(`--clientProcessId=${process.pid.toString()}`);
 					if (transport === TransportKind.ipc || transport === TransportKind.stdio) {
@@ -427,6 +425,7 @@ export class LanguageClient extends BaseLanguageClient {
 						});
 					} else if (Transport.isSocket(transport)) {
 						return createClientSocketTransport(transport.port).then((transport) => {
+							args.push(`--socket=${transport.port()}`);
 							const process = cp.spawn(runtime, args, execOptions);
 							if (!process || !process.pid) {
 								return handleChildProcessStartError(process, `Launching server using runtime ${runtime} failed.`);
@@ -450,8 +449,6 @@ export class LanguageClient extends BaseLanguageClient {
 						} else if (transport === TransportKind.pipe) {
 							pipeName = generateRandomPipeName();
 							args.push(`--pipe=${pipeName}`);
-						} else if (Transport.isSocket(transport)) {
-							args.push(`--socket=${transport.port}`);
 						}
 						args.push(`--clientProcessId=${process.pid.toString()}`);
 						const options: cp.ForkOptions = node.options ? { ...node.options } : Object.create(null);
@@ -483,6 +480,7 @@ export class LanguageClient extends BaseLanguageClient {
 							}, reject);
 						} else if (Transport.isSocket(transport)) {
 							createClientSocketTransport(transport.port).then((transport) => {
+								args.push(`--socket=${transport.port()}`);
 								const sp = cp.fork(node.module, args || [], options);
 								assertStdio(sp);
 								this._serverProcess = sp;
@@ -505,8 +503,6 @@ export class LanguageClient extends BaseLanguageClient {
 				} else if (transport === TransportKind.pipe) {
 					pipeName = generateRandomPipeName();
 					args.push(`--pipe=${pipeName}`);
-				} else if (Transport.isSocket(transport)) {
-					args.push(`--socket=${transport.port}`);
 				} else if (transport === TransportKind.ipc) {
 					throw new Error(`Transport kind ipc is not support for command executable`);
 				}
@@ -537,6 +533,7 @@ export class LanguageClient extends BaseLanguageClient {
 					});
 				} else if (Transport.isSocket(transport)) {
 					return createClientSocketTransport(transport.port).then((transport) => {
+						args.push(`--socket=${transport.port()}`);
 						const serverProcess = cp.spawn(command.command, args, options);
 						if (!serverProcess || !serverProcess.pid) {
 							return handleChildProcessStartError(serverProcess, `Launching server using command ${command.command} failed.`);

--- a/jsonrpc/src/node/main.ts
+++ b/jsonrpc/src/node/main.ts
@@ -229,6 +229,7 @@ export function createServerPipeTransport(pipeName: string, encoding: RAL.Messag
 }
 
 export interface SocketTransport {
+	port(): number;
 	onConnected(): Promise<[MessageReader, MessageWriter]>;
 }
 
@@ -248,7 +249,14 @@ export function createClientSocketTransport(port: number, encoding: RAL.MessageB
 		server.on('error', reject);
 		server.listen(port, '127.0.0.1', () => {
 			server.removeListener('error', reject);
+			const address = server.address();
+			if (address === null || typeof address === 'string') {
+				reject(new Error(`Unexpected server address: ${address}`));
+				return;
+			}
+			const boundPort = address.port;
 			resolve({
+				port: () => boundPort,
 				onConnected: () => { return connected; }
 			});
 		});

--- a/jsonrpc/src/node/test/connection.test.ts
+++ b/jsonrpc/src/node/test/connection.test.ts
@@ -76,6 +76,34 @@ suite('Connection', () => {
 		execFileSync(process.execPath, ['-e', script], { stdio: 'pipe' });
 	});
 
+	test('createClientSocketTransport resolves with the requested port when non-zero', async () => {
+		const net = await import('net');
+		const probe = net.createServer();
+		await new Promise<void>((resolve, reject) => {
+			probe.on('error', reject);
+			probe.listen(0, '127.0.0.1', () => resolve());
+		});
+		const requested = (probe.address() as import('net').AddressInfo).port;
+		await new Promise<void>(resolve => probe.close(() => resolve()));
+
+		const transport = await hostConnection.createClientSocketTransport(requested);
+		const reported = transport.port();
+		const client = net.connect(reported, '127.0.0.1');
+		await transport.onConnected();
+		client.destroy();
+		assert.strictEqual(reported, requested);
+	});
+
+	test('createClientSocketTransport exposes the actual bound port when port=0', async () => {
+		const net = await import('net');
+		const transport = await hostConnection.createClientSocketTransport(0);
+		const bound = transport.port();
+		const client = net.connect(bound, '127.0.0.1');
+		await transport.onConnected();
+		client.destroy();
+		assert.ok(bound > 0, `expected a positive bound port, got ${bound}`);
+	});
+
 	test('Test Duplex Stream Connection', (done) => {
 		const type = new RequestType<string, string, void>('test/handleSingleRequest');
 		const duplexStream1 = new TestDuplex('ds1');


### PR DESCRIPTION
When the client is configured with `transport: { kind: TransportKind.socket, port: 0 }`, Node's `server.listen(0, ...)` picks a random port. The client was pushing `--socket=0` to the server args before the transport was created, so the server never learned the actual bound port and was unable to connect.

Expose the actually-bound port on SocketTransport via `port(): number`, and defer pushing `--socket=<port>` until after `createClientSocketTransport` resolves in all three spawn paths (runtime, fork, executable command).

Resolves #1845.