### PR TITLE
Enable publishing to Azure Artifacts

### DIFF
--- a/build/azure-pipelines/pipeline.yml
+++ b/build/azure-pipelines/pipeline.yml
@@ -84,7 +84,7 @@ extends:
         tag: ${{ parameters.quality }}
         preReleaseTag: next
         publishPackage: ${{ parameters.publishTsconfigGen }}
-        publishPackageToAzureArtifacts: false
+        publishPackageToAzureArtifacts: true
         workingDirectory: $(Build.SourcesDirectory)/tsconfig-gen
 
       - name: textDocument
@@ -111,7 +111,7 @@ extends:
         tag: ${{ parameters.quality }}
         preReleaseTag: next
         publishPackage: ${{ parameters.publishTextDocument }}
-        publishPackageToAzureArtifacts: false
+        publishPackageToAzureArtifacts: true
         workingDirectory: $(Build.SourcesDirectory)/textDocument
 
       - name: types
@@ -138,7 +138,7 @@ extends:
         tag: ${{ parameters.quality }}
         preReleaseTag: next
         publishPackage: ${{ parameters.publishTypes }}
-        publishPackageToAzureArtifacts: false
+        publishPackageToAzureArtifacts: true
         workingDirectory: $(Build.SourcesDirectory)/types
 
       - name: jsonrpc
@@ -165,7 +165,7 @@ extends:
         tag: ${{ parameters.quality }}
         preReleaseTag: next
         publishPackage: ${{ parameters.publishJsonrpc }}
-        publishPackageToAzureArtifacts: false
+        publishPackageToAzureArtifacts: true
         workingDirectory: $(Build.SourcesDirectory)/jsonrpc
 
       - name: protocol
@@ -192,7 +192,7 @@ extends:
         tag: ${{ parameters.quality }}
         preReleaseTag: next
         publishPackage: ${{ parameters.publishProtocol }}
-        publishPackageToAzureArtifacts: false
+        publishPackageToAzureArtifacts: true
         workingDirectory: $(Build.SourcesDirectory)/protocol
 
       - name: server
@@ -219,7 +219,7 @@ extends:
         tag: ${{ parameters.quality }}
         preReleaseTag: next
         publishPackage: ${{ parameters.publishServer }}
-        publishPackageToAzureArtifacts: false
+        publishPackageToAzureArtifacts: true
         workingDirectory: $(Build.SourcesDirectory)/server
 
       - name: client
@@ -246,5 +246,5 @@ extends:
         tag: ${{ parameters.quality }}
         preReleaseTag: next
         publishPackage: ${{ parameters.publishClient }}
-        publishPackageToAzureArtifacts: false
+        publishPackageToAzureArtifacts: true
         workingDirectory: $(Build.SourcesDirectory)/client

--- a/client/package.json
+++ b/client/package.json
@@ -47,7 +47,7 @@
 		"vscode-languageserver-protocol": "3.18.3"
 	},
 	"scripts": {
-		"prepublishOnly": "echo \"⛔ Can only publish from a secure pipeline ⛔\" && node ../build/npm/fail",
+		"prepublishOnly": "npm run all:publish",
 		"prepack": "npm run all:publish",
 		"compile": "tsc -b ./tsconfig.json",
 		"compile:clean": "git clean -xfd . && npm install && npm run clean && npm run compile",

--- a/jsonrpc/package.json
+++ b/jsonrpc/package.json
@@ -34,7 +34,7 @@
 		"msgpack-lite": "^0.1.26"
 	},
 	"scripts": {
-		"prepublishOnly": "echo \"⛔ Can only publish from a secure pipeline ⛔\" && node ../build/npm/fail",
+		"prepublishOnly": "npm run all:publish",
 		"prepack": "npm run all:publish",
 		"preversion": "npm test",
 		"compile": "tsc -b ./tsconfig.json",

--- a/protocol/package.json
+++ b/protocol/package.json
@@ -31,7 +31,7 @@
 		"vscode-languageserver-types": "3.18.3"
 	},
 	"scripts": {
-		"prepublishOnly": "echo \"⛔ Can only publish from a secure pipeline ⛔\" && node ../build/npm/fail",
+		"prepublishOnly": "npm run all:publish",
 		"prepack": "npm run all:publish",
 		"postpublish": "node ../build/npm/post-publish.js",
 		"preversion": "npm test",

--- a/server/package.json
+++ b/server/package.json
@@ -36,7 +36,7 @@
 		"vscode-languageserver-protocol": "3.18.3"
 	},
 	"scripts": {
-		"prepublishOnly": "echo \"⛔ Can only publish from a secure pipeline ⛔\" && node ../build/npm/fail",
+		"prepublishOnly": "npm run all:publish",
 		"prepack": "npm run all:publish",
 		"compile": "tsc -b ./tsconfig.json",
 		"watch": "tsc -b ./tsconfig.watch.json -w",

--- a/textDocument/package.json
+++ b/textDocument/package.json
@@ -23,7 +23,7 @@
 		}
 	},
 	"scripts": {
-		"prepublishOnly": "echo \"⛔ Can only publish from a secure pipeline ⛔\" && node ../build/npm/fail",
+		"prepublishOnly": "npm run all:publish",
 		"prepack": "npm run all:publish",
 		"compile": "tsc -b ./tsconfig.json",
 		"clean": "rimraf lib",

--- a/tsconfig-gen/package.json
+++ b/tsconfig-gen/package.json
@@ -28,8 +28,8 @@
 		"@types/yargs": "^17.0.33"
 	},
 	"scripts": {
-		"prepublishOnly": "echo \"⛔ Can only publish from a secure pipeline ⛔\" && node ../build/npm/fail",
-		"prepack": "git clean -xfd . && npm install && npm run all",
+		"prepublishOnly": "npm run all:publish",
+		"prepack": "npm run all:publish",
 		"compile": "tsc -b ./tsconfig.json",
 		"clean": "rimraf lib",
 		"watch": "tsc -b ./tsconfig.watch.json -w",

--- a/types/package.json
+++ b/types/package.json
@@ -23,7 +23,7 @@
 		}
 	},
 	"scripts": {
-		"prepublishOnly": "echo \"⛔ Can only publish from a secure pipeline ⛔\" && node ../build/npm/fail",
+		"prepublishOnly": "npm run all:publish",
 		"prepack": "npm run all:publish",
 		"compile": "tsc -b ./tsconfig.json",
 		"clean": "rimraf lib",


### PR DESCRIPTION
Configure the build pipeline to publish packages to Azure Artifacts, enhancing the deployment process. Update the prepublish script to allow publishing from a secure pipeline.