### PR TITLE
Align implementation with specification

### DIFF
--- a/protocol/metaModel.json
+++ b/protocol/metaModel.json
@@ -3899,6 +3899,10 @@
 				{
 					"kind": "reference",
 					"name": "WorkDoneProgressParams"
+				},
+				{
+					"kind": "reference",
+					"name": "PartialResultParams"
 				}
 			],
 			"documentation": "A parameter literal used in inline value requests.\n\n@since 3.17.0",
@@ -3950,6 +3954,10 @@
 				{
 					"kind": "reference",
 					"name": "WorkDoneProgressParams"
+				},
+				{
+					"kind": "reference",
+					"name": "PartialResultParams"
 				}
 			],
 			"documentation": "A parameter literal used in inlay hint requests.\n\n@since 3.17.0",
@@ -4358,6 +4366,10 @@
 				{
 					"kind": "reference",
 					"name": "WorkDoneProgressParams"
+				},
+				{
+					"kind": "reference",
+					"name": "PartialResultParams"
 				}
 			],
 			"documentation": "A parameter literal used in inline completion requests.\n\n@since 3.18.0",

--- a/protocol/src/common/protocol.inlayHint.ts
+++ b/protocol/src/common/protocol.inlayHint.ts
@@ -7,7 +7,7 @@ import { RequestHandler, RequestHandler0 } from 'vscode-jsonrpc';
 import { Range, TextDocumentIdentifier, InlayHint } from 'vscode-languageserver-types';
 import { CM, MessageDirection, ProtocolRequestType, ProtocolRequestType0 } from './messages';
 
-import { type StaticRegistrationOptions, type TextDocumentRegistrationOptions, type WorkDoneProgressOptions, type WorkDoneProgressParams } from './protocol';
+import { type PartialResultParams, type StaticRegistrationOptions, type TextDocumentRegistrationOptions, type WorkDoneProgressOptions, type WorkDoneProgressParams } from './protocol';
 
 /**
  * @since 3.18.0
@@ -81,7 +81,7 @@ export type InlayHintRegistrationOptions = InlayHintOptions & TextDocumentRegist
  *
  * @since 3.17.0
  */
-export type InlayHintParams = WorkDoneProgressParams & {
+export type InlayHintParams = WorkDoneProgressParams & PartialResultParams & {
 	/**
 	 * The text document.
 	 */

--- a/protocol/src/common/protocol.inlineCompletion.ts
+++ b/protocol/src/common/protocol.inlineCompletion.ts
@@ -7,7 +7,7 @@ import { InlineCompletionItem, InlineCompletionContext, InlineCompletionList } f
 import { RequestHandler } from 'vscode-jsonrpc';
 
 import { CM, MessageDirection, ProtocolRequestType } from './messages';
-import { type TextDocumentRegistrationOptions, type WorkDoneProgressOptions, type StaticRegistrationOptions, type WorkDoneProgressParams, type TextDocumentPositionParams } from './protocol';
+import { type TextDocumentRegistrationOptions, type WorkDoneProgressOptions, type StaticRegistrationOptions, type WorkDoneProgressParams, type TextDocumentPositionParams, type PartialResultParams } from './protocol';
 
 // ---- capabilities
 
@@ -42,7 +42,7 @@ export type InlineCompletionRegistrationOptions = InlineCompletionOptions & Text
  *
  * @since 3.18.0
  */
-export type InlineCompletionParams = WorkDoneProgressParams & TextDocumentPositionParams & {
+export type InlineCompletionParams = WorkDoneProgressParams & TextDocumentPositionParams & PartialResultParams & {
 	/**
 	 * Additional information about the context in which inline completions were
 	 * requested.

--- a/protocol/src/common/protocol.inlineValue.ts
+++ b/protocol/src/common/protocol.inlineValue.ts
@@ -7,7 +7,7 @@ import { TextDocumentIdentifier, Range, InlineValue, InlineValueContext } from '
 import { RequestHandler, RequestHandler0 } from 'vscode-jsonrpc';
 
 import { CM, MessageDirection, ProtocolRequestType, ProtocolRequestType0 } from './messages';
-import { type TextDocumentRegistrationOptions, type WorkDoneProgressOptions, type StaticRegistrationOptions, type WorkDoneProgressParams } from './protocol';
+import { type TextDocumentRegistrationOptions, type WorkDoneProgressOptions, type StaticRegistrationOptions, type WorkDoneProgressParams, type PartialResultParams } from './protocol';
 
 // ---- capabilities
 
@@ -60,7 +60,7 @@ export type InlineValueRegistrationOptions = InlineValueOptions & TextDocumentRe
  *
  * @since 3.17.0
  */
-export type InlineValueParams = WorkDoneProgressParams & {
+export type InlineValueParams = WorkDoneProgressParams & PartialResultParams & {
 	/**
 	 * The text document.
 	 */


### PR DESCRIPTION
Update the implementation to align with the specification by incorporating `PartialResultParams` into relevant parameter types. This change enhances the functionality of inlay hints, inline completions, and inline values.