### PR TITLE
Preserve output channel visibility on restart

### DIFF
--- a/client-node-tests/src/integration.test.ts
+++ b/client-node-tests/src/integration.test.ts
@@ -242,6 +242,52 @@ suite('Server output', () => {
 	});
 });
 
+suite('Client restart', () => {
+
+	test('Preserves output channel visibility after restart', async () => {
+		const client = new RestartTestLanguageClient(true);
+
+		await client.restart();
+
+		assert.deepStrictEqual(client.events, ['isOutputChannelVisible', 'stop', 'start', 'restoreOutputChannelVisibility:true']);
+	});
+
+	test('Does not restore hidden output channel after restart', async () => {
+		const client = new RestartTestLanguageClient(false);
+
+		await client.restart();
+
+		assert.deepStrictEqual(client.events, ['isOutputChannelVisible', 'stop', 'start', 'restoreOutputChannelVisibility:false']);
+	});
+});
+
+class RestartTestLanguageClient extends lsclient.LanguageClient {
+
+	public readonly events: string[] = [];
+
+	public constructor(private readonly outputChannelVisible: boolean) {
+		super('test restart', { module: 'unused', transport: lsclient.TransportKind.ipc }, {});
+	}
+
+	public override async start(): Promise<void> {
+		this.events.push('start');
+	}
+
+	public override stop(): Promise<void> {
+		this.events.push('stop');
+		return Promise.resolve();
+	}
+
+	protected override isOutputChannelVisible(): boolean {
+		this.events.push('isOutputChannelVisible');
+		return this.outputChannelVisible;
+	}
+
+	protected override restoreOutputChannelVisibility(wasVisible: boolean): void {
+		this.events.push(`restoreOutputChannelVisibility:${wasVisible}`);
+	}
+}
+
 suite('Client integration', () => {
 
 	let client!: lsclient.LanguageClient;

--- a/client/src/common/client.ts
+++ b/client/src/common/client.ts
@@ -858,6 +858,26 @@ export abstract class BaseLanguageClient implements FeatureClient<Middleware, La
 		return this._outputChannel;
 	}
 
+	protected isOutputChannelVisible(): boolean {
+		if (this._outputChannel === undefined) {
+			return false;
+		}
+		const outputChannelName = this._outputChannel.name.toLowerCase();
+		return Window.visibleTextEditors.some(editor => {
+			if (editor.document.uri.scheme !== 'output') {
+				return false;
+			}
+			const outputResource = `${editor.document.uri.toString(true)}\n${editor.document.fileName}`.toLowerCase();
+			return outputResource.includes(outputChannelName);
+		});
+	}
+
+	protected restoreOutputChannelVisibility(wasVisible: boolean): void {
+		if (wasVisible) {
+			this.outputChannel.show(true);
+		}
+	}
+
 	public get traceOutputChannel(): LogOutputChannel {
 		return this._traceOutputChannel ? this._traceOutputChannel : this.outputChannel;
 	}

--- a/client/src/node/main.ts
+++ b/client/src/node/main.ts
@@ -236,6 +236,7 @@ export class LanguageClient extends BaseLanguageClient {
 	}
 
 	public async restart(): Promise<void> {
+		const outputChannelVisible = this.isOutputChannelVisible();
 		await this.stop();
 		// We are in debug mode. Wait a little before we restart
 		// so that the debug port can be freed. We can safely ignore
@@ -247,6 +248,7 @@ export class LanguageClient extends BaseLanguageClient {
 		} else {
 			await this.start();
 		}
+		this.restoreOutputChannelVisibility(outputChannelVisible);
 	}
 
 	protected shutdown(mode: ShutdownMode, timeout: number = 2000): Promise<void> {


### PR DESCRIPTION
## Summary

Preserves a language client's output channel visibility across `LanguageClient.restart()`.

If the output channel is already visible before restart, the client shows it again after restart succeeds using `show(true)` so focus is preserved. If the output channel is hidden or has not been created, restart behavior is unchanged.

The visibility detector now matches VS Code log output resources by a normalized `<outputChannelId>.<outputChannelName>.log` resource name. `outputChannelId` can be supplied through `LanguageClientOptions` (for example, an extension id such as `publisher.extension`) and falls back to the language client id when omitted. This avoids treating another visible output channel with the same display name, or an extension id containing the channel name, as this client's output channel. It also handles channel names that VS Code sanitizes in log file names.

This moves the behavior requested in microsoft/vscode-eslint#2206 into the shared LSP client library so other clients can benefit from it too.

## Validation

- `npm run compile:client`
- `npm run compile:client-node-tests`
- `npm run lint --prefix client`
- `npm run lint --prefix client-node-tests`
- `npm run test --prefix client-node-tests` (`211 passing`)